### PR TITLE
Remove Current View fixed

### DIFF
--- a/src/Widgets/SplitView.vala
+++ b/src/Widgets/SplitView.vala
@@ -122,7 +122,7 @@ namespace Scratch.Widgets {
         public void remove_view (Scratch.Widgets.DocumentView? view = null) {
             // If no specific view is required to be removed, just remove the current one
             if (view == null) {
-                view = get_focus_child () as Scratch.Widgets.DocumentView;
+                view = current_view as Scratch.Widgets.DocumentView;
             }
 
             if (view == null) {


### PR DESCRIPTION
Using "Remove Current View" from the AppMenu was not working. This resolves that. Previously the code was using `get_focus_child ()` on `SplitView`, but as soon as you click on AppMenu the focus is lost. Using `current_view` instead works. Resolves #224.