### PR TITLE
Try an info icon for smart cut/copy

### DIFF
--- a/src/Dialogs/PreferencesDialog.vala
+++ b/src/Dialogs/PreferencesDialog.vala
@@ -43,24 +43,30 @@ namespace Scratch.Dialogs {
         }
 
         construct {
+            var smart_cut_copy_info = new Gtk.Image.from_icon_name ("dialog-information-symbolic", Gtk.IconSize.MENU);
+            smart_cut_copy_info.halign = Gtk.Align.START;
+            smart_cut_copy_info.tooltip_text = _("Cutting or copying without an active selection will cut or copy the entire current line");
+            smart_cut_copy_info.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+
             var indent_width = new Gtk.SpinButton.with_range (1, 24, 1);
             Scratch.settings.schema.bind ("indent-width", indent_width, "value", SettingsBindFlags.DEFAULT);
 
             var general_grid = new Gtk.Grid ();
             general_grid.column_spacing = 12;
             general_grid.row_spacing = 6;
-            general_grid.attach (new Granite.HeaderLabel (_("General")), 0, 0, 2, 1);
-            general_grid.attach (new SettingsLabel (_("Save files when changed:")), 0, 1, 1, 1);
-            general_grid.attach (new SettingsSwitch ("autosave"), 1, 1, 1, 1);
-            general_grid.attach (new SettingsLabel (_("Cut or copy current line without a selection:")), 0, 2, 1, 1);
-            general_grid.attach (new SettingsSwitch ("smart-cut-copy"), 1, 2, 1, 1);
-            general_grid.attach (new Granite.HeaderLabel (_("Tabs")), 0, 3, 2, 1);
-            general_grid.attach (new SettingsLabel (_("Automatic indentation:")), 0, 4, 1, 1);
-            general_grid.attach (new SettingsSwitch ("auto-indent"), 1, 4, 1, 1);
-            general_grid.attach (new SettingsLabel (_("Insert spaces instead of tabs:")), 0, 5, 1, 1);
-            general_grid.attach (new SettingsSwitch ("spaces-instead-of-tabs"), 1, 5, 1, 1);
-            general_grid.attach (new SettingsLabel (_("Tab width:")), 0, 6, 1, 1);
-            general_grid.attach (indent_width, 1, 6, 1, 1);
+            general_grid.attach (new Granite.HeaderLabel (_("General")), 0, 0, 3);
+            general_grid.attach (new SettingsLabel (_("Save files when changed:")), 0, 1);
+            general_grid.attach (new SettingsSwitch ("autosave"), 1, 1, 2);
+            general_grid.attach (new SettingsLabel (_("Smart cut/copy lines:")), 0, 2);
+            general_grid.attach (new SettingsSwitch ("smart-cut-copy"), 1, 2);
+            general_grid.attach (smart_cut_copy_info, 2, 2);
+            general_grid.attach (new Granite.HeaderLabel (_("Tabs")), 0, 3, 3);
+            general_grid.attach (new SettingsLabel (_("Automatic indentation:")), 0, 4);
+            general_grid.attach (new SettingsSwitch ("auto-indent"), 1, 4, 2);
+            general_grid.attach (new SettingsLabel (_("Insert spaces instead of tabs:")), 0, 5);
+            general_grid.attach (new SettingsSwitch ("spaces-instead-of-tabs"), 1, 5, 2);
+            general_grid.attach (new SettingsLabel (_("Tab width:")), 0, 6);
+            general_grid.attach (indent_width, 1, 6, 2);
 
             main_stack = new Gtk.Stack ();
             main_stack.margin = 6;

--- a/src/Dialogs/PreferencesDialog.vala
+++ b/src/Dialogs/PreferencesDialog.vala
@@ -46,7 +46,6 @@ namespace Scratch.Dialogs {
             var smart_cut_copy_info = new Gtk.Image.from_icon_name ("dialog-information-symbolic", Gtk.IconSize.MENU);
             smart_cut_copy_info.halign = Gtk.Align.START;
             smart_cut_copy_info.tooltip_text = _("Cutting or copying without an active selection will cut or copy the entire current line");
-            smart_cut_copy_info.get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
             var indent_width = new Gtk.SpinButton.with_range (1, 24, 1);
             Scratch.settings.schema.bind ("indent-width", indent_width, "value", SettingsBindFlags.DEFAULT);


### PR DESCRIPTION
An example of something we could do for #425. Suggestions welcome.

![screenshot from 2018-12-19 14 44 06](https://user-images.githubusercontent.com/611168/50249896-9456aa80-039c-11e9-8149-f56ad231cc9b.png)
