### PR TITLE
Git branch submenu is only sensitive if there is more than 1 branch.

### DIFF
--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -246,13 +246,19 @@ namespace Scratch.FolderManager {
                     string? branch_name = null;
                     try {
                         branch_name = branch.get_name ();
-                        if (branch_name != null && branch_name != cur_branch.get_name ()) {
+                        if (branch_name != null) {
                             var ref_name = ref_branch.get_name ();
                             if (ref_name != null) {
-                                var branch_item = new Gtk.MenuItem.with_label (branch_name);
+                                var branch_item = new Gtk.CheckMenuItem.with_label (branch_name);
+                                branch_item.draw_as_radio = true;
+
+                                if (branch_name == cur_branch.get_name ()) {
+                                    branch_item.active = true;
+                                }
+
                                 change_branch_menu.add (branch_item);
 
-                                branch_item.activate.connect (() => {
+                                branch_item.toggled.connect (() => {
                                     try {
                                         git_repo.set_head (ref_name);
                                     } catch (GLib.Error e) {
@@ -266,11 +272,7 @@ namespace Scratch.FolderManager {
                     }
                 }
 
-                if (change_branch_menu.get_children ().length () == 0) {
-                  sensitive = false;
-                }
-
-                label = _("Change Branch");
+                label = _("Branch");
                 submenu = change_branch_menu;
             }
         }

--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -266,6 +266,10 @@ namespace Scratch.FolderManager {
                     }
                 }
 
+                if (change_branch_menu.get_children ().length () == 0) {
+                  sensitive = false;
+                }
+
                 label = _("Change Branch");
                 submenu = change_branch_menu;
             }


### PR DESCRIPTION
Fixes #660 
![image](https://user-images.githubusercontent.com/18509589/58127237-e8331d00-7be2-11e9-903c-65a3b0694413.png)

Git branch submenu is set insensitive if there is only a single branch instead of showing an empty menu.