### PR TITLE
Remove contractor from plugins schema

### DIFF
--- a/data/io.elementary.code.gschema.xml
+++ b/data/io.elementary.code.gschema.xml
@@ -50,7 +50,7 @@
   </schema>
   <schema path="/io/elementary/code/settings/" id="io.elementary.code.settings" gettext-domain="io.elementary.code">
     <key type="as" name="plugins-enabled">
-      <default>['detect-indent', 'editorconfig', 'contractor', 'outline']</default>
+      <default>['detect-indent', 'editorconfig', 'outline']</default>
       <summary>Enabled Plugins</summary>
       <description>Enabled Plugins</description>
     </key>


### PR DESCRIPTION
This is now a built-in part of the folder manager instead of a plugin