### PR TITLE
Fix plugins compile warnings

### DIFF
--- a/plugins/terminal/terminal.vala
+++ b/plugins/terminal/terminal.vala
@@ -240,7 +240,7 @@ public class Scratch.Plugins.Terminal : Peas.ExtensionBase, Peas.Activatable {
         this.terminal.button_press_event.connect ((event) => {
             if (event.button == 3) {
                 menu.select_first (false);
-                menu.popup (null, null, null, event.button, event.time);
+                menu.popup_at_pointer (event);
             }
             return false;
         });
@@ -268,9 +268,6 @@ public class Scratch.Plugins.Terminal : Peas.ExtensionBase, Peas.Activatable {
         var pantheon_terminal_settings = new GLib.Settings (settings_schema);
 
         font_name = pantheon_terminal_settings.get_string ("font");
-
-        bool allow_bold_setting = pantheon_terminal_settings.get_boolean ("allow-bold");
-        this.terminal.set_allow_bold (allow_bold_setting);
 
         bool audible_bell_setting = pantheon_terminal_settings.get_boolean ("audible-bell");
         this.terminal.set_audible_bell (audible_bell_setting);

--- a/plugins/word-completion/completion-provider.vala
+++ b/plugins/word-completion/completion-provider.vala
@@ -25,7 +25,6 @@ public class Scratch.Plugins.CompletionProvider : Gtk.SourceCompletionProvider, 
     public const string COMPLETION_END_MARK_NAME = "ScratchWordCompletionEnd";
     public const string COMPLETION_START_MARK_NAME = "ScratchWordCompletionStart";
 
-    private Gdk.Pixbuf icon;
     private Gtk.TextView? view;
     private Gtk.TextBuffer? buffer;
     private Euclide.Completion.Parser parser;


### PR DESCRIPTION
Fixes most compile warnings arising from plugins

Something weird is happening with `Vte.Terminal.spawn_async ()` - the Vala compiler is producing code that fails the C compiler for some reason so the deprecated `Vte.Terminal.spawn_sync ()` will be addressed in a later PR.