### PR TITLE
ChooseProjectButton: simplify ProjectRow click handling

### DIFF
--- a/src/Widgets/ChooseProjectButton.vala
+++ b/src/Widgets/ChooseProjectButton.vala
@@ -134,7 +134,7 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
         project_listbox.select_row (project_entry);
         label_widget.label = project_entry.project_name;
         label_widget.tooltip_text = _("Active Git project: %s").printf (project_entry.project_path);
-        project_entry.selected = true;
+        project_entry.active = true;
     }
 
     public void set_document (Scratch.Services.Document doc) {
@@ -173,18 +173,6 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
 
         public Gtk.RadioButton project_radio { get; construct; }
 
-        public bool selected {
-            get {
-                return project_radio.active;
-            }
-
-            set {
-                project_radio.toggled.disconnect (radio_toggled);
-                project_radio.active = value;
-                project_radio.toggled.connect (radio_toggled);
-            }
-        }
-
         public ProjectRow (string project_path) {
             Object (
                 project_path: project_path
@@ -201,13 +189,12 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
             show_all ();
 
             bind_property ("active", project_radio, "active", BindingFlags.BIDIRECTIONAL);
-            project_radio.toggled.connect (radio_toggled);
-        }
 
-        private void radio_toggled () {
-            if (project_radio.active) {
-                activate ();
-            }
+            project_radio.clicked.connect (() => {
+                if (project_radio.active) {
+                    activate ();
+                }
+            });
         }
     }
 }

--- a/src/Widgets/ChooseProjectButton.vala
+++ b/src/Widgets/ChooseProjectButton.vala
@@ -190,10 +190,9 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
 
             bind_property ("active", project_radio, "active", BindingFlags.BIDIRECTIONAL);
 
-            project_radio.clicked.connect (() => {
-                if (project_radio.active) {
-                    activate ();
-                }
+            project_radio.button_release_event.connect (() => {
+                activate ();
+                return Gdk.EVENT_PROPAGATE;
             });
         }
     }


### PR DESCRIPTION
It looks like this `selected` property is a duplicate of `active` but it exists only as a setter to workaround toggling the radiobutton.

Instead, we can use `active` for the setter, but change the signal handling of the radiobutton to `button_release_event` so that `activate ()` is only triggered when the button is actually activated by the user