### PR TITLE
GitManager: source of truth for active_project_path

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1004,7 +1004,7 @@ namespace Scratch {
              }
 
              if (path == "") { // Happens when keyboard accelerator is used
-                 path = toolbar.active_project_path;
+                 path = Services.GitManager.get_instance ().active_project_path;
                  if (path == null) {
                      var current_doc = get_current_document ();
                      if (current_doc != null) {

--- a/src/Services/GitManager.vala
+++ b/src/Services/GitManager.vala
@@ -21,6 +21,7 @@
 namespace Scratch.Services {
     public class GitManager : Object {
         public ListStore project_liststore { get; private set; }
+        public string active_project_path { get; set; default = "";}
 
         static Gee.HashMap<string, MonitoredRepository> project_gitrepo_map;
         static GitManager? instance;

--- a/src/Widgets/ChooseProjectButton.vala
+++ b/src/Widgets/ChooseProjectButton.vala
@@ -99,6 +99,7 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
         project_listbox.row_activated.connect ((row) => {
             var project_entry = ((ProjectRow) row);
             select_project (project_entry);
+
         });
     }
 
@@ -118,6 +119,7 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
         label_widget.label = project_entry.project_name;
         label_widget.tooltip_text = _("Active Git project: %s").printf (project_entry.project_path);
         project_entry.selected = true;
+        Scratch.Services.GitManager.get_instance ().active_project_path = project_entry.project_path;
     }
 
     public void set_document (Scratch.Services.Document doc) {
@@ -131,18 +133,6 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
                 select_project (project_entry);
             }
         });
-    }
-
-    public string? get_active_path () {
-        string? active_path = null;
-        project_listbox.get_children ().foreach ((child) => {
-            var project_entry = ((ProjectRow) child);
-            if (project_entry.active) {
-                active_path = project_entry.project_path;
-            }
-        });
-
-        return active_path;
     }
 
     public class ProjectRow : Gtk.ListBoxRow {

--- a/src/Widgets/ChooseProjectButton.vala
+++ b/src/Widgets/ChooseProjectButton.vala
@@ -99,7 +99,6 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
         project_listbox.row_activated.connect ((row) => {
             var project_entry = ((ProjectRow) row);
             select_project (project_entry);
-
         });
     }
 

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -29,12 +29,6 @@ namespace Scratch.Widgets {
         public Code.FormatBar format_bar;
         public Code.ChooseProjectButton choose_project_button;
 
-        public string? active_project_path {
-            owned get {
-                return choose_project_button.get_active_path ();
-            }
-        }
-
         private const string STYLE_SCHEME_HIGH_CONTRAST = "classic";
         private const string STYLE_SCHEME_LIGHT = "solarized-light";
         private const string STYLE_SCHEME_DARK = "solarized-dark";


### PR DESCRIPTION
Using GitManager as source of truth for the active project saves a useful number of lines and increases clarity.

- We may need a "ProjectManager" class as a controller for project objects in the wider sense (not just git repository objects).? #940  goes down this route. In which vase the active project should be controlled there and there are further simplifications possible in other classes.
