### PR TITLE
Application: Remove unnecessary Intl

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -44,13 +44,6 @@ namespace Scratch {
         }
 
         public Application () {
-            // Init internationalization support
-            Intl.setlocale (LocaleCategory.ALL, "");
-            string langpack_dir = Path.build_filename (Constants.INSTALL_PREFIX, "share", "locale");
-            Intl.bindtextdomain (Constants.GETTEXT_PACKAGE, langpack_dir);
-            Intl.bind_textdomain_codeset (Constants.GETTEXT_PACKAGE, "UTF-8");
-            Intl.textdomain (Constants.GETTEXT_PACKAGE);
-
             Granite.Services.Logger.initialize ("Code");
 
             // Init settings


### PR DESCRIPTION
We shouldn't need to do this since we're a Gtk.Application