### PR TITLE
Draw spaces in selection the same way if drawn at all.

### DIFF
--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -341,7 +341,10 @@ namespace Scratch.Widgets {
             Gtk.TextIter start, end;
             var selection = buffer.get_selection_bounds (out start, out end);
 
-            if (selection && settings.draw_spaces == ScratchDrawSpacesState.FOR_SELECTION) {
+            /* Draw spaces in selection the same way if drawn at all */
+            if (selection &&
+                settings.draw_spaces in (ScratchDrawSpacesState.FOR_SELECTION | ScratchDrawSpacesState.ALWAYS)) {
+
                 buffer.apply_tag_by_name ("draw_spaces", start, end);
             }
         }


### PR DESCRIPTION
Following a change to using native Gtk space drawing, white space within selection appeared differently (that is whether the line endings were drawn) depending on the settings.  With this PR, whitespace within a selection is always drawn with SourceTags.

Ideally a solution should be found for the SourceTags behaving differently from the SourceSpaceDrawer (maybe upstream?)