### PR TITLE
Set solarized light by default

### DIFF
--- a/schemas/io.elementary.code.gschema.xml
+++ b/schemas/io.elementary.code.gschema.xml
@@ -130,7 +130,7 @@
 			<description>Set the preferred font.</description>
 		</key>
 		<key name="style-scheme" type="s">
-			<default>'classic'</default>
+			<default>'solarized-light'</default>
 			<summary>Preferred Style Scheme</summary>
 			<description>Set the preferred style scheme.</description>
 		</key>


### PR DESCRIPTION
I guess it turns out this isn't the default. We're setting it in the distro which is weird