### PR TITLE
Fix issues with the Pastebin plugin

### DIFF
--- a/plugins/pastebin/pastebin.vala
+++ b/plugins/pastebin/pastebin.vala
@@ -72,7 +72,7 @@ public class Scratch.Plugins.Pastebin : Peas.ExtensionBase, Peas.Activatable {
     Gtk.MenuItem? menuitem = null;
 
     public Object object { owned get; construct; }
-    
+
     Scratch.Services.Document? doc = null;
     Scratch.Services.Interface plugins;
 

--- a/plugins/pastebin/pastebin.vala
+++ b/plugins/pastebin/pastebin.vala
@@ -36,7 +36,7 @@ namespace Scratch.Services {
 
             if (paste_code.length == 0) { link = "No text to paste"; return false; }
 
-            string api_url = "http://pastebin.com/api/api_post.php";
+            string api_url = "https://pastebin.com/api/api_post.php";
 
             var session = new Soup.Session ();
             var message = new Soup.Message ("POST", api_url);
@@ -58,7 +58,7 @@ namespace Scratch.Services {
             var output = (string) message.response_body.data;
             link = output;
 
-            if (Uri.parse_scheme (output) == null) {
+            if (Uri.parse_scheme (output) == null || message.status_code != 200) {
                 // A URI was not returned
                 return false;
             }

--- a/plugins/pastebin/pastebin.vala
+++ b/plugins/pastebin/pastebin.vala
@@ -71,8 +71,9 @@ namespace Scratch.Services {
 public class Scratch.Plugins.Pastebin : Peas.ExtensionBase, Peas.Activatable {
     Gtk.MenuItem? menuitem = null;
 
-    [NoAcessorMethod]
     public Object object { owned get; construct; }
+    
+    Scratch.Services.Document? doc = null;
     Scratch.Services.Interface plugins;
 
     public void update_state () {
@@ -81,27 +82,29 @@ public class Scratch.Plugins.Pastebin : Peas.ExtensionBase, Peas.Activatable {
     public void activate () {
         plugins = (Scratch.Services.Interface) object;
 
-        plugins.hook_share_menu.connect (on_hook);
+        plugins.hook_document.connect ((doc) => {
+            this.doc = doc;
+        });
+
+        plugins.hook_share_menu.connect (on_hook_share_menu);
     }
 
-    void on_hook (Gtk.Menu menu) {
-        plugins.hook_document.connect ((doc) => {
-            if (menuitem != null)
-                menuitem.destroy ();
-            menuitem = new Gtk.MenuItem.with_label (_("Upload to Pastebin"));
-            menuitem.activate.connect (() => {
-                MainWindow window = plugins.manager.window;
-                new Dialogs.PasteBinDialog (window, doc);
-            });
-            menu.append (menuitem);
-            menuitem.show_all ();
+    void on_hook_share_menu (Gtk.Menu menu) {
+        if (menuitem != null)
+            return;
+
+        menuitem = new Gtk.MenuItem.with_label (_("Upload to Pastebin"));
+        menuitem.activate.connect (() => {
+            MainWindow window = plugins.manager.window;
+            new Dialogs.PasteBinDialog (window, doc);
         });
+        menu.append (menuitem);
+        menuitem.show_all ();
     }
 
     public void deactivate () {
         menuitem.destroy ();
     }
-
 }
 
 [ModuleInit]

--- a/plugins/pastebin/pastebin_dialog.vala
+++ b/plugins/pastebin/pastebin_dialog.vala
@@ -385,7 +385,7 @@ namespace Scratch.Dialogs {
             var cancel_button = (Gtk.Button)format_dialog.add_button (_("Cancel"), Gtk.ResponseType.CANCEL);
             cancel_button.clicked.connect (cancel_button_clicked);
 
-            var select_button = (Gtk.Button)format_dialog.add_button (_("Select format"), Gtk.ResponseType.OK);
+            var select_button = (Gtk.Button)format_dialog.add_button (_("Select Format"), Gtk.ResponseType.OK);
             select_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
             select_button.clicked.connect (select_button_clicked);
 

--- a/plugins/pastebin/pastebin_dialog.vala
+++ b/plugins/pastebin/pastebin_dialog.vala
@@ -228,12 +228,6 @@ namespace Scratch.Dialogs {
             {"n", "zxbasic", "ZXBasic", ""}
         };
 
-        private const string CSS = """
-            list {
-                background-color: transparent;
-            }
-        """;
-
         public Scratch.Services.Document doc { get; construct; }
 
         private Gtk.Button close_button;
@@ -258,14 +252,6 @@ namespace Scratch.Dialogs {
         }
 
         construct {
-            var provider = new Gtk.CssProvider ();
-            try {
-                provider.load_from_data (CSS, CSS.length);
-                Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
-            } catch (Error e) {
-                critical (e.message);
-            }
-
             name_entry = new Gtk.Entry ();
 
             var name_entry_l = new Gtk.Label (_("Name:"));
@@ -389,9 +375,12 @@ namespace Scratch.Dialogs {
             select_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
             select_button.clicked.connect (select_button_clicked);
 
-            var content_area = format_dialog.get_content_area ();
-            content_area.add (languages_scrolled);
+            var frame = new Gtk.Frame (null);
+            frame.add (languages_scrolled);
+            frame.margin = 6;
+            frame.margin_top = 0;
 
+            format_dialog.get_content_area ().add (frame);
             format_dialog.show_all ();
         }
 

--- a/plugins/pastebin/pastebin_dialog.vala
+++ b/plugins/pastebin/pastebin_dialog.vala
@@ -373,7 +373,7 @@ namespace Scratch.Dialogs {
 
                 languages_listbox.add (label);
             }
-            
+
             var languages_scrolled = new Gtk.ScrolledWindow (null, null);
             languages_scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
             languages_scrolled.height_request = 250;
@@ -401,16 +401,13 @@ namespace Scratch.Dialogs {
 
         private void select_button_clicked () {
             var selection = languages_listbox.get_selected_row ();
-            if (selection != null)
-            {
+            if (selection != null) {
                 var label = (Gtk.Label)selection.get_child ();
                 var lang_name = label.label;
                 var lang_code = "";
 
-                for (var i=0; i < languages.length[0]; i++)
-                {
-                    if (languages[i, 2] == lang_name)
-                    {
+                for (var i=0; i < languages.length[0]; i++) {
+                    if (languages[i, 2] == lang_name) {
                         lang_code = languages[i, 1];
                         format_combo.append (lang_code, lang_name);
                         format_combo.set_active_id (lang_code);

--- a/plugins/pastebin/pastebin_dialog.vala
+++ b/plugins/pastebin/pastebin_dialog.vala
@@ -262,8 +262,9 @@ namespace Scratch.Dialogs {
 
             format_combo = new Gtk.ComboBoxText ();
 
-            var format_button = new Gtk.Button.from_icon_name ("view-more-horizontal-symbolic");
-            format_button.name = _("Choose Different Format");
+            var format_button = new Gtk.Button.from_icon_name ("view-more-horizontal-symbolic") {
+                tooltip_text = _("Choose different format")
+            };
             format_button.clicked.connect (format_button_clicked);
 
             //populate combo box

--- a/plugins/pastebin/pastebin_dialog.vala
+++ b/plugins/pastebin/pastebin_dialog.vala
@@ -335,7 +335,7 @@ namespace Scratch.Dialogs {
 
             close_button = (Gtk.Button)add_button (_("Cancel"), Gtk.ResponseType.CANCEL);
             upload_button = (Gtk.Button)add_button (_("Upload to Pastebin"), Gtk.ResponseType.OK);
-            upload_button.get_style_context ().add_class ("suggested-action");
+            upload_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
 
             read_settings ();
 
@@ -386,7 +386,7 @@ namespace Scratch.Dialogs {
             cancel_button.clicked.connect (cancel_button_clicked);
 
             var select_button = (Gtk.Button)format_dialog.add_button (_("Select format"), Gtk.ResponseType.OK);
-            select_button.get_style_context ().add_class ("suggested-action");
+            select_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
             select_button.clicked.connect (select_button_clicked);
 
             var content_area = format_dialog.get_content_area ();

--- a/plugins/pastebin/pastebin_dialog.vala
+++ b/plugins/pastebin/pastebin_dialog.vala
@@ -355,7 +355,6 @@ namespace Scratch.Dialogs {
             });
         }
 
-
         private void format_button_clicked () {
             format_dialog = new Gtk.Dialog ();
             format_dialog.deletable = false;
@@ -459,7 +458,6 @@ namespace Scratch.Dialogs {
             box.show_all ();
             stack.visible_child = box;
         }
-
 
         private bool submit_paste (out string link) {
             // Get the values

--- a/plugins/pastebin/pastebin_dialog.vala
+++ b/plugins/pastebin/pastebin_dialog.vala
@@ -228,29 +228,44 @@ namespace Scratch.Dialogs {
             {"n", "zxbasic", "ZXBasic", ""}
         };
 
+        private const string CSS = """
+            list {
+                background-color: transparent;
+            }
+        """;
+
         public Scratch.Services.Document doc { get; construct; }
 
-        private Gtk.Button send_button;
+        private Gtk.Button close_button;
+        private Gtk.Button upload_button;
         private Gtk.Entry name_entry;
         private Gtk.ComboBoxText expiry_combo;
         private Gtk.CheckButton private_check;
         private Gtk.ComboBoxText format_combo;
-        private Gtk.Window format_others_win;
-        private Gtk.TreeView format_others_view;
-        private Gtk.ListStore format_store;
+        private Gtk.Dialog format_dialog;
         private Gtk.Stack stack;
+        private Gtk.ListBox languages_listbox;
 
         public PasteBinDialog (Gtk.Window? parent, Scratch.Services.Document doc) {
             Object (
-                border_width: 5,
                 deletable: false,
+                resizable: false,
+                border_width: 5,
                 doc: doc,
                 transient_for: parent,
-                title: _("Share via Pastebin")
+                title: _("Upload to Pastebin")
             );
         }
 
         construct {
+            var provider = new Gtk.CssProvider ();
+            try {
+                provider.load_from_data (CSS, CSS.length);
+                Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
+            } catch (Error e) {
+                critical (e.message);
+            }
+
             name_entry = new Gtk.Entry ();
 
             var name_entry_l = new Gtk.Label (_("Name:"));
@@ -261,7 +276,7 @@ namespace Scratch.Dialogs {
 
             format_combo = new Gtk.ComboBoxText ();
 
-            var format_button = new Gtk.Button.with_label (_("Others…"));
+            var format_button = new Gtk.Button.with_label (_("…"));
             format_button.clicked.connect (format_button_clicked);
 
             //populate combo box
@@ -283,18 +298,18 @@ namespace Scratch.Dialogs {
                 format_combo.set_active_id ("text");
             }
 
-            var expiry_combo_l = new Gtk.Label (_("Expiry time:"));
+            var expiry_combo_l = new Gtk.Label (_("Expiration:"));
             expiry_combo_l.halign = Gtk.Align.END;
 
             expiry_combo = new Gtk.ComboBoxText ();
             populate_expiry_combo ();
 
             private_check = new Gtk.CheckButton.with_label (_("Keep this paste private"));
-            private_check.margin_top = 12;
+            private_check.margin_bottom = 15;
 
             var grid = new Gtk.Grid ();
-            grid.column_spacing = 6;
-            grid.row_spacing = 12;
+            grid.column_spacing = 10;
+            grid.row_spacing = 8;
             grid.margin = 5;
             grid.margin_top = 0;
             grid.attach (name_entry_l, 0, 0, 1, 1);
@@ -315,28 +330,23 @@ namespace Scratch.Dialogs {
             stack.add (grid);
             stack.add (spinner);
 
-            var content_area = get_content_area () as Gtk.Box;
+            var content_area = get_content_area ();
             content_area.add (stack);
 
-            send_button = new Gtk.Button.with_label (_("Upload"));
-
-            var cancel_button = new Gtk.Button.with_label (_("Close"));
-
-            var action_area = get_action_area () as Gtk.Box;
-            action_area.margin_top = 7;
-            action_area.add (cancel_button);
-            action_area.add (send_button);
+            close_button = (Gtk.Button)add_button (_("Cancel"), Gtk.ResponseType.CANCEL);
+            upload_button = (Gtk.Button)add_button (_("Upload to Pastebin"), Gtk.ResponseType.OK);
+            upload_button.get_style_context ().add_class ("suggested-action");
 
             read_settings ();
 
             show_all ();
 
-            send_button.clicked.connect (() => {
+            upload_button.clicked.connect (() => {
                 stack.visible_child = spinner;
-                send_button_clicked ();
+                upload_button_clicked ();
             });
 
-            cancel_button.clicked.connect (() => {
+            close_button.clicked.connect (() => {
                 destroy ();
             });
 
@@ -347,65 +357,70 @@ namespace Scratch.Dialogs {
 
 
         private void format_button_clicked () {
-            format_others_win = new Gtk.Window ();
-            format_others_win.modal = true;
-            format_others_win.title = _("Other formats");
-            format_others_win.set_default_size (250, 300);
+            format_dialog = new Gtk.Dialog ();
+            format_dialog.deletable = false;
+            format_dialog.resizable = false;
+            format_dialog.border_width = 5;
+            format_dialog.title = _("More formats");
+            format_dialog.set_default_size (220, 300);
 
-            format_others_view = new Gtk.TreeView ();
-            format_others_view.set_headers_visible (false);
+            languages_listbox = new Gtk.ListBox ();
+            languages_listbox.selection_mode = Gtk.SelectionMode.SINGLE;
 
-            format_store = new Gtk.ListStore (2, typeof (string), typeof (string));
-            format_others_view.set_model (format_store);
-            format_others_view.insert_column_with_attributes (-1, "Language", new Gtk.CellRendererText (), "text", 0);
-
-            Gtk.TreeIter iter;
             for (var i=0; i < languages.length[0]; i++) {
-                format_store.append (out iter);
-                format_store.set (iter, 0, languages[i, 2], 1, languages[i, 1]);
+                var label = new Gtk.Label (languages[i, 2]);
+                label.halign = Gtk.Align.START;
+                label.ypad = 5;
+
+                languages_listbox.add (label);
             }
+            
+            var languages_scrolled = new Gtk.ScrolledWindow (null, null);
+            languages_scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
+            languages_scrolled.height_request = 250;
+            languages_scrolled.expand = true;
+            languages_scrolled.margin_start = languages_scrolled.margin_end = 10;
+            languages_scrolled.margin_bottom = 10;
+            languages_scrolled.add (languages_listbox);
 
-            var format_others_scroll = new Gtk.ScrolledWindow (null, null);
-            format_others_scroll.add (format_others_view);
+            var cancel_button = (Gtk.Button)format_dialog.add_button (_("Cancel"), Gtk.ResponseType.CANCEL);
+            cancel_button.clicked.connect (cancel_button_clicked);
 
-            var format_others_ok = new Gtk.Button.from_icon_name ("dialog-ok", Gtk.IconSize.BUTTON);
-            format_others_ok.clicked.connect (format_others_ok_clicked);
+            var select_button = (Gtk.Button)format_dialog.add_button (_("Select format"), Gtk.ResponseType.OK);
+            select_button.get_style_context ().add_class ("suggested-action");
+            select_button.clicked.connect (select_button_clicked);
 
-            var format_others_cancel = new Gtk.Button.from_icon_name ("dialog-cancel", Gtk.IconSize.BUTTON);
-            format_others_cancel.clicked.connect (format_others_cancel_clicked);
+            var content_area = format_dialog.get_content_area ();
+            content_area.add (languages_scrolled);
 
-            var format_others_buttons = new Gtk.ButtonBox (Gtk.Orientation.HORIZONTAL);
-            format_others_buttons.set_layout (Gtk.ButtonBoxStyle.CENTER);
-            format_others_buttons.pack_start (format_others_cancel);
-            format_others_buttons.pack_start (format_others_ok);
-
-            var format_others_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 10);
-            format_others_box.pack_start (format_others_scroll);
-            format_others_box.pack_start (format_others_buttons);
-
-            format_others_win.add (format_others_box);
-            format_others_win.show_all ();
+            format_dialog.show_all ();
         }
 
-        private void format_others_cancel_clicked () {
-            format_others_win.destroy ();
+        private void cancel_button_clicked () {
+            format_dialog.destroy ();
         }
 
-        private void format_others_ok_clicked () {
+        private void select_button_clicked () {
+            var selection = languages_listbox.get_selected_row ();
+            if (selection != null)
+            {
+                var label = (Gtk.Label)selection.get_child ();
+                var lang_name = label.label;
+                var lang_code = "";
 
-            var selection = format_others_view.get_selection ();
-            Gtk.TreeIter iter;
-            if (selection.get_selected (null, out iter) == true) {
-                Value lang_name;
-                Value lang_code;
-                format_store.get_value (iter, 0, out lang_name);
-                format_store.get_value (iter, 1, out lang_code);
-
-                format_combo.append ((string) lang_code, (string) lang_name);
-                format_combo.set_active_id ((string) lang_code);
+                for (var i=0; i < languages.length[0]; i++)
+                {
+                    if (languages[i, 2] == lang_name)
+                    {
+                        lang_code = languages[i, 1];
+                        format_combo.append (lang_code, lang_name);
+                        format_combo.set_active_id (lang_code);
+                        break;
+                    }
+                }
             }
 
-            format_others_win.destroy ();
+            format_dialog.destroy ();
         }
 
         private void read_settings () {
@@ -422,8 +437,9 @@ namespace Scratch.Dialogs {
             Scratch.service_settings.set_boolean ("set-private", private_check.active);
         }
 
-        private void send_button_clicked () {
-            send_button.sensitive = false;
+        private void upload_button_clicked () {
+            upload_button.sensitive = false;
+            close_button.label = _("Close");
 
             string link;
             var submit_result = submit_paste (out link);

--- a/plugins/pastebin/pastebin_dialog.vala
+++ b/plugins/pastebin/pastebin_dialog.vala
@@ -244,7 +244,7 @@ namespace Scratch.Dialogs {
             Object (
                 deletable: false,
                 resizable: false,
-                border_width: 5,
+                border_width: 6,
                 doc: doc,
                 transient_for: parent,
                 title: _("Upload to Pastebin")
@@ -292,13 +292,15 @@ namespace Scratch.Dialogs {
             populate_expiry_combo ();
 
             private_check = new Gtk.CheckButton.with_label (_("Keep this paste private"));
-            private_check.margin_bottom = 15;
+            private_check.margin_bottom = 12;
 
-            var grid = new Gtk.Grid ();
-            grid.column_spacing = 10;
-            grid.row_spacing = 8;
-            grid.margin = 5;
-            grid.margin_top = 0;
+            var grid = new Gtk.Grid () {
+                column_spacing = 6,
+                row_spacing = 12,
+                margin = 6,
+                margin_top = 0,
+                halign = Gtk.Align.CENTER
+            };
             grid.attach (name_entry_l, 0, 0, 1, 1);
             grid.attach (name_entry, 1, 0, 1, 1);
             grid.attach (format_label, 0, 1, 1, 1);
@@ -343,20 +345,22 @@ namespace Scratch.Dialogs {
         }
 
         private void format_button_clicked () {
-            format_dialog = new Gtk.Dialog ();
-            format_dialog.deletable = false;
-            format_dialog.resizable = false;
-            format_dialog.border_width = 5;
-            format_dialog.title = _("More formats");
+            format_dialog = new Gtk.Dialog () {
+                deletable = false,
+                resizable = false,
+                border_width = 6,
+                title = _("Available Formats")
+            };
             format_dialog.set_default_size (220, 300);
 
             languages_listbox = new Gtk.ListBox ();
             languages_listbox.selection_mode = Gtk.SelectionMode.SINGLE;
 
             for (var i=0; i < languages.length[0]; i++) {
-                var label = new Gtk.Label (languages[i, 2]);
-                label.halign = Gtk.Align.START;
-                label.ypad = 5;
+                var label = new Gtk.Label (languages[i, 2]) {
+                    halign = Gtk.Align.START,
+                    margin = 6
+                };
 
                 languages_listbox.add (label);
             }

--- a/plugins/pastebin/pastebin_dialog.vala
+++ b/plugins/pastebin/pastebin_dialog.vala
@@ -26,6 +26,7 @@ namespace Scratch.Dialogs {
 
         public string[,] languages = {
             //if default, code, desc, Code-equivalent
+            {"n", "text", "None", "text"},
             {"n", "4cs", "4CS", ""},
             {"n", "6502acme", "6502 ACME Cross Assembler", ""},
             {"n", "6502kickass", "6502 Kick Assembler", ""},
@@ -203,7 +204,6 @@ namespace Scratch.Dialogs {
             {"n", "tsql", "T-SQL", ""},
             {"n", "tcl", "TCL", ""},
             {"n", "teraterm", "Tera Term", ""},
-            {"n", "text", "None", "text"},
             {"n", "thinbasic", "thinBasic", ""},
             {"n", "typoscript", "TypoScript", ""},
             {"n", "unicon", "Unicon", ""},

--- a/plugins/pastebin/pastebin_dialog.vala
+++ b/plugins/pastebin/pastebin_dialog.vala
@@ -262,7 +262,8 @@ namespace Scratch.Dialogs {
 
             format_combo = new Gtk.ComboBoxText ();
 
-            var format_button = new Gtk.Button.with_label (_("…"));
+            var format_button = new Gtk.Button.from_icon_name ("view-more-horizontal-symbolic");
+            format_button.name = _("Choose Different Format");
             format_button.clicked.connect (format_button_clicked);
 
             //populate combo box

--- a/plugins/pastebin/pastebin_dialog.vala
+++ b/plugins/pastebin/pastebin_dialog.vala
@@ -308,19 +308,19 @@ namespace Scratch.Dialogs {
             grid.attach (format_button, 2, 1, 1, 1);
             grid.attach (expiry_combo_l, 0, 2, 1, 1);
             grid.attach (expiry_combo, 1, 2, 1, 1);
-            grid.attach (private_check, 1, 3, 2, 1);
+            grid.attach (private_check, 1, 3, 1, 1);
 
-            var spinner = new Gtk.Spinner ();
-            spinner.active = true;
-            spinner.height_request = 32;
-            spinner.valign = Gtk.Align.CENTER;
+            var spinner = new Gtk.Spinner () {
+                active = true,
+                height_request = 32,
+                valign = Gtk.Align.CENTER
+            };
 
             stack = new Gtk.Stack ();
             stack.add (grid);
             stack.add (spinner);
 
-            var content_area = get_content_area ();
-            content_area.add (stack);
+            get_content_area ().add (stack);
 
             close_button = (Gtk.Button)add_button (_("Cancel"), Gtk.ResponseType.CANCEL);
             upload_button = (Gtk.Button)add_button (_("Upload to Pastebin"), Gtk.ResponseType.OK);
@@ -353,8 +353,9 @@ namespace Scratch.Dialogs {
             };
             format_dialog.set_default_size (220, 300);
 
-            languages_listbox = new Gtk.ListBox ();
-            languages_listbox.selection_mode = Gtk.SelectionMode.SINGLE;
+            languages_listbox = new Gtk.ListBox () {
+                selection_mode = Gtk.SelectionMode.SINGLE
+            };
 
             for (var i=0; i < languages.length[0]; i++) {
                 var label = new Gtk.Label (languages[i, 2]) {
@@ -365,12 +366,11 @@ namespace Scratch.Dialogs {
                 languages_listbox.add (label);
             }
 
-            var languages_scrolled = new Gtk.ScrolledWindow (null, null);
-            languages_scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
-            languages_scrolled.height_request = 250;
-            languages_scrolled.expand = true;
-            languages_scrolled.margin_start = languages_scrolled.margin_end = 10;
-            languages_scrolled.margin_bottom = 10;
+            var languages_scrolled = new Gtk.ScrolledWindow (null, null) {
+                hscrollbar_policy = Gtk.PolicyType.NEVER,
+                height_request = 250,
+                expand = true
+            };
             languages_scrolled.add (languages_listbox);
 
             var cancel_button = (Gtk.Button)format_dialog.add_button (_("Cancel"), Gtk.ResponseType.CANCEL);
@@ -380,10 +380,11 @@ namespace Scratch.Dialogs {
             select_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
             select_button.clicked.connect (select_button_clicked);
 
-            var frame = new Gtk.Frame (null);
+            var frame = new Gtk.Frame (null) {
+                margin = 6,
+                margin_top = 0
+            };
             frame.add (languages_scrolled);
-            frame.margin = 6;
-            frame.margin_top = 0;
 
             format_dialog.get_content_area ().add (frame);
             format_dialog.show_all ();

--- a/po/fr.po
+++ b/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: scratch\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2020-09-01 22:59+0000\n"
-"PO-Revision-Date: 2020-05-30 10:11+0000\n"
+"PO-Revision-Date: 2020-09-02 22:23+0000\n"
 "Last-Translator: Nathan <bonnemainsnathan@gmail.com>\n"
 "Language-Team: French <https://l10n.elementary.io/projects/code/code/fr/>\n"
 "Language: fr\n"
@@ -523,8 +523,6 @@ msgid "Menu"
 msgstr "Menu"
 
 #: src/Widgets/Pane.vala:45
-#, fuzzy
-#| msgid "Open project folder…"
 msgid "Open Project Folder…"
 msgstr "Ouvrir le dossier du projet…"
 

--- a/src/Widgets/FormatBar.vala
+++ b/src/Widgets/FormatBar.vala
@@ -42,7 +42,7 @@ public class Code.FormatBar : Gtk.Grid {
     """;
 
     static construct {
-       var provider = new Gtk.CssProvider ();
+        var provider = new Gtk.CssProvider ();
         try {
             provider.load_from_data (CSS, CSS.length);
             Gtk.StyleContext.add_provider_for_screen (Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);


### PR DESCRIPTION
This fixes all of the issues mentioned in #871, removes one warning from #773 and improves the overall aesthetics of this plugin.

Before:
![before](https://user-images.githubusercontent.com/2980983/92193531-e0939800-ee68-11ea-80c0-f0e5466dcf73.png)

After:
![after](https://user-images.githubusercontent.com/2980983/92193539-e4bfb580-ee68-11ea-9e3c-c01002b021af.png)

I also adjusted some of the translatable texts in the code and I am not sure whether there is anything else needed there to make them available for translation.

Fixes #871 