### PR TITLE
FolderManager: Rename before create new file

### DIFF
--- a/src/FolderManager/File.vala
+++ b/src/FolderManager/File.vala
@@ -50,10 +50,11 @@ namespace Scratch.FolderManager {
                 }
 
                 if (info == null) {
-                    return "";
+                    _name = file.get_basename ();
+                } else {
+                    _name = info.get_display_name ();
                 }
 
-                _name = info.get_display_name ();
                 return _name;
             }
         }
@@ -183,7 +184,9 @@ namespace Scratch.FolderManager {
 
         public void rename (string name) {
             try {
-                file.set_display_name (name);
+                if (exists) {
+                    file.set_display_name (name);
+                }
             } catch (GLib.Error error) {
                 warning (error.message);
             }

--- a/src/FolderManager/FolderItem.vala
+++ b/src/FolderManager/FolderItem.vala
@@ -366,6 +366,12 @@ namespace Scratch.FolderManager {
 
         construct {
             edited.connect (rename);
+
+            if (is_folder) {
+                icon = GLib.ContentType.get_icon ("inode/directory");
+            } else {
+                icon = GLib.ContentType.get_icon ("text");
+            }
         }
 
         protected new void rename (string new_name) {

--- a/src/FolderManager/FolderItem.vala
+++ b/src/FolderManager/FolderItem.vala
@@ -327,7 +327,7 @@ namespace Scratch.FolderManager {
                 return;
             }
 
-            var name = is_folder ? _("untitled folder") : _("new file");
+            unowned string name = is_folder ? _("untitled folder") : _("new file");
             var new_file = file.file.get_child (name);
             var n = 1;
 
@@ -356,7 +356,7 @@ namespace Scratch.FolderManager {
                         var new_name = rename_item.name;
                         remove (rename_item);
                         var path = file.file.get_path () + "/" + new_name;
-                        GLib.File gfile = GLib.File.new_for_path (path);
+                        var gfile = GLib.File.new_for_path (path);
                         try {
                             if (is_folder) {
                                 gfile.make_directory ();
@@ -392,7 +392,7 @@ namespace Scratch.FolderManager {
 
         construct {
             editable = true;
-            edited.connect (rename);
+            edited.connect (on_edited);
 
             if (is_folder) {
                 icon = GLib.ContentType.get_icon ("inode/directory");
@@ -401,7 +401,7 @@ namespace Scratch.FolderManager {
             }
         }
 
-        protected new void rename (string new_name) {
+        private void on_edited (string new_name) {
             if (new_name != "") {
                 name = new_name;
             }

--- a/src/FolderManager/FolderItem.vala
+++ b/src/FolderManager/FolderItem.vala
@@ -355,8 +355,7 @@ namespace Scratch.FolderManager {
                     } else {
                         var new_name = rename_item.name;
                         remove (rename_item);
-                        var path = file.file.get_path () + "/" + new_name;
-                        var gfile = GLib.File.new_for_path (path);
+                        var gfile = file.file.get_child_for_display_name (new_name);
                         try {
                             if (is_folder) {
                                 gfile.make_directory ();

--- a/src/FolderManager/FolderItem.vala
+++ b/src/FolderManager/FolderItem.vala
@@ -375,7 +375,7 @@ namespace Scratch.FolderManager {
                     return Source.REMOVE;
                 });
 
-                return false;
+                return Source.REMOVE;
             });
         }
     }

--- a/src/FolderManager/Item.vala
+++ b/src/FolderManager/Item.vala
@@ -49,6 +49,12 @@ namespace Scratch.FolderManager {
         }
 
         public int compare (Granite.Widgets.SourceList.Item a, Granite.Widgets.SourceList.Item b) {
+            if (a is RenameItem) {
+                return -1;
+            } else if ( b is RenameItem) {
+                return 1;
+            }
+
             if (a is FolderItem && b is FileItem) {
                 return -1;
             } else if (a is FileItem && b is FolderItem) {

--- a/src/FolderManager/Item.vala
+++ b/src/FolderManager/Item.vala
@@ -51,7 +51,7 @@ namespace Scratch.FolderManager {
         public int compare (Granite.Widgets.SourceList.Item a, Granite.Widgets.SourceList.Item b) {
             if (a is RenameItem) {
                 return -1;
-            } else if ( b is RenameItem) {
+            } else if (b is RenameItem) {
                 return 1;
             }
 


### PR DESCRIPTION
Fixes #213 

An alternative to #650, which should be less prone to race conditions.  The filename to be created is entered *before* any file is created using a temporary renaming item.  To match Files behaviour, if <Esc> is pressed (or a blank name entered) then a file with the default name is created rather than cancelling the file creation.

It proved necessary to poll the SourceList to determine when editing finishes because cancelling the editing does not generate any signal and we need to remove the temporary item in either case.

If this were fixed in Granite then a simplification here would be possible.