### PR TITLE
Fix finding editorconfig

### DIFF
--- a/plugins/editorconfig/meson.build
+++ b/plugins/editorconfig/meson.build
@@ -7,7 +7,7 @@ module_files = [
 
 module_deps = [
     codecore_dep,
-    meson.get_compiler('c').find_library('libeditorconfig')
+    meson.get_compiler('c').find_library('editorconfig')
 ]
 
 shared_module(


### PR DESCRIPTION
`compiler.find_library` expects the `lib_name` without `lib` prefix.