### PR TITLE
Add initial editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,12 +3,12 @@ root = true
 
 # elementary defaults
 [*]
-end_of_line = lf
-insert_final_newline = true
 charset = utf-8
-max_line_length = 80
-indent_style = space
+end_of_line = lf
 indent_size = tab
+indent_style = space
+insert_final_newline = true
+max_line_length = 80
 tab_width = 4
 
 [{*.xml,*.xml.in,*.yml}]

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,16 @@
+# EditorConfig <http://EditorConfig.org>
+root = true
+
+# elementary defaults
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+max_line_length = 80
+indent_style = space
+indent_size = tab
+tab_width = 4
+
+[{*.xml,*.xml.in,*.yml}]
+tab_width = 2
+


### PR DESCRIPTION
Since I've been dogfooding the editorconfig plugin, I figured it makes sense to ship one with this repo. This is mostly a reflection of the existing code, which is elementary-style, but with two-character indents for YML and XML (as it was in the repo). I can remove the special casing there if we want.