### PR TITLE
HeaderBar: Correctly load color button states

### DIFF
--- a/data/io.elementary.code.gschema.xml
+++ b/data/io.elementary.code.gschema.xml
@@ -151,6 +151,7 @@
       <description>Whether text searching should cycle back to the beginning of the document after reaching the end of the document.</description>
     </key>
   </schema>
+
   <schema path="/io/elementary/code/services/" id="io.elementary.code.services" gettext-domain="io.elementary.code">
     <key name="paste-format-code" type="s">
       <default>'None'</default>
@@ -168,11 +169,11 @@
       <description>Set the preferred policy.</description>
     </key>
   </schema>
-    <schema path="/io/elementary/code/folder-manager/" id="io.elementary.code.folder-manager">
-        <key name="opened-folders" type="as">
-            <default>[]</default>
-            <summary>Opened folders.</summary>
-            <description>Opened folders that should be restored in startup.</description>
-        </key>
-    </schema>
+  <schema path="/io/elementary/code/folder-manager/" id="io.elementary.code.folder-manager">
+    <key name="opened-folders" type="as">
+      <default>[]</default>
+      <summary>Opened folders.</summary>
+      <description>Opened folders that should be restored in startup.</description>
+    </key>
+  </schema>
 </schemalist>

--- a/data/io.elementary.code.gschema.xml
+++ b/data/io.elementary.code.gschema.xml
@@ -151,7 +151,6 @@
       <description>Whether text searching should cycle back to the beginning of the document after reaching the end of the document.</description>
     </key>
   </schema>
-
   <schema path="/io/elementary/code/services/" id="io.elementary.code.services" gettext-domain="io.elementary.code">
     <key name="paste-format-code" type="s">
       <default>'None'</default>
@@ -169,11 +168,11 @@
       <description>Set the preferred policy.</description>
     </key>
   </schema>
-  <schema path="/io/elementary/code/folder-manager/" id="io.elementary.code.folder-manager">
-    <key name="opened-folders" type="as">
-      <default>[]</default>
-      <summary>Opened folders.</summary>
-      <description>Opened folders that should be restored in startup.</description>
-    </key>
-  </schema>
+    <schema path="/io/elementary/code/folder-manager/" id="io.elementary.code.folder-manager">
+        <key name="opened-folders" type="as">
+            <default>[]</default>
+            <summary>Opened folders.</summary>
+            <description>Opened folders that should be restored in startup.</description>
+        </key>
+    </schema>
 </schemalist>

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -28,6 +28,10 @@ namespace Scratch.Widgets {
         public Gtk.Button templates_button;
         public Code.FormatBar format_bar;
 
+        private const string STYLE_SCHEME_HIGH_CONTRAST = "classic";
+        private const string STYLE_SCHEME_LIGHT = "solarized-light";
+        private const string STYLE_SCHEME_DARK = "solarized-dark";
+
         public HeaderBar () {
             Object (
                 has_subtitle: false,
@@ -115,7 +119,10 @@ namespace Scratch.Widgets {
             font_size_grid.add (zoom_default_button);
             font_size_grid.add (zoom_in_button);
 
-            var color_button_white = new Gtk.RadioButton (null);
+            // Intentionally never attached so we can have a non-selected state
+            var color_button_none = new Gtk.RadioButton (null);
+
+            var color_button_white = new Gtk.RadioButton.from_widget (color_button_none);
             color_button_white.halign = Gtk.Align.CENTER;
             color_button_white.tooltip_text = _("High Contrast");
 
@@ -123,7 +130,7 @@ namespace Scratch.Widgets {
             color_button_white_context.add_class ("color-button");
             color_button_white_context.add_class ("color-white");
 
-            var color_button_light = new Gtk.RadioButton.from_widget (color_button_white);
+            var color_button_light = new Gtk.RadioButton.from_widget (color_button_none);
             color_button_light.halign = Gtk.Align.CENTER;
             color_button_light.tooltip_text = _("Solarized Light");
 
@@ -131,7 +138,7 @@ namespace Scratch.Widgets {
             color_button_light_context.add_class ("color-button");
             color_button_light_context.add_class ("color-light");
 
-            var color_button_dark = new Gtk.RadioButton.from_widget (color_button_white);
+            var color_button_dark = new Gtk.RadioButton.from_widget (color_button_none);
             color_button_dark.halign = Gtk.Align.CENTER;
             color_button_dark.tooltip_text = _("Solarized Dark");
 
@@ -214,32 +221,34 @@ namespace Scratch.Widgets {
             var gtk_settings = Gtk.Settings.get_default ();
 
             switch (Scratch.settings.get_string ("style-scheme")) {
-               case "high-contrast":
-                   color_button_white.active = true;
-                   break;
-               case "solarized-light":
-                   color_button_light.active = true;
-                   break;
-               case "solarized-dark":
-                   color_button_dark.active = true;
-                   break;
+                case STYLE_SCHEME_HIGH_CONTRAST:
+                    color_button_white.active = true;
+                    break;
+                case STYLE_SCHEME_LIGHT:
+                    color_button_light.active = true;
+                    break;
+                case STYLE_SCHEME_DARK:
+                    color_button_dark.active = true;
+                    break;
+                default:
+                    color_button_none.active = true;
             }
 
             color_button_dark.clicked.connect (() => {
                 Scratch.settings.set_boolean ("prefer-dark-style", true);
-                Scratch.settings.set_string ("style-scheme", "solarized-dark");
+                Scratch.settings.set_string ("style-scheme", STYLE_SCHEME_DARK);
                 gtk_settings.gtk_application_prefer_dark_theme = true;
             });
 
             color_button_light.clicked.connect (() => {
                 Scratch.settings.set_boolean ("prefer-dark-style", false);
-                Scratch.settings.set_string ("style-scheme", "solarized-light");
+                Scratch.settings.set_string ("style-scheme", STYLE_SCHEME_LIGHT);
                 gtk_settings.gtk_application_prefer_dark_theme = false;
             });
 
             color_button_white.clicked.connect (() => {
                 Scratch.settings.set_boolean ("prefer-dark-style", false);
-                Scratch.settings.set_string ("style-scheme", "classic");
+                Scratch.settings.set_string ("style-scheme", STYLE_SCHEME_HIGH_CONTRAST);
                 gtk_settings.gtk_application_prefer_dark_theme = false;
             });
         }


### PR DESCRIPTION
We were incorrectly checking for `high-contrast` as a color scheme name in the switch statement, when it should have actually been `classic`; the fact that it was a group of radio buttons meant the mismatch selected the first radio button which just happened to be the right one, but this makes it more explicit in a couple of ways:

- Adds and uses consts for color scheme names so we can't mismatch them anymore
- Adds a hidden `color_button_none` that's never attached
- Defaults to selecting `color_button_none` when the switch statement doesn't have a match so we don't select the wrong color button e.g. if someone manually edits the GSettings