### PR TITLE
User can see all file types and open in default application. 

### DIFF
--- a/src/FolderManager/File.vala
+++ b/src/FolderManager/File.vala
@@ -139,10 +139,7 @@ namespace Scratch.FolderManager {
                     while ((file_info = enumerator.next_file ()) != null) {
                         var child = file.get_child (file_info.get_name ());
                         var file = new File (child.get_path ());
-
-                        if (file.is_valid_directory || file.is_valid_textfile) {
-                            _children.add (new File (child.get_path ()));
-                        }
+                        _children.add (new File (child.get_path ()));
                     }
 
                     children_valid = true;

--- a/src/FolderManager/FileItem.vala
+++ b/src/FolderManager/FileItem.vala
@@ -23,7 +23,7 @@ namespace Scratch.FolderManager {
      * Normal item in the source list, represents a textfile.
      */
     internal class FileItem : Item {
-        public FileItem (File file, FileView view) requires (file.is_valid_textfile) {
+        public FileItem (File file, FileView view) {
             Object (file: file, view: view);
         }
 

--- a/src/FolderManager/FolderItem.vala
+++ b/src/FolderManager/FolderItem.vala
@@ -166,7 +166,7 @@ namespace Scratch.FolderManager {
                 if (child.is_valid_directory) {
                     var item = new FolderItem (child, view);
                     add (item);
-                } else if (child.is_valid_textfile) {
+                } else {
                     var item = new FileItem (child, view);
                     add (item);
                 }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -304,9 +304,14 @@ namespace Scratch {
             folder_manager_view = new FolderManager.FileView ();
 
             folder_manager_view.select.connect ((a) => {
-                var file = GLib.File.new_for_path (a);
-                var doc = new Scratch.Services.Document (actions, file);
-                open_document (doc);
+                var file = new Scratch.FolderManager.File (a);
+                var doc = new Scratch.Services.Document (actions, file.file);
+                
+                if (file.is_valid_textfile) {
+                    open_document (doc);
+                } else {
+                    open_binary (file.file);
+                }
             });
 
             folder_manager_view.root.child_added.connect (() => {
@@ -374,6 +379,18 @@ namespace Scratch {
 
             // Show/Hide widgets
             show_all ();
+        }
+
+        private void open_binary (File file) {
+            if (!file.query_exists ()) {
+                return;
+            }
+
+            try {
+                AppInfo.launch_default_for_uri (file.get_uri (), null);
+            } catch (Error e) {
+                critical (e.message);
+            }
         }
 
         public void restore_opened_documents () {


### PR DESCRIPTION
User can view all file types (files were previously limited to mime text files and folders) and open non-text files in OS default application. Resolves #449.