### PR TITLE
Expand folder when opening an already open project

### DIFF
--- a/src/FolderManager/FileView.vala
+++ b/src/FolderManager/FileView.vala
@@ -65,7 +65,11 @@ namespace Scratch.FolderManager {
 
         public void open_folder (File folder) {
             if (is_open (folder)) {
-                warning ("Folder '%s' is already open.", folder.path);
+                var existing = find_path (root, folder.path);
+                if (existing is Granite.Widgets.SourceList.ExpandableItem) {
+                    ((Granite.Widgets.SourceList.ExpandableItem)existing).expanded = true;
+                }
+
                 return;
             } else if (!folder.is_valid_directory) {
                 warning ("Cannot open invalid directory.");


### PR DESCRIPTION
Currently if you have a long list of projects in the sidebar and you try and open one that's already open, nothing happens (other than a warning in the terminal). How about we expand that already open folder so you can see where it is easier?