### PR TITLE
Simplify cmdline option handling

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -40,7 +40,7 @@ namespace Scratch {
             { "new-window", 'n', 0, OptionArg.NONE, null, N_("New Window"), null },
             { "version", 'v', 0, OptionArg.NONE, null, N_("Print version info and exit"), null },
             { "set", 's', 0, OptionArg.STRING, ref _app_cmd_name, N_("Set of plugins"), N_("plugin") },
-            { GLib.OPTION_REMAINING, 0, 0, OptionArg.FILENAME_ARRAY, null, null, null },
+            { GLib.OPTION_REMAINING, 0, 0, OptionArg.FILENAME_ARRAY, null, null, N_("[FILE…]") },
             { null }
         };
 

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -32,15 +32,25 @@ namespace Scratch {
         public string default_font { get; set; }
         private static string _app_cmd_name;
         private static string _data_home_folder_unsaved;
-        private static bool print_version = false;
         private static bool create_new_tab = false;
         private static bool create_new_window = false;
+
+        const OptionEntry[] ENTRIES = {
+            { "new-tab", 't', 0, OptionArg.NONE, null, N_("New Tab"), null },
+            { "new-window", 'n', 0, OptionArg.NONE, null, N_("New Window"), null },
+            { "version", 'v', 0, OptionArg.NONE, null, N_("Print version info and exit"), null },
+            { "set", 's', 0, OptionArg.STRING, ref _app_cmd_name, N_("Set of plugins"), N_("plugin") },
+            { GLib.OPTION_REMAINING, 0, 0, OptionArg.FILENAME_ARRAY, null, null, null },
+            { null }
+        };
 
         construct {
             flags |= ApplicationFlags.HANDLES_OPEN;
             flags |= ApplicationFlags.HANDLES_COMMAND_LINE;
 
             application_id = Constants.PROJECT_NAME;
+
+            add_main_option_entries (ENTRIES);
         }
 
         public Application () {
@@ -55,128 +65,42 @@ namespace Scratch {
             _data_home_folder_unsaved = Path.build_filename (Environment.get_user_data_dir (), Constants.PROJECT_NAME, "unsaved");
         }
 
-        protected override int command_line (ApplicationCommandLine command_line) {
-            var context = new OptionContext ("File");
-            context.add_main_entries (ENTRIES, Constants.GETTEXT_PACKAGE);
-            context.add_group (Gtk.get_option_group (true));
-
-            string[] args = command_line.get_arguments ();
-
-            try {
-                context.parse_strv (ref args);
-            } catch (Error e) {
-                print (e.message + "\n");
-
-                return Posix.EXIT_FAILURE;
-            }
-
-            if (print_version) {
+        public override int handle_local_options (VariantDict options) {
+            if (options.contains ("version")) {
                 stdout.printf ("Code %s\n", Constants.VERSION);
                 return Posix.EXIT_SUCCESS;
             }
 
-            // Create a next window if requested and it's not the app launch
-            bool is_app_launch = (get_last_window () == null);
-            if (create_new_window && !is_app_launch) {
-                create_new_window = false;
-                this.new_window ();
+            return -1;
+        }
+
+        public override int command_line (GLib.ApplicationCommandLine command_line) {
+            var options = command_line.get_options_dict ();
+
+            if (options.contains ("new-tab")) {
+                create_new_tab = true;
             }
 
-            // Create (or show) the first window
+            if (options.contains ("new-window")) {
+                create_new_window = true;
+            }
+
             activate ();
 
-            // Create a new document if requested
-            if (create_new_tab) {
-                create_new_tab = false;
-                var window = get_last_window ();
-                Utils.action_from_group (MainWindow.ACTION_NEW_TAB, window.actions).activate (null);
-            }
-
-            int args_length = args.length;
-            // Open all files given as arguments
-            if (args_length > 1) { /* First arg is program name */
+            if (options.contains (GLib.OPTION_REMAINING)) {
                 File[] files = {};
-                foreach (unowned string arg in args[1:args_length]) {
-                    if (arg == null) { /* Recognised options changed to null */
-                        continue;
-                    }
-                    // We set a message, that later is informed to the user
-                    // in a dialog if something noteworthy happens.
-                    string title = "";
-                    string body = "";
-                    try {
-                        var file = command_line.create_file_for_arg (arg);
 
-                        if (!file.query_exists ()) {
-                            try {
-                                FileUtils.set_contents (file.get_path (), "");
-                            } catch (Error e) {
-                                title = _("File \"%s\" Cannot Be Created".printf (file.get_path ()));
+                (unowned string)[] remaining = options.lookup_value (
+                    GLib.OPTION_REMAINING,
+                    VariantType.BYTESTRING_ARRAY
+                ).get_bytestring_array ();
 
-                                // We list some common errors for quick feedback
-                                if (e is FileError.ACCES) {
-                                    body = _("Maybe you do not have the necessary permissions.");
-                                } else if (e is FileError.NOENT) {
-                                    body = _("Maybe the file path provided is not valid.");
-                                } else if (e is FileError.ROFS) {
-                                    body = _("The location is read-only.");
-                                } else if (e is FileError.NOTDIR) {
-                                    body = _("The parent directory doesn't exist.");
-                                } else {
-                                    // Otherwise we simple use the error notification from glib
-                                    body = e.message;
-                                }
-
-                                // Escape to the outer catch clause, and overwrite
-                                // the weird glib's standard errors.
-                                throw new Error (e.domain, e.code, "%s %s".printf (title, body));
-                            }
-                        }
-
-                        var info = file.query_info ("standard::*", FileQueryInfoFlags.NONE, null);
-
-                        switch (info.get_file_type ()) {
-                            case FileType.REGULAR:
-                            case FileType.SYMBOLIC_LINK:
-                            case FileType.DIRECTORY:
-                                files += file;
-                                break;
-                            case FileType.MOUNTABLE:
-                                body = _("It is a mountable location.");
-                                break;
-                            case FileType.SPECIAL:
-                                body = _("It is a \"special\" file such as a socket,\n FIFO, block device, or character device.");
-                                break;
-                            default:
-                                body = _("It is an \"unknown\" file type.");
-                                break;
-                        }
-
-                        if (body.length > 0) {
-                            title = _("File \"%s\" Cannot Be Opened".printf (file.get_path ()));
-                        }
-
-                    } catch (Error e) {
-                        warning (e.message);
-                    }
-
-                    // Notify the user that something happened.
-                    if (title.length > 0) {
-                        var dialog = new Granite.MessageDialog (
-                            title,
-                            body,
-                            new ThemedIcon ("dialog-error"),
-                            Gtk.ButtonsType.CLOSE
-                        );
-                        dialog.transient_for = get_last_window () as Gtk.Window;
-                        dialog.run ();
-                        dialog.destroy ();
-                    }
+                for (int i = 0; i < remaining.length; i++) {
+                    unowned string file = remaining[i];
+                    files += command_line.create_file_for_arg (file);
                 }
 
-                if (files.length > 0) {
-                    open (files, "");
-                }
+                open (files, "");
             }
 
             return Posix.EXIT_SUCCESS;
@@ -184,12 +108,21 @@ namespace Scratch {
 
         protected override void activate () {
             var window = get_last_window ();
-            if (window == null) {
+            if (window != null && create_new_window) {
+                create_new_window = false;
+                this.new_window ();
+            } else if (window == null) {
                 window = this.new_window ();
                 window.show ();
                 window.restore_opened_documents ();
             } else {
                 window.present ();
+            }
+
+            // Create a new document if requested
+            if (create_new_tab) {
+                create_new_tab = false;
+                Utils.action_from_group (MainWindow.ACTION_NEW_TAB, window.actions).activate (null);
             }
         }
 
@@ -215,14 +148,6 @@ namespace Scratch {
         public MainWindow new_window () {
             return new MainWindow (this);
         }
-
-        const OptionEntry[] ENTRIES = {
-            { "new-tab", 't', 0, OptionArg.NONE, out create_new_tab, N_("New Tab"), null },
-            { "new-window", 'n', 0, OptionArg.NONE, out create_new_window, N_("New Window"), null },
-            { "version", 'v', 0, OptionArg.NONE, out print_version, N_("Print version info and exit"), null },
-            { "set", 's', 0, OptionArg.STRING, ref _app_cmd_name, N_("Set of plugins"), N_("plugin") },
-            { null }
-        };
 
         public static int main (string[] args) {
             _app_cmd_name = "Code";


### PR DESCRIPTION
Fixes #689 

Supersedes #811 

This makes the option parsing much more compliant with the GLib recommended best practices and removes a lot of the manual parsing and error checking of arguments.

We already have error views per-tab (instead of one dialog for each file) when something fails to open, so let's use those.