### PR TITLE
Fix Gala 1147: Use present_with_time instead of present to focus window

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -129,7 +129,7 @@ namespace Scratch {
                 window.show ();
                 window.restore_opened_documents ();
             } else {
-                window.present ();
+                window.present_with_time ((uint32) GLib.get_monotonic_time ());
             }
 
             // Create a new document if requested


### PR DESCRIPTION
I think this should fix https://github.com/elementary/gala/issues/1147

see https://valadoc.org/gtk+-3.0/Gtk.Window.present_with_time.html