### PR TITLE
Suppress criticals on startup

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -416,6 +416,9 @@ namespace Scratch {
                 });
 
                 hook_func ();
+            });
+
+            document_view.realize.connect (() => {
                 restore_opened_documents ();
             });
 


### PR DESCRIPTION
Fixes `gtk_box_gadget_distribute: assertion 'size >= 0' failed in GtkNotebook` critical errors on startup.