### PR TITLE
Fix help info is not displayed correctly other than in en_US

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -259,8 +259,8 @@ namespace Scratch {
             { "new-tab", 't', 0, OptionArg.NONE, out create_new_tab, N_("New Tab"), null },
             { "new-window", 'n', 0, OptionArg.NONE, out create_new_window, N_("New Window"), null },
             { "version", 'v', 0, OptionArg.NONE, out print_version, N_("Print version info and exit"), null },
-            { "set", 's', 0, OptionArg.STRING, ref _app_cmd_name, N_("Set of plugins"), "" },
-            { "cwd", 'c', 0, OptionArg.STRING, ref _cwd, N_("Current working directory"), "" },
+            { "set", 's', 0, OptionArg.STRING, ref _app_cmd_name, N_("Set of plugins"), N_("plugin") },
+            { "cwd", 'c', 0, OptionArg.STRING, ref _cwd, N_("Current working directory"), N_("directory") },
             { null }
         };
 


### PR DESCRIPTION
Fixes #488

To test this PR, specify some language like this:

```
LANGUAGE=ja_JP io.elementary.code --help
```

## BEFORE in ja_JP

![Screenshot from 2019-04-25 17-27-48](https://user-images.githubusercontent.com/26003928/56721292-8d430d00-677f-11e9-9dd3-ab0d8009be53.png)

```bash
ryo@ryo-pc:~/Projects$ LANGUAGE=ja_JP io.elementary.code --help
用法:
  io.elementary.code [OPTION…] File

ヘルプのオプション:
  -h, --help                                                                                                                                                                                                                                                                                                                                                                                                                                                          ヘルプのオプションを表示する
  --help-all                                                                                                                                                                                                                                                                                                                                                                                                                                                          ヘルプのオプションをすべて表示する
  --help-gtk                                                                                                                                                                                                                                                                                                                                                                                                                                                          GTK+ のオプションを表示する

アプリケーションのオプション:
  -t, --new-tab                                                                                                                                                                                                                                                                                                                                                                                                                                                       新しいタブ
  -n, --new-window                                                                                                                                                                                                                                                                                                                                                                                                                                                    新しいウィンドウ
  -v, --version                                                                                                                                                                                                                                                                                                                                                                                                                                                       バージョン情報を表示して終了します
  -s, --set=Project-Id-Version: scratch
Report-Msgid-Bugs-To: 
PO-Revision-Date: 2019-01-28 11:10+0000
Last-Translator: Ryo Nakano <ryonakaknock3@gmail.com>
Language-Team: Japanese <https://weblate.elementary.io/projects/code/code/ja/>
Language: ja
MIME-Version: 1.0
Content-Type: text/plain; charset=UTF-8
Content-Transfer-Encoding: 8bit
Plural-Forms: nplurals=1; plural=0;
X-Generator: Weblate 3.0.1
X-Launchpad-Export-Date: 2017-05-03 06:02+0000
     プラグインのセット
  -c, --cwd=Project-Id-Version: scratch
Report-Msgid-Bugs-To: 
PO-Revision-Date: 2019-01-28 11:10+0000
Last-Translator: Ryo Nakano <ryonakaknock3@gmail.com>
Language-Team: Japanese <https://weblate.elementary.io/projects/code/code/ja/>
Language: ja
MIME-Version: 1.0
Content-Type: text/plain; charset=UTF-8
Content-Transfer-Encoding: 8bit
Plural-Forms: nplurals=1; plural=0;
X-Generator: Weblate 3.0.1
X-Launchpad-Export-Date: 2017-05-03 06:02+0000
     カレントディレクトリ
  --display=DISPLAY                                                                                                                                                                                                                                                                                                                                                                                                                                                   使用するXのディスプレイを指定する

```

## AFTER in ja_JP

![Screenshot from 2019-04-25 17-27-55](https://user-images.githubusercontent.com/26003928/56721305-916f2a80-677f-11e9-9123-940035fee6ed.png)

```bash
ryo@ryo-pc:~/Projects$ LANGUAGE=ja_JP io.elementary.code --help
用法:
  io.elementary.code [OPTION…] File

ヘルプのオプション:
  -h, --help               ヘルプのオプションを表示する
  --help-all               ヘルプのオプションをすべて表示する
  --help-gtk               GTK+ のオプションを表示する

アプリケーションのオプション:
  -t, --new-tab            新しいタブ
  -n, --new-window         新しいウィンドウ
  -v, --version            バージョン情報を表示して終了します
  -s, --set=plugin         プラグインのセット
  -c, --cwd=directory      カレントディレクトリ
  --display=DISPLAY        使用するXのディスプレイを指定する

```

## Changes Summary

* Add command line argument strings like "plugin" and "directory" to prevent help info is broken other than in en_US
