### PR TITLE
MainWindow: Center new windows

### DIFF
--- a/data/io.elementary.code.gschema.xml
+++ b/data/io.elementary.code.gschema.xml
@@ -28,12 +28,12 @@
       <description>The saved height of the window. Must be greater than 400, or it will not take effect.</description>
     </key>
     <key name="window-x" type="i">
-      <default>250</default>
+      <default>-1</default>
       <summary></summary>
       <description></description>
     </key>
     <key name="window-y" type="i">
-      <default>250</default>
+      <default>-1</default>
       <summary></summary>
       <description></description>
     </key>

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -208,7 +208,25 @@ namespace Scratch {
             set_size_request (450, 400);
             set_hide_titlebar_when_maximized (false);
 
-            restore_saved_state ();
+            default_width = Scratch.saved_state.window_width;
+            default_height = Scratch.saved_state.window_height;
+
+            var gtk_settings = Gtk.Settings.get_default ();
+            gtk_settings.gtk_application_prefer_dark_theme = Scratch.settings.prefer_dark_style;
+
+            switch (Scratch.saved_state.window_state) {
+                case ScratchWindowState.MAXIMIZED:
+                    maximize ();
+                    break;
+                case ScratchWindowState.FULLSCREEN:
+                    fullscreen ();
+                    break;
+                default:
+                    if (Scratch.saved_state.window_x != -1 && Scratch.saved_state.window_y != -1) {
+                        move (Scratch.saved_state.window_x, Scratch.saved_state.window_y);
+                    }
+                    break;
+            }
 
             clipboard = Gtk.Clipboard.get_for_display (get_display (), Gdk.SELECTION_CLIPBOARD);
 
@@ -600,27 +618,6 @@ namespace Scratch {
             }
 
             return true;
-        }
-
-        // Save windows size and state
-        private void restore_saved_state () {
-            default_width = Scratch.saved_state.window_width;
-            default_height = Scratch.saved_state.window_height;
-
-            var gtk_settings = Gtk.Settings.get_default ();
-            gtk_settings.gtk_application_prefer_dark_theme = Scratch.settings.prefer_dark_style;
-
-            switch (Scratch.saved_state.window_state) {
-                case ScratchWindowState.MAXIMIZED:
-                    maximize ();
-                    break;
-                case ScratchWindowState.FULLSCREEN:
-                    fullscreen ();
-                    break;
-                default:
-                    move (Scratch.saved_state.window_x, Scratch.saved_state.window_y);
-                    break;
-            }
         }
 
         // Save session informations different from window state


### PR DESCRIPTION
For some reason we had hardcoded new windows to spawn at some arbitrary coordinates. This makes it so new windows will spawn centered (as dictated by gala)