### PR TITLE
Spelling "PasteBin" → "Pastebin"

### DIFF
--- a/plugins/pastebin/pastebin_dialog.vala
+++ b/plugins/pastebin/pastebin_dialog.vala
@@ -246,7 +246,7 @@ namespace Scratch.Dialogs {
                 deletable: false,
                 doc: doc,
                 transient_for: parent,
-                title: _("Share via PasteBin")
+                title: _("Share via Pastebin")
             );
         }
 


### PR DESCRIPTION
As per https://pastebin.com/faq
It could be that it should be "Pastebin.com", but in any event "PasteBin" is incorrect.