### PR TITLE
Don't set prefs dialog modal

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -690,6 +690,10 @@ namespace Scratch {
             if (preferences_dialog == null) {
                 preferences_dialog = new Scratch.Dialogs.Preferences (this, plugins);
                 preferences_dialog.show_all ();
+
+                preferences_dialog.destroy.connect (() => {
+                    preferences_dialog = null;
+                });
             }
 
             preferences_dialog.present ();

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -41,6 +41,7 @@ namespace Scratch {
         public Gtk.Notebook bottombar;
         public Code.Pane project_pane;
 
+        private Gtk.Dialog? preferences_dialog = null;
         private Gtk.Paned hp1;
         private Gtk.Paned hp2;
         private Gtk.Paned vp;
@@ -686,9 +687,12 @@ namespace Scratch {
         }
 
         private void action_preferences () {
-            var dialog = new Scratch.Dialogs.Preferences (this, plugins);
-            dialog.set_modal (true);
-            dialog.show_all ();
+            if (preferences_dialog == null) {
+                preferences_dialog = new Scratch.Dialogs.Preferences (this, plugins);
+                preferences_dialog.show_all ();
+            }
+
+            preferences_dialog.present ();
         }
 
         private void action_close_tab () {


### PR DESCRIPTION
https://elementary.io/docs/human-interface-guidelines#preference-dialogs

"Preference dialogs should be made Transient, but not Modal. When a user makes a change in a preference dialog, the change should be immediately visible in the UI. If the dialog is modal, the user may be blocked from seeing (and especially from interacting with) the change. This means they will have to close the dialog, evaluate the change, then possibly re-open the dialog."