### PR TITLE
Closes files opened from the side bar when their corresponding project is closed

### DIFF
--- a/src/FolderManager/FileItem.vala
+++ b/src/FolderManager/FileItem.vala
@@ -22,9 +22,19 @@ namespace Scratch.FolderManager {
     /**
      * Normal item in the source list, represents a textfile.
      */
+
+
     internal class FileItem : Item {
-        public FileItem (File file, FileView view) {
+        private ProjectFolderItem _root;
+        public ProjectFolderItem project_root {
+            get {
+                return _root;
+            }
+        }
+
+        public FileItem (File file, FileView view, ProjectFolderItem root) {
             Object (file: file, view: view);
+            this._root = root;
         }
 
         public override Gtk.Menu? get_context_menu () {

--- a/src/FolderManager/FileItem.vala
+++ b/src/FolderManager/FileItem.vala
@@ -26,7 +26,7 @@ namespace Scratch.FolderManager {
 
     internal class FileItem : Item {
         private ProjectFolderItem _root;
-        public ProjectFolderItem project_root {
+        public ProjectFolderItem project_root { get; construct; }
             get {
                 return _root;
             }

--- a/src/FolderManager/FileItem.vala
+++ b/src/FolderManager/FileItem.vala
@@ -33,7 +33,7 @@ namespace Scratch.FolderManager {
         }
 
         public FileItem (File file, FileView view, ProjectFolderItem root) {
-            Object (file: file, view: view);
+            Object (file: file, view: view, project_root: root);
             this._root = root;
         }
 

--- a/src/FolderManager/FileView.vala
+++ b/src/FolderManager/FileView.vala
@@ -25,7 +25,8 @@ namespace Scratch.FolderManager {
     internal class FileView : Granite.Widgets.SourceList, Code.PaneSwitcher {
         private FolderManagerSettings settings;
 
-        public signal void select (string file);
+        public signal void select (string file, string project_root);
+        public signal void project_closed (string project_root);
 
         // This is a workaround for SourceList silliness: you cannot remove an item
         // without it automatically selecting another one.
@@ -52,7 +53,8 @@ namespace Scratch.FolderManager {
             }
 
             if (item is FileItem) {
-                select ((item as FileItem).file.path);
+                var it = item as FileItem;
+                select (it.file.path, it.project_root.file.path );
             }
         }
 
@@ -142,6 +144,7 @@ namespace Scratch.FolderManager {
             folder_root.closed.connect (() => {
                 root.remove (folder_root);
                 write_settings ();
+                project_closed (folder_root.file.path);
             });
 
             folder_root.close_all_except.connect (() => {

--- a/src/FolderManager/FileView.vala
+++ b/src/FolderManager/FileView.vala
@@ -53,7 +53,7 @@ namespace Scratch.FolderManager {
             }
 
             if (item is FileItem) {
-                var it = item as FileItem;
+                unowned FileItem it = (FileItem) item;
                 select (it.file.path, it.project_root.file.path );
             }
         }

--- a/src/FolderManager/FolderItem.vala
+++ b/src/FolderManager/FolderItem.vala
@@ -183,7 +183,7 @@ namespace Scratch.FolderManager {
                 if (child.is_valid_directory) {
                     item = new FolderItem (child, view);
                 } else if (child.is_valid_textfile) {
-                    item = new FileItem (child, view);
+                    item = new FileItem (child, view, get_root_folder());
                 }
 
                 if (item != null) {
@@ -288,7 +288,7 @@ namespace Scratch.FolderManager {
                             if (file.is_valid_directory) {
                                 item = new FolderItem (file, view);
                             } else if (!file.is_temporary) {
-                                item = new FileItem (file, view);
+                                item = new FileItem (file, view, get_root_folder());
                             }
                         }
 

--- a/src/FolderManager/FolderItem.vala
+++ b/src/FolderManager/FolderItem.vala
@@ -183,7 +183,7 @@ namespace Scratch.FolderManager {
                 if (child.is_valid_directory) {
                     item = new FolderItem (child, view);
                 } else if (child.is_valid_textfile) {
-                    item = new FileItem (child, view, get_root_folder());
+                    item = new FileItem (child, view, get_root_folder ());
                 }
 
                 if (item != null) {

--- a/src/FolderManager/FolderItem.vala
+++ b/src/FolderManager/FolderItem.vala
@@ -288,7 +288,7 @@ namespace Scratch.FolderManager {
                             if (file.is_valid_directory) {
                                 item = new FolderItem (file, view);
                             } else if (!file.is_temporary) {
-                                item = new FileItem (file, view, get_root_folder());
+                                item = new FileItem (file, view, get_root_folder ());
                             }
                         }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -331,15 +331,34 @@ namespace Scratch {
 
             folder_manager_view = new FolderManager.FileView ();
 
-            folder_manager_view.select.connect ((a) => {
+            folder_manager_view.select.connect ((a, b) => {
                 var file = new Scratch.FolderManager.File (a);
-                var doc = new Scratch.Services.Document (actions, file.file);
+                var doc = new Scratch.Services.Document (actions, file.file, b);
 
                 if (file.is_valid_textfile) {
                     open_document (doc);
                 } else {
                     open_binary (file.file);
                 }
+            });
+
+
+            folder_manager_view.project_closed.connect((a) => {
+                foreach (Scratch.Widgets.DocumentView? v in split_view.views) {
+                    GLib.List<Services.Document> to_close = new GLib.List<Services.Document>();
+                    foreach (Services.Document doc in v.docs) {
+                        if (doc.project_folder == a) {
+                            to_close.append (doc);
+                        }
+                        stdout.printf("%s (pasta): %s %s\n", doc.file.get_basename(), doc.project_folder, doc.project_folder == a?"fecha":"não");
+                    }
+
+                    foreach (Services.Document doc in to_close) {
+                        v.close_document (doc);
+                    }
+
+                }
+                stdout.printf("%s fechou\n", a);
             });
 
             folder_manager_view.root.child_added.connect (() => {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -350,7 +350,6 @@ namespace Scratch {
                         if (doc.project_folder == a) {
                             to_close.append (doc);
                         }
-                        stdout.printf("%s (pasta): %s %s\n", doc.file.get_basename(), doc.project_folder, doc.project_folder == a?"fecha":"não");
                     }
 
                     foreach (Services.Document doc in to_close) {
@@ -358,7 +357,6 @@ namespace Scratch {
                     }
 
                 }
-                stdout.printf("%s fechou\n", a);
             });
 
             folder_manager_view.root.child_added.connect (() => {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -352,7 +352,7 @@ namespace Scratch {
                         }
                     }
 
-                    foreach (Services.Document doc in to_close) {
+                    foreach (unowned Services.Document doc in to_close) {
                         v.close_document (doc);
                     }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -345,7 +345,7 @@ namespace Scratch {
 
             folder_manager_view.project_closed.connect((a) => {
                 foreach (Scratch.Widgets.DocumentView? v in split_view.views) {
-                    GLib.List<Services.Document> to_close = new GLib.List<Services.Document>();
+                    var to_close = new GLib.List<Services.Document>();
                     foreach (Services.Document doc in v.docs) {
                         if (doc.project_folder == a) {
                             to_close.append (doc);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -331,7 +331,7 @@ namespace Scratch {
 
             folder_manager_view = new FolderManager.FileView ();
 
-            folder_manager_view.select.connect ((a, b) => {
+            folder_manager_view.select.connect ((a, project_root) => {
                 var file = new Scratch.FolderManager.File (a);
                 var doc = new Scratch.Services.Document (actions, file.file, b);
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -343,9 +343,9 @@ namespace Scratch {
             });
 
 
-            folder_manager_view.project_closed.connect((a) => {
+            folder_manager_view.project_closed.connect ((a) => {
                 foreach (Scratch.Widgets.DocumentView? v in split_view.views) {
-                    var to_close = new GLib.List<Services.Document>();
+                    var to_close = new GLib.List<Services.Document> ();
                     foreach (Services.Document doc in v.docs) {
                         if (doc.project_folder == a) {
                             to_close.append (doc);

--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -90,7 +90,7 @@ namespace Scratch.Services {
         public string original_content;
         private string last_save_content;
         public bool saved = true;
-        public string project_folder;
+        public string? project_folder;
 
         private Gtk.ScrolledWindow scroll;
         private Gtk.InfoBar info_bar;

--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -90,6 +90,7 @@ namespace Scratch.Services {
         public string original_content;
         private string last_save_content;
         public bool saved = true;
+        public string project_folder;
 
         private Gtk.ScrolledWindow scroll;
         private Gtk.InfoBar info_bar;
@@ -109,9 +110,10 @@ namespace Scratch.Services {
         // Zeitgeist integration
         private ZeitgeistLogger zg_log = new ZeitgeistLogger ();
 #endif
-        public Document (SimpleActionGroup actions, File? file = null) {
+        public Document (SimpleActionGroup actions, File? file = null, string? project_folder = null) {
             this.actions = actions;
             this.file = file;
+            this.project_folder = project_folder;
             page = main_stack;
         }
 


### PR DESCRIPTION
Closes #774 : when a project folder is closed all files opened by clicking in the sidebar are closed too. Files opened by using the "open" button in the toolbar (or Ctrl+O) remain even if they belong to a project folder that was closed. 

Keep in mind that this is my first experience with Vala. I am aware that my solution is probably not the best, but I am willing to make it so. 

Thank you for your contributions on this and hope to hear from you soon. 