### PR TITLE
Use a single gsetting key for window coords/size (#768)

### DIFF
--- a/data/io.elementary.code.appdata.xml.in
+++ b/data/io.elementary.code.appdata.xml.in
@@ -46,6 +46,15 @@
     </ul>
   </description>
   <releases>
+    <release version="3.4.1" date="2020-04-23">
+      <description>
+        <p>Minor updates:</p>
+        <ul>
+          <li>More efficiently save and restore window position</li>
+          <li>Updated translations</li>
+        </ul>
+      </description>
+    </release>
     <release version="3.4.0" date="2020-04-01">
       <description>
         <p>New features:</p>

--- a/data/io.elementary.code.gschema.xml
+++ b/data/io.elementary.code.gschema.xml
@@ -17,25 +17,15 @@
       <summary>The saved state of the window.</summary>
       <description>The saved state of the window.</description>
     </key>
-    <key name="window-width" type="i">
-      <default>850</default>
-      <summary>The saved width of the window.</summary>
-      <description>The saved width of the window. Must be greater than 700, or it will not take effect.</description>
+    <key name="window-position" type="(ii)">
+      <default>(-1, -1)</default>
+      <summary>Window position</summary>
+      <description>Most recent window position (x, y)</description>
     </key>
-    <key name="window-height" type="i">
-      <default>550</default>
-      <summary>The saved height of the window.</summary>
-      <description>The saved height of the window. Must be greater than 400, or it will not take effect.</description>
-    </key>
-    <key name="window-x" type="i">
-      <default>-1</default>
-      <summary></summary>
-      <description></description>
-    </key>
-    <key name="window-y" type="i">
-      <default>-1</default>
-      <summary></summary>
-      <description></description>
+    <key name="window-size" type="(ii)">
+      <default>(850, 550)</default>
+      <summary>Most recent window size</summary>
+      <description>Most recent window size (width, height)</description>
     </key>
     <key name="hp1-size" type="i">
       <default>125</default>

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -21,7 +21,7 @@
 */
 
 namespace Scratch {
-    public SavedState saved_state;
+    public GLib.Settings saved_state;
     public Settings settings;
     public ServicesSettings services;
     public GLib.Settings privacy_settings;
@@ -55,7 +55,7 @@ namespace Scratch {
 
             // Init settings
             default_font = new GLib.Settings ("org.gnome.desktop.interface").get_string ("monospace-font-name");
-            saved_state = new SavedState ();
+            saved_state = new GLib.Settings (Constants.PROJECT_NAME + ".saved-state");
             settings = new Settings ();
             services = new ServicesSettings ();
             privacy_settings = new GLib.Settings ("org.gnome.desktop.privacy");

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -55,7 +55,7 @@ namespace Scratch {
 
             // Init settings
             default_font = new GLib.Settings ("org.gnome.desktop.interface").get_string ("monospace-font-name");
-            saved_state = new GLib.Settings (Constants.PROJECT_NAME + ".saved-state");
+            saved_state = new GLib.Settings ("io.elementary.code.saved-state");
             settings = new Settings ();
             services = new ServicesSettings ();
             privacy_settings = new GLib.Settings ("org.gnome.desktop.privacy");

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -208,13 +208,17 @@ namespace Scratch {
             set_size_request (450, 400);
             set_hide_titlebar_when_maximized (false);
 
-            default_width = Scratch.saved_state.window_width;
-            default_height = Scratch.saved_state.window_height;
+            var rect = Gdk.Rectangle ();
+            Scratch.saved_state.get ("window-size", "(ii)", out rect.width, out rect.height);
+
+            default_width = rect.width;
+            default_height = rect.height;
 
             var gtk_settings = Gtk.Settings.get_default ();
             gtk_settings.gtk_application_prefer_dark_theme = Scratch.settings.prefer_dark_style;
 
-            switch (Scratch.saved_state.window_state) {
+            var window_state = Scratch.saved_state.get_enum ("window-state");
+            switch (window_state) {
                 case ScratchWindowState.MAXIMIZED:
                     maximize ();
                     break;
@@ -222,8 +226,9 @@ namespace Scratch {
                     fullscreen ();
                     break;
                 default:
-                    if (Scratch.saved_state.window_x != -1 && Scratch.saved_state.window_y != -1) {
-                        move (Scratch.saved_state.window_x, Scratch.saved_state.window_y);
+                    Scratch.saved_state.get ("window-position", "(ii)", out rect.x, out rect.y);
+                    if (rect.x != -1 && rect.y != -1) {
+                        move (rect.x, rect.y);
                     }
                     break;
             }
@@ -623,8 +628,8 @@ namespace Scratch {
         // Save session informations different from window state
         private void restore_saved_state_extra () {
             // Plugin panes size
-            hp1.set_position (Scratch.saved_state.hp1_size);
-            vp.set_position (Scratch.saved_state.vp_size);
+            hp1.set_position (Scratch.saved_state.get_int ("hp1-size"));
+            vp.set_position (Scratch.saved_state.get_int ("vp-size"));
         }
 
         private void create_unsaved_documents_directory () {
@@ -643,27 +648,25 @@ namespace Scratch {
             // Save window state
             var state = get_window ().get_state ();
             if (Gdk.WindowState.MAXIMIZED in state) {
-                Scratch.saved_state.window_state = ScratchWindowState.MAXIMIZED;
+                Scratch.saved_state.set_enum ("window-state", ScratchWindowState.MAXIMIZED);
             } else if (Gdk.WindowState.FULLSCREEN in state) {
-                Scratch.saved_state.window_state = ScratchWindowState.FULLSCREEN;
+                Scratch.saved_state.set_enum ("window-state", ScratchWindowState.FULLSCREEN);
             } else {
-                Scratch.saved_state.window_state = ScratchWindowState.NORMAL;
+                Scratch.saved_state.set_enum ("window-state", ScratchWindowState.NORMAL);
                 // Save window size
                 int width, height;
                 get_size (out width, out height);
-                Scratch.saved_state.window_width = width;
-                Scratch.saved_state.window_height = height;
+                Scratch.saved_state.set ("window-size", "(ii)", width, height);
             }
 
             // Save window position
             int x, y;
             get_position (out x, out y);
-            Scratch.saved_state.window_x = x;
-            Scratch.saved_state.window_y = y;
+            Scratch.saved_state.set ("window-position", "(ii)", x, y);
 
             // Plugin panes size
-            Scratch.saved_state.hp1_size = hp1.get_position ();
-            Scratch.saved_state.vp_size = vp.get_position ();
+            Scratch.saved_state.set_int ("hp1-size", hp1.get_position ());
+            Scratch.saved_state.set_int ("vp-size", vp.get_position ());
         }
 
         // SIGTERM/SIGINT Handling

--- a/src/Services/Settings.vala
+++ b/src/Services/Settings.vala
@@ -33,23 +33,6 @@ namespace Scratch {
         ALWAYS = 2
     }
 
-    public class SavedState : Granite.Services.Settings {
-
-        public int window_width { get; set; }
-        public int window_height { get; set; }
-        public ScratchWindowState window_state { get; set; }
-        public int window_x { get; set; }
-        public int window_y { get; set; }
-
-        public int hp1_size { get; set; }
-        public int vp_size { get; set; }
-
-        public SavedState () {
-            base (Constants.PROJECT_NAME + ".saved-state");
-        }
-
-    }
-
     public class Settings : Granite.Services.Settings {
 
         public bool highlight_matching_brackets { get; set; }


### PR DESCRIPTION
Lockdown has led me to play with elementary and vala and a stab at one of the Bitesize issues

This may be utter nonsense but it seems to work for me so far, I'm not sure what to do about migrating an existing schema though?

Any feedback appreciated