### PR TITLE
Added "Open In" menu to the top-level project folder

### DIFF
--- a/src/FolderManager/FolderItem.vala
+++ b/src/FolderManager/FolderItem.vala
@@ -99,7 +99,7 @@ namespace Scratch.FolderManager {
             delete_item.activate.connect (trash);
 
             var menu = new Gtk.Menu ();
-            menu.append (create_submenu_for_openin (info, file_type));
+            menu.append (create_submenu_for_open_in (info, file_type));
             menu.append (contractor_item);
             menu.append (new Gtk.SeparatorMenuItem ());
             menu.append (create_submenu_for_new ());
@@ -110,7 +110,7 @@ namespace Scratch.FolderManager {
             return menu;
         }
 
-        protected Gtk.MenuItem create_submenu_for_openin (GLib.FileInfo? info, string file_type) {
+        protected Gtk.MenuItem create_submenu_for_open_in (GLib.FileInfo? info, string file_type) {
             var other_menuitem = new Gtk.MenuItem.with_label (_("Other Application…"));
             other_menuitem.activate.connect (() => show_app_chooser (file));
 

--- a/src/FolderManager/FolderItem.vala
+++ b/src/FolderManager/FolderItem.vala
@@ -64,11 +64,11 @@ namespace Scratch.FolderManager {
             var contractor_menu = new Gtk.Menu ();
 
             GLib.FileInfo info = null;
-            string file_type = "";
+            unowned string? file_type = null;
 
             try {
-                info = file.file.query_info (GLib.FileAttribute.STANDARD_CONTENT_TYPE, 0);
-                file_type = info.get_attribute_string (GLib.FileAttribute.STANDARD_CONTENT_TYPE);
+                info = file.file.query_info (GLib.FileAttribute.STANDARD_CONTENT_TYPE, GLib.FileQueryInfoFlags.NONE);
+                file_type = info.get_content_type();
             } catch (Error e) {
                 warning (e.message);
             }
@@ -110,9 +110,11 @@ namespace Scratch.FolderManager {
             return menu;
         }
 
-        protected Gtk.MenuItem create_submenu_for_open_in (GLib.FileInfo? info, string file_type) {
+        protected Gtk.MenuItem create_submenu_for_open_in (GLib.FileInfo? info, string? file_type) {
             var other_menuitem = new Gtk.MenuItem.with_label (_("Other Application…"));
             other_menuitem.activate.connect (() => show_app_chooser (file));
+
+            file_type = file_type ?? "inode/directory";
 
             var open_in_menu = new Gtk.Menu ();
 

--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -84,8 +84,19 @@ namespace Scratch.FolderManager {
                 trash ();
             });
 
+            GLib.FileInfo info = null;
+            string file_type = "";
+
+            try {
+                info = file.file.query_info (GLib.FileAttribute.STANDARD_CONTENT_TYPE, 0);
+                file_type = info.get_attribute_string (GLib.FileAttribute.STANDARD_CONTENT_TYPE);
+            } catch (Error e) {
+                warning (e.message);
+            }
+
             var menu = new Gtk.Menu ();
             menu.append (close_item);
+            menu.append (create_submenu_for_openin (info, file_type));
             menu.append (create_submenu_for_new ());
             menu.append (delete_item);
 

--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -96,7 +96,7 @@ namespace Scratch.FolderManager {
 
             var menu = new Gtk.Menu ();
             menu.append (close_item);
-            menu.append (create_submenu_for_openin (info, file_type));
+            menu.append (create_submenu_for_open_in (info, file_type));
             menu.append (create_submenu_for_new ());
             menu.append (delete_item);
 

--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -85,11 +85,11 @@ namespace Scratch.FolderManager {
             });
 
             GLib.FileInfo info = null;
-            string file_type = "";
+            unowned string? file_type = null;
 
             try {
-                info = file.file.query_info (GLib.FileAttribute.STANDARD_CONTENT_TYPE, 0);
-                file_type = info.get_attribute_string (GLib.FileAttribute.STANDARD_CONTENT_TYPE);
+                info = file.file.query_info (GLib.FileAttribute.STANDARD_CONTENT_TYPE, GLib.FileQueryInfoFlags.NONE);
+                file_type = info.get_content_type();
             } catch (Error e) {
                 warning (e.message);
             }


### PR DESCRIPTION
Top level folders now have an "open in" menu to open the project directory in other applications.

Closes: #671  

![Screenshot](https://user-images.githubusercontent.com/18509589/58055925-59b09400-7b2d-11e9-98cc-f5e4b25cd502.png)

The existing "open in" menu code contained within the `FolderItem` component was refactored into a new function so that it can be accessed from the `ProjectFolderItem` since both "open in" menus are essentially the same.