### PR TITLE
Compare iterators instead of property for selection_changed event

### DIFF
--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -273,7 +273,7 @@ namespace Scratch.Widgets {
             }
 
             // Fire deselected immediatly
-            if (!buffer.get_has_selection ()) {
+            if (start.equal (end)) {
                 deselected ();
             // Don't fire signal till we think select movement is done
             } else {


### PR DESCRIPTION
Fixes some edge cases around the "selection/deselection" event handling. It would seem the buffers, `get_has_selection` method isn't quite up to date with the selection state of the buffer during the `on_mark_set` events. So if we compare the start and end iterators of the selection instead, we can see whether some text is selected or not.

It's probably slightly more optimised too, since we already have those properties. You can test this with the highlight word selection plugin, as that is the only thing that uses these events. This pull request should make the selection/deselection events more consistent, seems to have gone a bit flaky since the last couple of merges (my bad).