### PR TITLE
Allow non-git projects to fix global search

### DIFF
--- a/src/FolderManager/FileView.vala
+++ b/src/FolderManager/FileView.vala
@@ -164,8 +164,13 @@ namespace Scratch.FolderManager {
         }
 
         public void new_branch (string active_project_path) {
-            string? branch_name = null;
             unowned var active_project = (ProjectFolderItem)(find_path (root, active_project_path));
+            if (active_project == null || !active_project.is_git_repo) {
+                Gdk.beep ();
+                return;
+            }
+
+            string? branch_name = null;
             var dialog = new Dialogs.NewBranchDialog (active_project);
             dialog.show_all ();
             if (dialog.run () == Gtk.ResponseType.APPLY) {

--- a/src/Services/GitManager.vala
+++ b/src/Services/GitManager.vala
@@ -45,6 +45,8 @@ namespace Scratch.Services {
         }
 
         public MonitoredRepository? add_project (GLib.File root_folder) {
+            project_liststore.insert_sorted (root_folder, (CompareDataFunc<GLib.Object>) project_sort_func);
+
             var root_path = root_folder.get_path ();
             try {
                 var git_repo = Ggit.Repository.open (root_folder);
@@ -55,7 +57,6 @@ namespace Scratch.Services {
                 var monitored_repo = new MonitoredRepository (git_repo);
 
                 project_gitrepo_map.@set (root_path, monitored_repo);
-                project_liststore.insert_sorted (root_folder, (CompareDataFunc<GLib.Object>) project_sort_func);
                 return project_gitrepo_map.@get (root_path);
             } catch (Error e) {
                 debug ("Error opening git repo for %s, means this probably isn't one: %s", root_path, e.message);


### PR DESCRIPTION
Fix global search shortcut by allowing non-git projects in the chooser.

Throw a Gdk.beep if trying to use the new branch shortcut in a non-git project instead of crashing