### PR TITLE
Spell: Enable plugin for md files

### DIFF
--- a/data/io.elementary.code.appdata.xml.in
+++ b/data/io.elementary.code.appdata.xml.in
@@ -46,6 +46,14 @@
     </ul>
   </description>
   <releases>
+    <release version="3.4.2" date="2020-06-09">
+      <description>
+        <p>Minor updates:</p>
+        <ul>
+          <li>Allow Spell Checker extension in Markdown files</li>
+        </ul>
+      </description>
+    </release>
     <release version="3.4.1" date="2020-06-09">
       <description>
         <p>Fixes:</p>

--- a/plugins/spell/spell.vala
+++ b/plugins/spell/spell.vala
@@ -100,8 +100,9 @@ public class Scratch.Plugins.Spell: Peas.ExtensionBase, Peas.Activatable {
                 // Deactivate Spell checker when we are editing a code file
                 var source_buffer = (Gtk.SourceBuffer) d.source_view.buffer;
                 var lang = source_buffer.language;
-                if (lang != null)
+                if (lang != null && lang.id != "markdown") {
                     spell.detach ();
+                }
 
                 // Detect language changed event
                 view.notify["language"].connect (() => language_changed_spell (view));


### PR DESCRIPTION
Fixes #234. If we want to add more languages here, this might not be the best approach. But it seemed the least invasive.