### PR TITLE
[Request]Implement a "Restore tabs" option (default true)

### DIFF
--- a/data/io.elementary.code.gschema.xml
+++ b/data/io.elementary.code.gschema.xml
@@ -74,6 +74,11 @@
       <summary>Wrap long lines</summary>
       <description>Wrap long lines.</description>
     </key>
+    <key name="restore-tabs" type="b">
+      <default>true</default>
+      <summary>Whether to restore tabs when app is opened</summary>
+      <description>Whether to restore previously opened tabs or to show the welcome screen when the application is opened</description>
+    </key>
     <key name="show-right-margin" type="b">
       <default>false</default>
       <summary>Show the right margin</summary>

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -213,7 +213,9 @@ namespace Scratch {
             if (window == null) {
                 window = this.new_window ();
                 window.show ();
-                window.restore_opened_documents ();
+                if (settings.restore_tabs) {
+                    window.restore_opened_documents ();
+                }
             } else {
                 window.present ();
             }

--- a/src/Dialogs/PreferencesDialog.vala
+++ b/src/Dialogs/PreferencesDialog.vala
@@ -52,13 +52,15 @@ namespace Scratch.Dialogs {
             general_grid.attach (new Granite.HeaderLabel (_("General")), 0, 0, 2, 1);
             general_grid.attach (new SettingsLabel (_("Save files when changed:")), 0, 1, 1, 1);
             general_grid.attach (new SettingsSwitch ("autosave"), 1, 1, 1, 1);
-            general_grid.attach (new Granite.HeaderLabel (_("Tabs")), 0, 2, 2, 1);
-            general_grid.attach (new SettingsLabel (_("Automatic indentation:")), 0, 3, 1, 1);
-            general_grid.attach (new SettingsSwitch ("auto-indent"), 1, 3, 1, 1);
-            general_grid.attach (new SettingsLabel (_("Insert spaces instead of tabs:")), 0, 4, 1, 1);
-            general_grid.attach (new SettingsSwitch ("spaces-instead-of-tabs"), 1, 4, 1, 1);
-            general_grid.attach (new SettingsLabel (_("Tab width:")), 0, 5, 1, 1);
-            general_grid.attach (indent_width, 1, 5, 1, 1);
+            general_grid.attach (new SettingsLabel (_("Restore tabs:")), 0, 2, 1, 1);
+            general_grid.attach (new SettingsSwitch ("restore-tabs"), 1, 2, 1, 1);
+            general_grid.attach (new Granite.HeaderLabel (_("Tabs")), 0, 3, 2, 1);
+            general_grid.attach (new SettingsLabel (_("Automatic indentation:")), 0, 4, 1, 1);
+            general_grid.attach (new SettingsSwitch ("auto-indent"), 1, 4, 1, 1);
+            general_grid.attach (new SettingsLabel (_("Insert spaces instead of tabs:")), 0, 5, 1, 1);
+            general_grid.attach (new SettingsSwitch ("spaces-instead-of-tabs"), 1, 5, 1, 1);
+            general_grid.attach (new SettingsLabel (_("Tab width:")), 0, 6, 1, 1);
+            general_grid.attach (indent_width, 1, 6, 1, 1);
 
             main_stack = new Gtk.Stack ();
             main_stack.margin = 6;

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -67,6 +67,7 @@ namespace Scratch {
         public string[] opened_files_view1 { get; set; }
         public string[] opened_files_view2 { get; set; }
         public bool autosave { get; set; }
+        public bool restore_tabs { get; set; }
         public string focused_document_view1 { get; set; }
         public string focused_document_view2 { get; set; }
         public bool show_mini_map { get; set; }
@@ -89,7 +90,7 @@ namespace Scratch {
         }
 
     }
-    
+
     public class FolderManagerSettings : Granite.Services.Settings {
 
         private const string SCHEMA = Constants.PROJECT_NAME + ".folder-manager";


### PR DESCRIPTION
Fixes #605 

Adds another option to the Preferences dialog that turns of the default behaviour to open previously open documents when the application is launched and to show the welcome screen instead