### PR TITLE
Do not cripple non-git folder search

### DIFF
--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -255,7 +255,9 @@ namespace Scratch.FolderManager {
             Regex? pattern = null;
 
             var dialog = new Scratch.Dialogs.GlobalSearchDialog (
-                null, start_folder.get_basename (), monitored_repo.git_repo != null
+                null,
+                start_folder.get_basename (),
+                monitored_repo != null && monitored_repo.git_repo != null
             ) {
                 case_sensitive = case_sensitive,
                 use_regex = use_regex
@@ -361,7 +363,7 @@ namespace Scratch.FolderManager {
                     if (info != null && info.has_attribute (FileAttribute.STANDARD_TYPE)) {
                         if (info.get_file_type () == FileType.DIRECTORY) {
                             if (recurse_subfolders) {
-                                search_folder_children (child, pattern, false); //Limit depth to 1
+                                search_folder_children (child, pattern, recurse_subfolders);
                             }
                         } else {
                             perform_match (child, pattern, true, info);
@@ -404,7 +406,6 @@ namespace Scratch.FolderManager {
                 var type = info.get_content_type ();
                 if (!ContentType.is_mime_type (type, "text/*") ||
                     ContentType.is_mime_type (type, "image/*")) { //Do not search svg images
-
                     return;
                 }
             }


### PR DESCRIPTION
* Do not limit depth of recursion to 1
* Suppress terminal warning

Should not artificially limit the search depth to one - instead we should deal with possibly huge search scope and consequent interface blocking by making search asynchronous and providing a cancellation ability (for future PR).