### PR TITLE
Make sidebar folders non selectable

### DIFF
--- a/data/io.elementary.code.appdata.xml.in
+++ b/data/io.elementary.code.appdata.xml.in
@@ -55,6 +55,7 @@
         <p>Other updates:</p>
         <ul>
           <li>Add keyboard shortcuts to menu items</li>
+          <li>Make sidebar folder items not selectable</li>
           <li>Updated translations</li>
         </ul>
       </description>

--- a/src/FolderManager/FolderItem.vala
+++ b/src/FolderManager/FolderItem.vala
@@ -37,6 +37,8 @@ namespace Scratch.FolderManager {
         }
 
         construct {
+            selectable = false;
+
             dummy = new Granite.Widgets.SourceList.Item ("");
             add (dummy);
 


### PR DESCRIPTION
Fixes #408 

When clicking on a folder it now expands/collapses instead of being selected.  Note that this simple solution does not allow the folder to be selected with a modified click should that be desired.  If that is wanted then overriding the button press or release handler would be needed.