### PR TITLE
Change Primary Search Entry Icon on Failure

### DIFF
--- a/src/Widgets/SearchBar.vala
+++ b/src/Widgets/SearchBar.vala
@@ -163,9 +163,11 @@ namespace Scratch.Widgets {
                 tool_arrow_down.sensitive = true;
                 tool_arrow_up.sensitive = false;
                 search_entry.get_style_context ().remove_class (Gtk.STYLE_CLASS_ERROR);
+                search_entry.primary_icon_name = "edit-find-symbolic";
             } else {
                 if (search_entry.text != "") {
                     search_entry.get_style_context ().add_class (Gtk.STYLE_CLASS_ERROR);
+                    search_entry.primary_icon_name = "dialog-error";
                 }
 
                 tool_arrow_down.sensitive = false;
@@ -250,10 +252,12 @@ namespace Scratch.Widgets {
                                                     out start_iter, out end_iter, null);
             if (found) {
                 search_entry.get_style_context ().remove_class (Gtk.STYLE_CLASS_ERROR);
+                search_entry.primary_icon_name = "edit-find-symbolic";
                 return true;
             } else {
                 if (search_entry.text != "") {
                     search_entry.get_style_context ().add_class (Gtk.STYLE_CLASS_ERROR);
+                    search_entry.primary_icon_name = "dialog-error";
                 }
 
                 return false;
@@ -267,6 +271,7 @@ namespace Scratch.Widgets {
 
             if (text_buffer == null || text_buffer.text == "" || search_string == "") {
                 debug ("Can't search anything in an inexistant buffer and/or without anything to search.");
+                search_entry.primary_icon_name = "edit-find-symbolic";
                 return false;
             }
 
@@ -277,15 +282,18 @@ namespace Scratch.Widgets {
 
             if (search_for_iter (start_iter, out end_iter)) {
                 search_entry.get_style_context ().remove_class (Gtk.STYLE_CLASS_ERROR);
+                search_entry.primary_icon_name = "edit-find-symbolic";
             } else {
                 text_buffer.get_start_iter (out start_iter);
                 if (search_for_iter (start_iter, out end_iter)) {
                     search_entry.get_style_context ().remove_class (Gtk.STYLE_CLASS_ERROR);
+                    search_entry.primary_icon_name = "edit-find-symbolic";
                 } else {
                     debug ("Not found: \"%s\"", search_string);
                     start_iter.set_offset (-1);
                     text_buffer.select_range (start_iter, start_iter);
                     search_entry.get_style_context ().add_class (Gtk.STYLE_CLASS_ERROR);
+                    search_entry.primary_icon_name = "dialog-error";
                     return false;
                 }
             }

--- a/src/Widgets/SearchBar.vala
+++ b/src/Widgets/SearchBar.vala
@@ -167,7 +167,7 @@ namespace Scratch.Widgets {
             } else {
                 if (search_entry.text != "") {
                     search_entry.get_style_context ().add_class (Gtk.STYLE_CLASS_ERROR);
-                    search_entry.primary_icon_name = "dialog-error";
+                    search_entry.primary_icon_name = "dialog-error-symbolic";
                 }
 
                 tool_arrow_down.sensitive = false;
@@ -257,7 +257,7 @@ namespace Scratch.Widgets {
             } else {
                 if (search_entry.text != "") {
                     search_entry.get_style_context ().add_class (Gtk.STYLE_CLASS_ERROR);
-                    search_entry.primary_icon_name = "dialog-error";
+                    search_entry.primary_icon_name = "dialog-error-symbolic";
                 }
 
                 return false;
@@ -267,6 +267,7 @@ namespace Scratch.Widgets {
         public bool search () {
             /* So, first, let's check we can really search something. */
             string search_string = search_entry.text;
+            search_context.highlight = false;
             search_context.highlight = false;
 
             if (text_buffer == null || text_buffer.text == "" || search_string == "") {
@@ -293,7 +294,7 @@ namespace Scratch.Widgets {
                     start_iter.set_offset (-1);
                     text_buffer.select_range (start_iter, start_iter);
                     search_entry.get_style_context ().add_class (Gtk.STYLE_CLASS_ERROR);
-                    search_entry.primary_icon_name = "dialog-error";
+                    search_entry.primary_icon_name = "dialog-error-symbolic";
                     return false;
                 }
             }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/26660036/67638875-c2532800-f8a6-11e9-985d-8c9817d417fe.png)


Uses `dialog-error-symbolic` icon to indicate the search failed. I have also used vala-lint on the `SearchBar.vala` file I modified.

This is my second PR into an open source project, so feedback is greatly appreciated!

fixes #206 