### PR TITLE
Use zoom controls as in Terminal

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -75,7 +75,6 @@ namespace Scratch {
         public const string ACTION_SAVE_AS = "action_save_as";
         public const string ACTION_SHOW_FIND = "action_show_find";
         public const string ACTION_TEMPLATES = "action_templates";
-        public const string ACTION_ZOOM_DEFAULT = "action_zoom_default";
         public const string ACTION_SHOW_REPLACE = "action_show_replace";
         public const string ACTION_TO_LOWER_CASE = "action_to_lower_case";
         public const string ACTION_TO_UPPER_CASE = "action_to_upper_case";
@@ -83,6 +82,9 @@ namespace Scratch {
         public const string ACTION_FULLSCREEN = "action_fullscreen";
         public const string ACTION_CLOSE_TAB = "action_close_tab";
         public const string ACTION_QUIT = "action_quit";
+        public const string ACTION_ZOOM_DEFAULT = "action_zoom_default";
+        public const string ACTION_ZOOM_IN = "action_zoom_in";
+        public const string ACTION_ZOOM_OUT = "action_zoom_out";
 
         public static Gee.MultiMap<string, string> action_accelerators = new Gee.HashMultiMap<string, string> ();
 
@@ -95,7 +97,6 @@ namespace Scratch {
             { ACTION_SAVE_AS, action_save_as },
             { ACTION_SHOW_FIND, action_show_fetch, null, "false" },
             { ACTION_TEMPLATES, action_templates },
-            { ACTION_ZOOM_DEFAULT, action_set_default_zoom },
             { ACTION_GO_TO, action_go_to },
             { ACTION_NEW_VIEW, action_new_view },
             { ACTION_NEW_TAB, action_new_tab },
@@ -112,7 +113,10 @@ namespace Scratch {
             { ACTION_DUPLICATE, action_duplicate },
             { ACTION_FULLSCREEN, action_fullscreen },
             { ACTION_CLOSE_TAB, action_close_tab },
-            { ACTION_QUIT, action_quit }
+            { ACTION_QUIT, action_quit },
+            { ACTION_ZOOM_DEFAULT, action_set_default_zoom },
+            { ACTION_ZOOM_IN, action_zoom_in },
+            { ACTION_ZOOM_OUT, action_zoom_out}
         };
 
         public MainWindow (Scratch.Application scratch_app) {
@@ -130,7 +134,6 @@ namespace Scratch {
             action_accelerators.set (ACTION_REVERT, "<Control><shift>o");
             action_accelerators.set (ACTION_SAVE, "<Control>s");
             action_accelerators.set (ACTION_SAVE_AS, "<Control><shift>s");
-            action_accelerators.set (ACTION_ZOOM_DEFAULT, "<Control>0");
             action_accelerators.set (ACTION_GO_TO, "<Control>i");
             action_accelerators.set (ACTION_NEW_VIEW, "F3");
             action_accelerators.set (ACTION_NEW_TAB, "<Control>n");
@@ -145,6 +148,9 @@ namespace Scratch {
             action_accelerators.set (ACTION_FULLSCREEN, "F11");
             action_accelerators.set (ACTION_CLOSE_TAB, "<Control>w");
             action_accelerators.set (ACTION_QUIT, "<Control>q");
+            action_accelerators.set (ACTION_ZOOM_DEFAULT, "<Control>0");
+            action_accelerators.set (ACTION_ZOOM_IN, "<Control>plus");
+            action_accelerators.set (ACTION_ZOOM_OUT, "<Control>minus");
         }
 
         construct {
@@ -613,12 +619,12 @@ namespace Scratch {
         }
 
         // Ctrl + scroll
-        public void zoom_in () {
+        public void action_zoom_in () {
              zooming (Gdk.ScrollDirection.UP);
         }
 
         // Ctrl + scroll
-        public void zoom_out () {
+        public void action_zoom_out () {
             zooming (Gdk.ScrollDirection.DOWN);
         }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -149,6 +149,7 @@ namespace Scratch {
             action_accelerators.set (ACTION_CLOSE_TAB, "<Control>w");
             action_accelerators.set (ACTION_QUIT, "<Control>q");
             action_accelerators.set (ACTION_ZOOM_DEFAULT, "<Control>0");
+            action_accelerators.set (ACTION_ZOOM_DEFAULT, "<Control>KP_0");
             action_accelerators.set (ACTION_ZOOM_IN, "<Control>plus");
             action_accelerators.set (ACTION_ZOOM_IN, "<Control>KP_Add");
             action_accelerators.set (ACTION_ZOOM_OUT, "<Control>minus");

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -150,7 +150,9 @@ namespace Scratch {
             action_accelerators.set (ACTION_QUIT, "<Control>q");
             action_accelerators.set (ACTION_ZOOM_DEFAULT, "<Control>0");
             action_accelerators.set (ACTION_ZOOM_IN, "<Control>plus");
+            action_accelerators.set (ACTION_ZOOM_IN, "<Control>KP_Add");
             action_accelerators.set (ACTION_ZOOM_OUT, "<Control>minus");
+            action_accelerators.set (ACTION_ZOOM_OUT, "<Control>KP_Subtract");
         }
 
         construct {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1,7 +1,7 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*
 * Copyright (c) 2011-2013 Mario Guerriero <mefrio.g@gmail.com>
-*               2017 elementary LLC. <https://elementary.io>
+*               2017-2018 elementary LLC. <https://elementary.io>
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -1,7 +1,7 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*
 * Copyright (c) 2013 Mario Guerriero <mefrio.g@gmail.com>
-*               2017 elementary LLC. <https://elementary.io>
+*               2017-2018 elementary LLC. <https://elementary.io>
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public
@@ -61,16 +61,33 @@ namespace Scratch.Widgets {
             find_button.image = new Gtk.Image.from_icon_name ("edit-find", Gtk.IconSize.LARGE_TOOLBAR);
             find_button.tooltip_text = _("Find…");
 
-            var zoom_default = new Gtk.Button.from_icon_name ("zoom-original", Gtk.IconSize.LARGE_TOOLBAR);
-            zoom_default.action_name = MainWindow.ACTION_PREFIX + MainWindow.ACTION_ZOOM_DEFAULT;
-            zoom_default.tooltip_text = _("Zoom 1:1");
-
             share_menu = new Gtk.Menu ();
             share_app_menu = new Gtk.MenuButton ();
             share_app_menu.image = new Gtk.Image.from_icon_name ("document-export", Gtk.IconSize.LARGE_TOOLBAR);
             share_app_menu.no_show_all = true;
             share_app_menu.tooltip_text = _("Share");
             share_app_menu.set_popup (share_menu);
+
+            var zoom_out_button = new Gtk.Button.from_icon_name ("zoom-out-symbolic", Gtk.IconSize.MENU);
+            zoom_out_button.action_name = MainWindow.ACTION_PREFIX + MainWindow.ACTION_ZOOM_OUT;
+            zoom_out_button.tooltip_text = _("Zoom Out");
+
+            var zoom_default_button = new Gtk.Button.with_label ("100%");
+            zoom_default_button.action_name = MainWindow.ACTION_PREFIX + MainWindow.ACTION_ZOOM_DEFAULT;
+            zoom_default_button.tooltip_text = _("Zoom 1:1");
+
+            var zoom_in_button = new Gtk.Button.from_icon_name ("zoom-in-symbolic", Gtk.IconSize.MENU);
+            zoom_in_button.action_name = MainWindow.ACTION_PREFIX + MainWindow.ACTION_ZOOM_IN;
+            zoom_in_button.tooltip_text = _("Zoom In");
+
+            var font_size_grid = new Gtk.Grid ();
+            font_size_grid.column_homogeneous = true;
+            font_size_grid.hexpand = true;
+            font_size_grid.margin = 12;
+            font_size_grid.get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
+            font_size_grid.add (zoom_out_button);
+            font_size_grid.add (zoom_default_button);
+            font_size_grid.add (zoom_in_button);
 
             var new_view_menuitem = new Gtk.ModelButton ();
             new_view_menuitem.text = _("Add New View");
@@ -87,9 +104,11 @@ namespace Scratch.Widgets {
             var menu_grid = new Gtk.Grid ();
             menu_grid.margin_top = menu_grid.margin_bottom = 3;
             menu_grid.orientation = Gtk.Orientation.VERTICAL;
+            menu_grid.width_request = 200;
+            menu_grid.add (font_size_grid);
+            menu_grid.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
             menu_grid.add (new_view_menuitem);
             menu_grid.add (remove_view_menuitem);
-            menu_grid.add (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
             menu_grid.add (preferences_menuitem);
             menu_grid.show_all ();
 
@@ -115,7 +134,6 @@ namespace Scratch.Widgets {
             pack_end (share_app_menu);
             pack_end (new Gtk.Separator (Gtk.Orientation.HORIZONTAL));
             pack_end (find_button);
-            pack_end (zoom_default);
 
             show_all ();
 
@@ -125,7 +143,7 @@ namespace Scratch.Widgets {
             settings.changed.connect (() => {
                 save_button.visible = !settings.autosave;
                 var last_window = Application.instance.get_last_window ();
-                zoom_default.visible = last_window.get_default_font_size () != last_window.get_current_font_size ();
+                zoom_default_button.label = "%.0f%%".printf (last_window.get_current_font_size () * 10);
             });
 
         }

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -102,7 +102,7 @@ namespace Scratch.Widgets {
             preferences_menuitem.action_name = MainWindow.ACTION_PREFIX + MainWindow.ACTION_PREFERENCES;
 
             var menu_grid = new Gtk.Grid ();
-            menu_grid.margin_top = menu_grid.margin_bottom = 3;
+            menu_grid.margin_bottom = 3;
             menu_grid.orientation = Gtk.Orientation.VERTICAL;
             menu_grid.width_request = 200;
             menu_grid.add (font_size_grid);

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -84,29 +84,11 @@ namespace Scratch.Widgets {
 
             scroll_event.connect ((key_event) => {
                 if ((Gdk.ModifierType.CONTROL_MASK in key_event.state) && key_event.delta_y < 0) {
-                    Application.instance.get_last_window ().zoom_in ();
+                    Application.instance.get_last_window ().action_zoom_in ();
                     return true;
                 } else if ((Gdk.ModifierType.CONTROL_MASK in key_event.state) && key_event.delta_y > 0) {
-                    Application.instance.get_last_window ().zoom_out ();
+                    Application.instance.get_last_window ().action_zoom_out ();
                     return true;
-                }
-
-                return false;
-            });
-
-            key_press_event.connect ((key_event) => {
-                if (Gdk.ModifierType.CONTROL_MASK in key_event.state) {
-                    switch (key_event.keyval) {
-                        case Gdk.Key.plus:
-                            Application.instance.get_last_window ().zoom_in ();
-                            return true;
-                        case Gdk.Key.minus:
-                            Application.instance.get_last_window ().zoom_out ();
-                            return true;
-                        case 0x30:
-                            Application.instance.get_last_window ().set_default_zoom ();
-                            return true;
-                    }
                 }
 
                 return false;

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -1,7 +1,7 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*
 * Copyright (c) 2013 Mario Guerriero <mefrio.g@gmail.com>
-*               2017 elementary LLC. <https://elementary.io>
+*               2017-2018 elementary LLC. <https://elementary.io>
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public


### PR DESCRIPTION
* Add Actions for zoom in and zoom out
* Use action accels instead of manually grabbing keys from gdk
* Remove the zoom default button from the headerbar and use the zoom controls widget from Terminal

![screenshot from 2018-01-11 10 18 48](https://user-images.githubusercontent.com/7277719/34840672-8fc934be-f6ba-11e7-99d4-2c47c5dc3aaf.png)
