### PR TITLE
Fix crash on startup under some circumstances

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -358,20 +358,22 @@ namespace Scratch {
 
             search_revealer.set_reveal_child (false);
 
-            // Plugins hook
-            HookFunc hook_func = () => {
-                plugins.hook_window (this);
-                plugins.hook_toolbar (toolbar);
-                plugins.hook_share_menu (toolbar.share_menu);
-                plugins.hook_notebook_bottom (bottombar);
-                plugins.hook_split_view (split_view);
-            };
+            realize.connect (() => {
+                // Plugins hook
+                HookFunc hook_func = () => {
+                    plugins.hook_window (this);
+                    plugins.hook_toolbar (toolbar);
+                    plugins.hook_share_menu (toolbar.share_menu);
+                    plugins.hook_notebook_bottom (bottombar);
+                    plugins.hook_split_view (split_view);
+                };
 
-            plugins.extension_added.connect (() => {
+                plugins.extension_added.connect (() => {
+                    hook_func ();
+                });
+
                 hook_func ();
             });
-
-            hook_func ();
         }
 
         public void restore_opened_documents () {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -353,9 +353,6 @@ namespace Scratch {
 
             add (vp);
 
-            // Show/Hide widgets
-            show_all ();
-
             search_revealer.set_reveal_child (false);
 
             realize.connect (() => {
@@ -374,6 +371,9 @@ namespace Scratch {
 
                 hook_func ();
             });
+
+            // Show/Hide widgets
+            show_all ();
         }
 
         public void restore_opened_documents () {


### PR DESCRIPTION
Fixes #619 

The cause was not precisely identified but is related to a race between realizing the widgets and hooking the plugins.  This is avoided by not hooking plugins until the realize signal is received.