### PR TITLE
Highlight matching brackets by default

### DIFF
--- a/schemas/io.elementary.code.gschema.xml
+++ b/schemas/io.elementary.code.gschema.xml
@@ -90,7 +90,7 @@
 			<description>Whether Scratch should highlight the current line.</description>
 		</key>
 		<key name="highlight-matching-brackets" type="b">
-			<default>false</default>
+			<default>true</default>
 			<summary>Highlight Matching Brackets</summary>
 			<description>Whether Scratch should highlight matching brackets.</description>
 		</key>


### PR DESCRIPTION
Turns out we were setting this in the [distro](https://github.com/elementary/default-settings/pull/19) instead of here for some reason