### PR TITLE
Don't add temporary GLib file

### DIFF
--- a/src/FolderManager/FolderItem.vala
+++ b/src/FolderManager/FolderItem.vala
@@ -167,6 +167,11 @@ namespace Scratch.FolderManager {
                             return;
                         }
 
+                        // Temporary files from GLib that are present when saving a file
+                        if (source.get_basename ().has_prefix (".goutputstream")) {
+                            return;
+                        }
+
                         var file = new File (source.get_path ());
                         var exists = false;
                         foreach (var item in children) {


### PR DESCRIPTION
This temporary file made the file view flicker on file modification