### PR TITLE
Fix source tags

### DIFF
--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -75,6 +75,9 @@ namespace Scratch.Widgets {
             error_tag = new Gtk.TextTag ("error_bg");
             error_tag.underline = Pango.Underline.ERROR;
 
+            source_buffer.tag_table.add (error_tag);
+            source_buffer.tag_table.add (warning_tag);
+
             restore_settings ();
 
             Gtk.drag_dest_add_uri_targets (this);

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -70,7 +70,8 @@ namespace Scratch.Widgets {
 
             // Create common tags
             warning_tag = new Gtk.TextTag ("warning_bg");
-            warning_tag.background_rgba = Gdk.RGBA () { red = 1.0, green = 1.0, blue = 0, alpha = 0.8 };
+            warning_tag.underline = Pango.Underline.ERROR;
+            warning_tag.underline_rgba = Gdk.RGBA () { red = 0.13, green = 0.55, blue = 0.13, alpha = 1.0 };
 
             error_tag = new Gtk.TextTag ("error_bg");
             error_tag.underline = Pango.Underline.ERROR;


### PR DESCRIPTION
There was some reference to a couple of source tags in the code. They weren't being added to the tag table and hence unusable. But these would be really useful for a language client implementation :wink: 

So, I've added them to the tag table and made a punt at changing the styling of one of them as I wasn't feeling the bright yellow background. The error tag is a nice red squiggly underline as you might expect. Green for warning?

**Before:**
![screenshot from 2018-03-19 22 39 56 2x](https://user-images.githubusercontent.com/3372394/37626217-008f82ca-2bc7-11e8-861f-92d11fc06e65.png)

**After:**
![screenshot from 2018-03-19 22 40 59 2x](https://user-images.githubusercontent.com/3372394/37626236-0e5ace82-2bc7-11e8-9e08-8d7b7eb62e76.png)
