### PR TITLE
GSchema: Correct whitespace

### DIFF
--- a/data/io.elementary.code.gschema.xml
+++ b/data/io.elementary.code.gschema.xml
@@ -151,6 +151,7 @@
       <description>Whether text searching should cycle back to the beginning of the document after reaching the end of the document.</description>
     </key>
   </schema>
+
   <schema path="/io/elementary/code/services/" id="io.elementary.code.services" gettext-domain="io.elementary.code">
     <key name="paste-format-code" type="s">
       <default>'None'</default>
@@ -168,11 +169,12 @@
       <description>Set the preferred policy.</description>
     </key>
   </schema>
-    <schema path="/io/elementary/code/folder-manager/" id="io.elementary.code.folder-manager">
-        <key name="opened-folders" type="as">
-            <default>[]</default>
-            <summary>Opened folders.</summary>
-            <description>Opened folders that should be restored in startup.</description>
-        </key>
-    </schema>
+
+  <schema path="/io/elementary/code/folder-manager/" id="io.elementary.code.folder-manager">
+    <key name="opened-folders" type="as">
+      <default>[]</default>
+      <summary>Opened folders.</summary>
+      <description>Opened folders that should be restored in startup.</description>
+    </key>
+  </schema>
 </schemalist>


### PR DESCRIPTION
There were just a couple of spots using inconsistent newlines and four-space indentation instead of two.