### PR TITLE
Utils: Remove filechooser util

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -741,7 +741,7 @@ namespace Scratch {
 
         private void action_open () {
             // Show a GtkFileChooserDialog
-            var filech = Utils.new_file_chooser_dialog (Gtk.FileChooserAction.OPEN, _("Open some files"), this, true);
+            var filech = Utils.new_file_chooser_dialog (Gtk.FileChooserAction.OPEN, _("Open some files"), this);
             var response = filech.run ();
             filech.destroy (); // Close now so it does not stay open during lengthy or failed loading
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -740,13 +740,32 @@ namespace Scratch {
         }
 
         private void action_open () {
-            // Show a GtkFileChooserDialog
-            var filech = Utils.new_file_chooser_dialog (Gtk.FileChooserAction.OPEN, _("Open some files"), this);
-            var response = filech.run ();
-            filech.destroy (); // Close now so it does not stay open during lengthy or failed loading
+            var all_files_filter = new Gtk.FileFilter ();
+            all_files_filter.set_filter_name (_("All files"));
+            all_files_filter.add_pattern ("*");
+
+            var text_files_filter = new Gtk.FileFilter ();
+            text_files_filter.set_filter_name (_("Text files"));
+            text_files_filter.add_mime_type ("text/*");
+
+            var file_chooser = new Gtk.FileChooserNative (
+                _("Open some files"),
+                this,
+                Gtk.FileChooserAction.OPEN,
+                _("Open"),
+                _("Cancel")
+            );
+            file_chooser.add_filter (all_files_filter);
+            file_chooser.add_filter (text_files_filter);
+            file_chooser.filter = text_files_filter;
+            file_chooser.select_multiple = true;
+            file_chooser.set_current_folder_uri (Utils.last_path ?? GLib.Environment.get_home_dir ());
+
+            var response = file_chooser.run ();
+            file_chooser.destroy (); // Close now so it does not stay open during lengthy or failed loading
 
             if (response == Gtk.ResponseType.ACCEPT) {
-                foreach (string uri in filech.get_uris ()) {
+                foreach (string uri in file_chooser.get_uris ()) {
                     // Update last visited path
                     Utils.last_path = Path.get_dirname (uri);
                     // Open the file

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -755,9 +755,8 @@ namespace Scratch {
                 _("Open"),
                 _("Cancel")
             );
-            file_chooser.add_filter (all_files_filter);
             file_chooser.add_filter (text_files_filter);
-            file_chooser.filter = text_files_filter;
+            file_chooser.add_filter (all_files_filter);
             file_chooser.select_multiple = true;
             file_chooser.set_current_folder_uri (Utils.last_path ?? GLib.Environment.get_home_dir ());
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -743,7 +743,7 @@ namespace Scratch {
             // Show a GtkFileChooserDialog
             var filech = Utils.new_file_chooser_dialog (Gtk.FileChooserAction.OPEN, _("Open some files"), this, true);
             var response = filech.run ();
-            filech.close (); // Close now so it does not stay open during lengthy or failed loading
+            filech.destroy (); // Close now so it does not stay open during lengthy or failed loading
 
             if (response == Gtk.ResponseType.ACCEPT) {
                 foreach (string uri in filech.get_uris ()) {

--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -531,7 +531,7 @@ namespace Scratch.Services {
             var is_current_file_temporary = this.is_file_temporary;
 
             if (file_chooser.run () == Gtk.ResponseType.ACCEPT) {
-                this.file = File.new_for_uri (file_chooser.get_file ().get_uri ());
+                file = File.new_for_uri (file_chooser.get_uri ());
                 // Update last visited path
                 Utils.last_path = Path.get_dirname (file_chooser.get_file ().get_uri ());
                 success = true;

--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -506,18 +506,34 @@ namespace Scratch.Services {
                 return false;
             }
 
+            var all_files_filter = new Gtk.FileFilter ();
+            all_files_filter.set_filter_name (_("All files"));
+            all_files_filter.add_pattern ("*");
 
-            var filech = Utils.new_file_chooser_dialog (Gtk.FileChooserAction.SAVE, _("Save File"), null);
-            filech.do_overwrite_confirmation = true;
+            var text_files_filter = new Gtk.FileFilter ();
+            text_files_filter.set_filter_name (_("Text files"));
+            text_files_filter.add_mime_type ("text/*");
+
+            var file_chooser = new Gtk.FileChooserNative (
+                _("Save File"),
+                null,
+                Gtk.FileChooserAction.SAVE,
+                _("Save"),
+                _("Cancel")
+            );
+            file_chooser.add_filter (all_files_filter);
+            file_chooser.add_filter (text_files_filter);
+            file_chooser.do_overwrite_confirmation = true;
+            file_chooser.set_current_folder_uri (Utils.last_path ?? GLib.Environment.get_home_dir ());
 
             var success = false;
             var current_file = file.get_path ();
             var is_current_file_temporary = this.is_file_temporary;
 
-            if (filech.run () == Gtk.ResponseType.ACCEPT) {
-                this.file = File.new_for_uri (filech.get_file ().get_uri ());
+            if (file_chooser.run () == Gtk.ResponseType.ACCEPT) {
+                this.file = File.new_for_uri (file_chooser.get_file ().get_uri ());
                 // Update last visited path
-                Utils.last_path = Path.get_dirname (filech.get_file ().get_uri ());
+                Utils.last_path = Path.get_dirname (file_chooser.get_file ().get_uri ());
                 success = true;
             }
 
@@ -541,7 +557,7 @@ namespace Scratch.Services {
             /* We delay destruction of file chooser dialog til to avoid the document focussing in,
              * which triggers premature loading of overwritten content.
              */
-            filech.destroy ();
+            file_chooser.destroy ();
             return success;
         }
 

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -22,7 +22,7 @@
 namespace Scratch.Utils {
     public string? last_path = null;
 
-    public Gtk.FileChooserDialog new_file_chooser_dialog (Gtk.FileChooserAction action, string title, Gtk.Window? parent, bool select_multiple = false) {
+    private Gtk.FileChooserNative new_file_chooser_dialog (Gtk.FileChooserAction action, string title, Gtk.Window? parent, bool select_multiple = false) {
         var all_files_filter = new Gtk.FileFilter ();
         all_files_filter.set_filter_name (_("All files"));
         all_files_filter.add_pattern ("*");
@@ -31,28 +31,33 @@ namespace Scratch.Utils {
         text_files_filter.set_filter_name (_("Text files"));
         text_files_filter.add_mime_type ("text/*");
 
-        var filech = new Gtk.FileChooserDialog (title, parent, action);
-        filech.add_button (_("Cancel"), Gtk.ResponseType.CANCEL);
-        filech.add_filter (all_files_filter);
-        filech.add_filter (text_files_filter);
-        filech.set_current_folder_uri (Utils.last_path ?? GLib.Environment.get_home_dir ());
-        filech.set_default_response (Gtk.ResponseType.ACCEPT);
-        filech.select_multiple = select_multiple;
+        Gtk.FileChooserNative file_chooser;
 
         if (action == Gtk.FileChooserAction.OPEN) {
-            filech.filter = text_files_filter;
-            filech.add_button (_("Open"), Gtk.ResponseType.ACCEPT);
+            file_chooser = new Gtk.FileChooserNative (
+                title,
+                parent,
+                Gtk.FileChooserAction.OPEN,
+                _("Open"),
+                _("Cancel")
+            );
+            file_chooser.filter = text_files_filter;
         } else {
-            filech.add_button (_("Save"), Gtk.ResponseType.ACCEPT);
+            file_chooser = new Gtk.FileChooserNative (
+                title,
+                parent,
+                action,
+                _("Save"),
+                _("Cancel")
+            );
         }
 
-        filech.key_press_event.connect ((ev) => {
-            if (ev.keyval == 65307) // Esc key
-                filech.destroy ();
-            return false;
-        });
+        file_chooser.add_filter (all_files_filter);
+        file_chooser.add_filter (text_files_filter);
+        file_chooser.set_current_folder_uri (Utils.last_path ?? GLib.Environment.get_home_dir ());
+        file_chooser.select_multiple = select_multiple;
 
-        return filech;
+        return file_chooser;
     }
 
     public SimpleAction action_from_group (string action_name, SimpleActionGroup action_group) {

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -22,47 +22,6 @@
 namespace Scratch.Utils {
     public string? last_path = null;
 
-    private Gtk.FileChooserNative new_file_chooser_dialog (Gtk.FileChooserAction action, string title, Gtk.Window? parent) {
-        var all_files_filter = new Gtk.FileFilter ();
-        all_files_filter.set_filter_name (_("All files"));
-        all_files_filter.add_pattern ("*");
-
-        var text_files_filter = new Gtk.FileFilter ();
-        text_files_filter.set_filter_name (_("Text files"));
-        text_files_filter.add_mime_type ("text/*");
-
-        Gtk.FileChooserNative file_chooser;
-
-        if (action == Gtk.FileChooserAction.OPEN) {
-            file_chooser = new Gtk.FileChooserNative (
-                title,
-                parent,
-                Gtk.FileChooserAction.OPEN,
-                _("Open"),
-                _("Cancel")
-            );
-            file_chooser.select_multiple = true;
-        } else {
-            file_chooser = new Gtk.FileChooserNative (
-                title,
-                parent,
-                action,
-                _("Save"),
-                _("Cancel")
-            );
-        }
-
-        file_chooser.add_filter (all_files_filter);
-        file_chooser.add_filter (text_files_filter);
-        file_chooser.set_current_folder_uri (Utils.last_path ?? GLib.Environment.get_home_dir ());
-
-        if (action == Gtk.FileChooserAction.OPEN) {
-            file_chooser.filter = text_files_filter;
-        }
-
-        return file_chooser;
-    }
-
     public SimpleAction action_from_group (string action_name, SimpleActionGroup action_group) {
         return ((SimpleAction) action_group.lookup_action (action_name));
     }

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -22,7 +22,7 @@
 namespace Scratch.Utils {
     public string? last_path = null;
 
-    private Gtk.FileChooserNative new_file_chooser_dialog (Gtk.FileChooserAction action, string title, Gtk.Window? parent, bool select_multiple = false) {
+    private Gtk.FileChooserNative new_file_chooser_dialog (Gtk.FileChooserAction action, string title, Gtk.Window? parent) {
         var all_files_filter = new Gtk.FileFilter ();
         all_files_filter.set_filter_name (_("All files"));
         all_files_filter.add_pattern ("*");
@@ -41,7 +41,7 @@ namespace Scratch.Utils {
                 _("Open"),
                 _("Cancel")
             );
-            file_chooser.filter = text_files_filter;
+            file_chooser.select_multiple = true;
         } else {
             file_chooser = new Gtk.FileChooserNative (
                 title,
@@ -55,7 +55,10 @@ namespace Scratch.Utils {
         file_chooser.add_filter (all_files_filter);
         file_chooser.add_filter (text_files_filter);
         file_chooser.set_current_folder_uri (Utils.last_path ?? GLib.Environment.get_home_dir ());
-        file_chooser.select_multiple = select_multiple;
+
+        if (action == Gtk.FileChooserAction.OPEN) {
+            file_chooser.filter = text_files_filter;
+        }
 
         return file_chooser;
     }


### PR DESCRIPTION
Supersedes #640 
Fixes #639 

This util is only used twice so this seems like an unnecessary over abstraction. It's simpler and clearer to just make two dialogs.

Fwiw, this solution adds 2 lines as opposed to #640 which adds 8