### PR TITLE
Remove unnecessary devhelp dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
  - docker
 
 env:
- - DEPENDENCY_PACKAGES="cmake libdevhelp-dev libgail-3-dev libgee-0.8-dev libgtksourceview-3.0-dev libgtkspell3-3-dev libgranite-dev libpeas-dev libsoup2.4-dev libvala-0.36-dev libvte-2.91-dev libwebkit2gtk-4.0-dev libxml2-utils libzeitgeist-2.0 valac"
+ - DEPENDENCY_PACKAGES="cmake libgail-3-dev libgee-0.8-dev libgtksourceview-3.0-dev libgtkspell3-3-dev libgranite-dev libpeas-dev libsoup2.4-dev libvala-0.36-dev libvte-2.91-dev libwebkit2gtk-4.0-dev libxml2-utils libzeitgeist-2.0 valac"
 
 install:
  - docker pull elementary/docker:loki

--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@
 
 You'll need the following dependencies:
 * cmake
-* libdevhelp-dev
 * libgail-3-dev
 * libgee-0.8-dev
 * libgtksourceview-3.0-dev


### PR DESCRIPTION
libdevhelp-dev isn't actually used anymore, so let's remove it from the readme and travis build