### PR TITLE
Stop firing loads of selection/deselection events

### DIFF
--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -260,12 +260,16 @@ namespace Scratch.Widgets {
             Gtk.TextIter start, end;
             buffer.get_selection_bounds (out start,out end);
 
-            if (start == last_select_start_iter && end == last_select_end_iter) {
+            if (start.equal (last_select_start_iter) && end.equal (last_select_end_iter)) {
                 return;
             }
 
-            if (selection_changed_timer !=0 && MainContext.get_thread_default ().find_source_by_id (selection_changed_timer) != null) {
+            last_select_start_iter = start;
+            last_select_end_iter = end;
+
+            if (selection_changed_timer != 0) {
                 Source.remove (selection_changed_timer);
+                selection_changed_timer = 0;
             }
 
             // Fire deselected immediatly
@@ -287,6 +291,7 @@ namespace Scratch.Widgets {
                 deselected ();
             }
 
+            selection_changed_timer = 0;
             return false;
         }
 


### PR DESCRIPTION
There were a couple of things that meant we were firing deselect/selection changed signals a few times every second. Make sure we check if things have changed before we fire the events again.