### PR TITLE
Implement change branch context menu item.

### DIFF
--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -120,7 +120,7 @@ namespace Scratch.FolderManager {
                         }
                     }
                 } catch (GLib.Error e) {
-                    warning ("Failed to create menuitem fir branch %s. %s", branch_name ?? "unknown", e.message);
+                    warning ("Failed to create menuitem for branch %s. %s", branch_name ?? "unknown", e.message);
                 }
             }
 


### PR DESCRIPTION
* based on the work of Marcelo de Andrade <marceloga1@al.insper.edu.br>
* Catch GLib.Errors
* Null checks

Further work or PRs are advisable to, for example, warn if there are uncommitted changes in the current branch before changing branch and give options to deal with the situation.

