### PR TITLE
On change tab, select file in sidebar if visible

### DIFF
--- a/src/FolderManager/FileView.vala
+++ b/src/FolderManager/FileView.vala
@@ -81,7 +81,12 @@ namespace Scratch.FolderManager {
         private Granite.Widgets.SourceList.Item? find_path (Granite.Widgets.SourceList.ExpandableItem list, string path) {
             foreach (var item in list.children) {
                 if (item is Item) {
-                    if ((item as Item).path == path) {
+                    var code_item = item as Item;
+                    if (!path.has_prefix (code_item.path)) {
+                        continue;
+                    }
+
+                    if (code_item.path == path) {
                         return item;
                     }
                 }

--- a/src/FolderManager/FileView.vala
+++ b/src/FolderManager/FileView.vala
@@ -74,6 +74,34 @@ namespace Scratch.FolderManager {
             write_settings ();
         }
 
+        public void select_path (string path) {
+            selected = find_path (root, path);
+        }
+
+        private Granite.Widgets.SourceList.Item? find_path (Granite.Widgets.SourceList.ExpandableItem list, string path) {
+            foreach (var item in list.children) {
+                if (item is Item) {
+                    if ((item as Item).path == path) {
+                        return item;
+                    }
+                }
+
+                if (item is Granite.Widgets.SourceList.ExpandableItem) {
+                    var expander = item as Granite.Widgets.SourceList.ExpandableItem;
+                    if (!expander.expanded) {
+                        continue;
+                    }
+
+                    var recurse_item = find_path (item as Granite.Widgets.SourceList.ExpandableItem, path);
+                    if (recurse_item != null) {
+                        return recurse_item;
+                    }
+                }
+            }
+
+            return null;
+        }
+
         private void add_folder (File folder, bool expand) {
             if (is_open (folder)) {
                 warning ("Folder '%s' is already open.", folder.path);

--- a/src/FolderManager/FileView.vala
+++ b/src/FolderManager/FileView.vala
@@ -82,24 +82,20 @@ namespace Scratch.FolderManager {
             foreach (var item in list.children) {
                 if (item is Item) {
                     var code_item = item as Item;
-                    if (!path.has_prefix (code_item.path)) {
-                        continue;
-                    }
-
                     if (code_item.path == path) {
                         return item;
                     }
-                }
 
-                if (item is Granite.Widgets.SourceList.ExpandableItem) {
-                    var expander = item as Granite.Widgets.SourceList.ExpandableItem;
-                    if (!expander.expanded) {
-                        continue;
-                    }
+                    if (item is Granite.Widgets.SourceList.ExpandableItem) {
+                        var expander = item as Granite.Widgets.SourceList.ExpandableItem;
+                        if (!expander.expanded || !path.has_prefix (code_item.path)) {
+                            continue;
+                        }
 
-                    var recurse_item = find_path (item as Granite.Widgets.SourceList.ExpandableItem, path);
-                    if (recurse_item != null) {
-                        return recurse_item;
+                        var recurse_item = find_path (expander, path);
+                        if (recurse_item != null) {
+                            return recurse_item;
+                        }
                     }
                 }
             }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -275,6 +275,7 @@ namespace Scratch {
                 // Update MainWindow title
                 if (doc != null) {
                     toolbar.set_document_focus (doc);
+                    folder_manager_view.select_path (doc.file.get_path ());
                 }
 
                 // Set actions sensitive property


### PR DESCRIPTION
Fixes #6 

When changing tab, select the item belonging to the new tab in the sidebar if it is visible (i.e. expanded) in the folder manager scroll view.

Otherwise, deselect the currently selected item in the folder manager, so it can be clicked again if necessary.