### PR TITLE
SourceView: Scroll past end

### DIFF
--- a/data/io.elementary.code.appdata.xml.in
+++ b/data/io.elementary.code.appdata.xml.in
@@ -54,6 +54,7 @@
         </ul>
         <p>Minor updates:</p>
         <ul>
+          <li>Scroll past the end of a file</li>
           <li>More efficiently save and restore window position</li>
           <li>Updated translations</li>
         </ul>

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -147,6 +147,11 @@ namespace Scratch.Widgets {
             });
 
             populate_popup.connect_after (on_context_menu);
+
+            size_allocate.connect ((allocation) => {
+                // TODO: Throttle this for performance
+                bottom_margin = calculate_bottom_margin (allocation.height);
+            });
         }
 
         private bool get_current_line (out Gtk.TextIter start, out Gtk.TextIter end) {
@@ -414,6 +419,15 @@ namespace Scratch.Widgets {
             }
 
             menu.show_all ();
+        }
+
+        private int calculate_bottom_margin (int height_in_px) {
+            const int LINES_TO_KEEP = 3;
+            const double PT_TO_PX = 1.6666; // Normally 1.3̅, but this accounts for line-height
+
+            double px_per_line = Application.instance.get_last_window ().get_current_font_size () * PT_TO_PX;
+
+            return (int) (height_in_px - (LINES_TO_KEEP * px_per_line));
         }
 
         void on_mark_set (Gtk.TextIter loc, Gtk.TextMark mar) {

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -29,11 +29,11 @@ namespace Scratch.Widgets {
 
         private string font;
         private uint selection_changed_timer = 0;
+        private uint size_allocate_timer = 0;
         private Gtk.TextIter last_select_start_iter;
         private Gtk.TextIter last_select_end_iter;
 
-        // Pause after end user highlighting to confirm select,in ms
-        private const uint SELECTION_CHANGED_PAUSE = 400;
+        private const uint THROTTLE_MS = 400;
 
         public signal void style_changed (Gtk.SourceStyleScheme style);
         public signal void selection_changed (Gtk.TextIter start_iter, Gtk.TextIter end_iter);
@@ -149,8 +149,14 @@ namespace Scratch.Widgets {
             populate_popup.connect_after (on_context_menu);
 
             size_allocate.connect ((allocation) => {
-                // TODO: Throttle this for performance
-                bottom_margin = calculate_bottom_margin (allocation.height);
+                // Throttle for performance
+                if (size_allocate_timer == 0) {
+                    size_allocate_timer = Timeout.add (THROTTLE_MS, () => {
+                        size_allocate_timer = 0;
+                        bottom_margin = calculate_bottom_margin (allocation.height);
+                        return GLib.Source.REMOVE;
+                    });
+                }
             });
         }
 
@@ -423,7 +429,7 @@ namespace Scratch.Widgets {
 
         private int calculate_bottom_margin (int height_in_px) {
             const int LINES_TO_KEEP = 3;
-            const double PT_TO_PX = 1.6666; // Normally 1.3̅, but this accounts for line-height
+            const double PT_TO_PX = 1.6666; // Normally 1.3333, but this accounts for line-height
 
             double px_per_line = Application.instance.get_last_window ().get_current_font_size () * PT_TO_PX;
 
@@ -454,7 +460,7 @@ namespace Scratch.Widgets {
                 deselected ();
             // Don't fire signal till we think select movement is done
             } else {
-                selection_changed_timer = Timeout.add (SELECTION_CHANGED_PAUSE, selection_changed_event);
+                selection_changed_timer = Timeout.add (THROTTLE_MS, selection_changed_event);
             }
 
         }

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -429,7 +429,7 @@ namespace Scratch.Widgets {
 
         private int calculate_bottom_margin (int height_in_px) {
             const int LINES_TO_KEEP = 3;
-            const double PT_TO_PX = 1.6666; // Normally 1.3333, but this accounts for line-height
+            const double PT_TO_PX = 1.6667; // Normally 1.3333, but this accounts for line-height
 
             double px_per_line = Application.instance.get_last_window ().get_current_font_size () * PT_TO_PX;
 

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -1,7 +1,7 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /*
 * Copyright (c) 2013 Mario Guerriero <mefrio.g@gmail.com>
-*               2017-2018 elementary LLC. <https://elementary.io>
+*               2017–2020 elementary, Inc. <https://elementary.io>
 *
 * This program is free software; you can redistribute it and/or
 * modify it under the terms of the GNU General Public
@@ -427,7 +427,7 @@ namespace Scratch.Widgets {
             menu.show_all ();
         }
 
-        private int calculate_bottom_margin (int height_in_px) {
+        private static int calculate_bottom_margin (int height_in_px) {
             const int LINES_TO_KEEP = 3;
             const double PT_TO_PX = 1.6667; // Normally 1.3333, but this accounts for line-height
 


### PR DESCRIPTION
Fixes #799.

- Assumes we want at least three lines visible at all times (not configurable)
- Always on (not configurable)
- Throttled for performance (noticeably lags on resize without a timeout)