### PR TITLE
Ctrl+Tab for next document and Ctrl+Shift+Tab for previous one

### DIFF
--- a/data/io.elementary.code.appdata.xml.in
+++ b/data/io.elementary.code.appdata.xml.in
@@ -52,6 +52,7 @@
         <ul>
           <li>Allow Spell Checker extension in Markdown files</li>
           <li>Remember whether the sidebar is open</li>
+          <li>Add keyboard shortcuts for next and previous documents.</li>
         </ul>
       </description>
     </release>

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -90,6 +90,8 @@ namespace Scratch {
         public const string ACTION_ZOOM_OUT = "action_zoom_out";
         public const string ACTION_TOGGLE_COMMENT = "action_toggle_comment";
         public const string ACTION_TOGGLE_SIDEBAR = "action_toggle_sidebar";
+        public const string ACTION_NEXT_TAB = "action_next_tab";
+        public const string ACTION_PREVIOUS_TAB = "action_previous_tab";
 
         public static Gee.MultiMap<string, string> action_accelerators = new Gee.HashMultiMap<string, string> ();
 
@@ -124,7 +126,9 @@ namespace Scratch {
             { ACTION_ZOOM_IN, action_zoom_in },
             { ACTION_ZOOM_OUT, action_zoom_out},
             { ACTION_TOGGLE_COMMENT, action_toggle_comment },
-            { ACTION_TOGGLE_SIDEBAR, action_toggle_sidebar }
+            { ACTION_TOGGLE_SIDEBAR, action_toggle_sidebar },
+            { ACTION_NEXT_TAB, action_next_tab },
+            { ACTION_PREVIOUS_TAB, action_previous_tab },
         };
 
         public MainWindow (Scratch.Application scratch_app) {
@@ -166,6 +170,8 @@ namespace Scratch {
             action_accelerators.set (ACTION_TOGGLE_COMMENT, "<Control>slash");
             action_accelerators.set (ACTION_TOGGLE_SIDEBAR, "F9"); // GNOME
             action_accelerators.set (ACTION_TOGGLE_SIDEBAR, "<Control>backslash"); // Atom
+            action_accelerators.set (ACTION_NEXT_TAB, "<Control>Tab");
+            action_accelerators.set (ACTION_PREVIOUS_TAB, "<Control><Shift>Tab");
 
             var provider = new Gtk.CssProvider ();
             provider.load_from_resource ("io/elementary/code/Application.css");
@@ -956,6 +962,14 @@ namespace Scratch {
             }
 
             sidebar.visible = !sidebar.visible;
+        }
+
+        private void action_next_tab () {
+            document_view.next_document ();
+        }
+
+        private void action_previous_tab () {
+            document_view.previous_document ();
         }
     }
 }

--- a/src/Widgets/DocumentView.vala
+++ b/src/Widgets/DocumentView.vala
@@ -233,6 +233,10 @@ public class Scratch.Widgets.DocumentView : Granite.Widgets.DynamicNotebook {
             var next_doc = docs.nth_data (current_index++);
             current_document = next_doc;
             next_doc.focus ();
+        } else if (docs.length () > 0) {
+            var next_doc = docs.nth_data (0);
+            current_document = next_doc;
+            next_doc.focus ();
         }
     }
 
@@ -240,6 +244,10 @@ public class Scratch.Widgets.DocumentView : Granite.Widgets.DynamicNotebook {
         uint current_index = docs.index (current_document);
         if (current_index > 0) {
             var previous_doc = docs.nth_data (--current_index);
+            current_document = previous_doc;
+            previous_doc.focus ();
+        } else if (docs.length () > 0) {
+            var previous_doc = docs.nth_data (docs.length () - 1);
             current_document = previous_doc;
             previous_doc.focus ();
         }


### PR DESCRIPTION
Fixes #841 : add shortcuts for next/previous documents. Also refactored `DocumentView.next/previous_document` to cycle opened documents.