### PR TITLE
Remove Granite.Services.Logger

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -44,8 +44,6 @@ namespace Scratch {
         }
 
         public Application () {
-            Granite.Services.Logger.initialize ("Code");
-
             // Init settings
             default_font = new GLib.Settings ("org.gnome.desktop.interface").get_string ("monospace-font-name");
             saved_state = new GLib.Settings (Constants.PROJECT_NAME + ".saved-state");


### PR DESCRIPTION
Having this here prevents `G_MESSAGES_DEBUG=all` from working, which is how we do things these days.