### PR TITLE
meson: Drop superfluous and erroneous install_dir usage

### DIFF
--- a/src/meson.build
+++ b/src/meson.build
@@ -56,7 +56,6 @@ codecore = library(
     config_header,
     dependencies: dependencies,
     install: true,
-    install_dir: [true, true, true],
     version: '0.0'
 )
 


### PR DESCRIPTION
Fixes #635 