### PR TITLE
Disconnect selected signals on tab change

### DIFF
--- a/src/FolderManager/FileView.vala
+++ b/src/FolderManager/FileView.vala
@@ -99,7 +99,9 @@ namespace Scratch.FolderManager {
         }
 
         public void select_path (string path) {
+            item_selected.disconnect (on_item_selected);
             selected = find_path (root, path);
+            item_selected.connect (on_item_selected);
         }
 
         private Granite.Widgets.SourceList.Item? find_path (Granite.Widgets.SourceList.ExpandableItem list, string path) {


### PR DESCRIPTION
I was seeing some issues where changing tab would sometimes work for a second and then switch back to the original tab.  Let's disconnect the `item_selected` signals in the Folder Manager when we're manually changing the selection so we don't get into some weird loop.