### PR TITLE
Null checks for get_last_window

### DIFF
--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -197,7 +197,11 @@ namespace Scratch.Widgets {
             share_menu.insert.connect (on_share_menu_changed);
             share_menu.remove.connect (on_share_menu_changed);
 
-            settings.changed.connect ((key) => {
+            Scratch.settings.changed.connect ((key) => {
+                if (key != "autosave" && key != "font") {
+                    return;
+                }
+
                 save_button.visible = !Scratch.settings.get_boolean ("autosave");
                 var last_window = app_instance.get_last_window ();
                 if (last_window != null) {

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -197,10 +197,12 @@ namespace Scratch.Widgets {
             share_menu.insert.connect (on_share_menu_changed);
             share_menu.remove.connect (on_share_menu_changed);
 
-            settings.changed.connect (() => {
+            settings.changed.connect ((key) => {
                 save_button.visible = !Scratch.settings.get_boolean ("autosave");
                 var last_window = app_instance.get_last_window ();
-                zoom_default_button.label = "%.0f%%".printf (last_window.get_current_font_size () * 10);
+                if (last_window != null) {
+                    zoom_default_button.label = "%.0f%%".printf (last_window.get_current_font_size () * 10);
+                }
             });
 
             var gtk_settings = Gtk.Settings.get_default ();

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -435,7 +435,12 @@ namespace Scratch.Widgets {
             const int LINES_TO_KEEP = 3;
             const double PT_TO_PX = 1.6667; // Normally 1.3333, but this accounts for line-height
 
-            double px_per_line = ((Scratch.Application) GLib.Application.get_default ()).get_last_window ().get_current_font_size () * PT_TO_PX;
+            double px_per_line = 10 * PT_TO_PX;
+
+            var last_window = ((Scratch.Application) GLib.Application.get_default ()).get_last_window ();
+            if (last_window != null) {
+                px_per_line = last_window.get_current_font_size () * PT_TO_PX;
+            }
 
             return (int) (height_in_px - (LINES_TO_KEEP * px_per_line));
         }

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -435,10 +435,12 @@ namespace Scratch.Widgets {
             const int LINES_TO_KEEP = 3;
             const double PT_TO_PX = 1.6667; // Normally 1.3333, but this accounts for line-height
 
+            // Use a default size of 10pt
             double px_per_line = 10 * PT_TO_PX;
 
             var last_window = ((Scratch.Application) GLib.Application.get_default ()).get_last_window ();
             if (last_window != null) {
+                // Get the actual font size
                 px_per_line = last_window.get_current_font_size () * PT_TO_PX;
             }
 


### PR DESCRIPTION
`get_last_window ()` can and does return `null` when Code is starting up. Make sure we check that so we don't end up with fatal errors about this on startup.