### PR TITLE
Stop document_change signal being emitted twice after tab switch.

### DIFF
--- a/src/Widgets/DocumentView.vala
+++ b/src/Widgets/DocumentView.vala
@@ -72,7 +72,7 @@ public class Scratch.Widgets.DocumentView : Granite.Widgets.DynamicNotebook {
         });
 
         tab_switched.connect ((old_tab, new_tab) => {
-            document_change (new_tab as Services.Document, this);
+            /* The 'document_change' signal is emitted when the document is focused. We do not need to emit it here */
             save_focused_document_uri (new_tab as Services.Document);
         });
 


### PR DESCRIPTION
The `document-change` signal is being currently emitted twice on every tab switch as it is emitted both in the tab-switch handler and when the document is focussed.  As this signal is propagated to all the plugins and triggers many other activities this is not desirable.
