### PR TITLE
Don't try to load gjs libpeas loader

### DIFF
--- a/src/Services/PluginManager.vala
+++ b/src/Services/PluginManager.vala
@@ -94,7 +94,6 @@ namespace Scratch.Services {
             /* Let's init the engine */
             engine = Peas.Engine.get_default ();
             engine.enable_loader ("python");
-            engine.enable_loader ("gjs");
             engine.add_search_path (Constants.PLUGINDIR, null);
             settings.bind("plugins-enabled", engine, "loaded-plugins", SettingsBindFlags.DEFAULT);
             
@@ -118,7 +117,6 @@ namespace Scratch.Services {
                 /* The core now */
                 engine_core = new Peas.Engine ();
                 engine_core.enable_loader ("python");
-                engine_core.enable_loader ("gjs");
                 engine_core.add_search_path (Constants.PLUGINDIR + "/" + set_name + "/", null);
 
                 var core_list = engine_core.get_plugin_list ().copy ();


### PR DESCRIPTION
- The `gjs` loader has been removed from upstream for many years
- Enabling two dynamic loaders (python and gjs) is broken in practice as they both leak references
- None of the plugins in-tree use it

(Sidenote it is probably time to move `python` to `python3`)