### PR TITLE
Scratch to Code in debian/control

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -36,21 +36,21 @@ Depends: exuberant-ctags,
          ${misc:Depends},
          ${shlibs:Depends}
 Description: text editor that works for you
- Scratch is the text editor that works for you. It auto-saves your files,
+ Code is the text editor that works for you. It auto-saves your files,
  meaning they're always up-to-date. Plus it remembers your tabs so you never
  lose your spot, even in between sessions.
  .
- Make it yours. Scratch is written from the ground up to be extensible. Keep
- things super lightweight and simple, or install extensions to turn Scratch
+ Make it yours. Code is written from the ground up to be extensible. Keep
+ things super lightweight and simple, or install extensions to turn Code
  into a full-blown IDE; it's your choice. And with a handful of useful
  preferences, you can tweak the behavior and interface to your liking.
  .
- It's elementary. Scratch is made to be the perfect text editor for elementary,
+ It's elementary. Code is made to be the perfect text editor for elementary,
  meaning it closely follows the high standards of design, speed, and
  consistency. It's sexy, but not distracting.
  .
  Works with your language. Whether you're crafting code in Vala, scripting with
- PHP, or marking things up in HTML, Scratch has you covered. Experience full
+ PHP, or marking things up in HTML, code has you covered. Experience full
  syntax highlighting with nearly all programming, scripting, and markup
  languages.
 
@@ -60,25 +60,25 @@ Priority: optional
 Section: libs
 Depends: ${gir:Depends}, ${misc:Depends}, ${shlibs:Depends}
 Description: text editor that works for you (shared library)
- Scratch is the text editor that works for you. It auto-saves your files,
+ Code is the text editor that works for you. It auto-saves your files,
  meaning they're always up-to-date. Plus it remembers your tabs so you never
  lose your spot, even in between sessions.
  .
- Make it yours. Scratch is written from the ground up to be extensible. Keep
- things super lightweight and simple, or install extensions to turn Scratch
+ Make it yours. Code is written from the ground up to be extensible. Keep
+ things super lightweight and simple, or install extensions to turn Code
  into a full-blown IDE; it's your choice. And with a handful of useful
  preferences, you can tweak the behavior and interface to your liking.
  .
- It's elementary. Scratch is made to be the perfect text editor for elementary,
+ It's elementary. Code is made to be the perfect text editor for elementary,
  meaning it closely follows the high standards of design, speed, and
  consistency. It's sexy, but not distracting.
  .
  Works with your language. Whether you're crafting code in Vala, scripting with
- PHP, or marking things up in HTML, Scratch has you covered. Experience full
+ PHP, or marking things up in HTML, Code has you covered. Experience full
  syntax highlighting with nearly all programming, scripting, and markup
  languages.
  .
- This package contains the shared library used by Scratch plugins.
+ This package contains the shared library used by Code plugins.
 
 Package: libcodecore-dev
 Architecture: any
@@ -89,25 +89,25 @@ Depends: libcodecore0 (= ${binary:Version}),
          ${misc:Depends},
          ${shlibs:Depends}
 Description: text editor that works for you (plugin development files)
- Scratch is the text editor that works for you. It auto-saves your files,
+ Code is the text editor that works for you. It auto-saves your files,
  meaning they're always up-to-date. Plus it remembers your tabs so you never
  lose your spot, even in between sessions.
  .
- Make it yours. Scratch is written from the ground up to be extensible. Keep
- things super lightweight and simple, or install extensions to turn Scratch
+ Make it yours. Code is written from the ground up to be extensible. Keep
+ things super lightweight and simple, or install extensions to turn Code
  into a full-blown IDE; it's your choice. And with a handful of useful
  preferences, you can tweak the behavior and interface to your liking.
  .
- It's elementary. Scratch is made to be the perfect text editor for elementary,
+ It's elementary. Code is made to be the perfect text editor for elementary,
  meaning it closely follows the high standards of design, speed, and
  consistency. It's sexy, but not distracting.
  .
  Works with your language. Whether you're crafting code in Vala, scripting with
- PHP, or marking things up in HTML, Scratch has you covered. Experience full
+ PHP, or marking things up in HTML, Code has you covered. Experience full
  syntax highlighting with nearly all programming, scripting, and markup
  languages.
  .
- This package contains the development headers for writing Scratch plugins.
+ This package contains the development headers for writing Code plugins.
 
 Package: io.elementary.code-dbg
 Architecture: any
@@ -115,21 +115,21 @@ Section: debug
 Priority: extra
 Depends: io.elementary.code (= ${binary:Version}), ${misc:Depends}
 Description: text editor that works for you (debugging symbols)
- Scratch is the text editor that works for you. It auto-saves your files,
+ Code is the text editor that works for you. It auto-saves your files,
  meaning they're always up-to-date. Plus it remembers your tabs so you never
  lose your spot, even in between sessions.
  .
- Make it yours. Scratch is written from the ground up to be extensible. Keep
- things super lightweight and simple, or install extensions to turn Scratch
+ Make it yours. Code is written from the ground up to be extensible. Keep
+ things super lightweight and simple, or install extensions to turn Code
  into a full-blown IDE; it's your choice. And with a handful of useful
  preferences, you can tweak the behavior and interface to your liking.
  .
- It's elementary. Scratch is made to be the perfect text editor for elementary,
+ It's elementary. Code is made to be the perfect text editor for elementary,
  meaning it closely follows the high standards of design, speed, and
  consistency. It's sexy, but not distracting.
  .
  Works with your language. Whether you're crafting code in Vala, scripting with
- PHP, or marking things up in HTML, Scratch has you covered. Experience full
+ PHP, or marking things up in HTML, Code has you covered. Experience full
  syntax highlighting with nearly all programming, scripting, and markup
  languages.
  .

--- a/debian/control
+++ b/debian/control
@@ -50,7 +50,7 @@ Description: text editor that works for you
  consistency. It's sexy, but not distracting.
  .
  Works with your language. Whether you're crafting code in Vala, scripting with
- PHP, or marking things up in HTML, code has you covered. Experience full
+ PHP, or marking things up in HTML, Code has you covered. Experience full
  syntax highlighting with nearly all programming, scripting, and markup
  languages.
 


### PR DESCRIPTION
Kind of a random thing, but I was playing around with `apt show` and ended up doing `apt show io.elementary.code` and saw that the description still reads "Scratch."
Since elementary Scratch has been renamed to elementary Code, I believe it would be a good idea to reflect this in the debian packaging description. Let me know if I am wrong about this or need to change anything!