### PR TITLE
SearchBar: Fix shift+enter

### DIFF
--- a/src/Widgets/SearchBar.vala
+++ b/src/Widgets/SearchBar.vala
@@ -394,7 +394,7 @@ namespace Scratch.Widgets {
             }
 
             string key = Gdk.keyval_name (event.keyval);
-            if ((event.state & Gdk.ModifierType.SHIFT_MASK) != 0) {
+            if (Gdk.ModifierType.SHIFT_MASK in event.state) {
                 key = "<Shift>" + key;
             }
 

--- a/src/Widgets/SearchBar.vala
+++ b/src/Widgets/SearchBar.vala
@@ -394,7 +394,7 @@ namespace Scratch.Widgets {
             }
 
             string key = Gdk.keyval_name (event.keyval);
-            if (event.state == Gdk.ModifierType.SHIFT_MASK) {
+            if ((event.state & Gdk.ModifierType.SHIFT_MASK) != 0) {
                 key = "<Shift>" + key;
             }
 


### PR DESCRIPTION
It looks like this fixes #708 

https://github.com/midori-browser/core/blob/34e938e2abf239df658bec91b6d8e708f5177f7a/core/urlbar.vala#L89