### PR TITLE
SearchBar: Refresh search on document focus change

### DIFF
--- a/src/Widgets/SearchBar.vala
+++ b/src/Widgets/SearchBar.vala
@@ -178,6 +178,7 @@ namespace Scratch.Widgets {
             this.search_context = new Gtk.SourceSearchContext (text_buffer as Gtk.SourceBuffer, null);
             search_context.settings.wrap_around = tool_cycle_search.active;
             search_context.settings.regex_enabled = false;
+            search_context.settings.search_text = search_entry.text;
 
             // Determine the search entry color
             bool found = (search_entry.text != "" && search_entry.text in this.text_buffer.text);


### PR DESCRIPTION
Fixes that really annoying search issue where if you re-focus the document it forgets what you were searching for. Might need some UX input as to whether this behaviour of keeping the search active until you delete it or close the search bar is desirable.

Fixes #528 
Fixes #692 
Fixes #812 