### PR TITLE
Avoid size allocation warnings when restoring first docs

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -125,9 +125,8 @@ namespace Scratch {
                 create_new_window = false;
                 this.new_window ();
             } else if (window == null) {
-                window = this.new_window ();
+                window = this.new_window (); // Will restore documents if required
                 window.show ();
-                window.restore_opened_documents ();
             } else {
                 window.present ();
             }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -298,7 +298,6 @@ namespace Scratch {
 
             welcome_view = new Code.WelcomeView (this);
             document_view = new Scratch.Widgets.DocumentView (this);
-
             // Handle Drag-and-drop for files functionality on welcome screen
             Gtk.TargetEntry target = {"text/uri-list", 0, 0};
             Gtk.drag_dest_set (welcome_view, Gtk.DestDefaults.ALL, {target}, Gdk.DragAction.COPY);
@@ -363,9 +362,10 @@ namespace Scratch {
                 expand = true,
                 width_request = 200
             };
-            content_stack.add (welcome_view);
-            content_stack.add (view_grid);
 
+            content_stack.add (view_grid);  // Must be added first to avoid terminal warnings
+            content_stack.add (welcome_view);
+            content_stack.visible_child = view_grid; // Must be visible while restoring
 
             // Set a proper position for ThinPaned widgets
             int width, height;
@@ -486,6 +486,10 @@ namespace Scratch {
                         }
                     }
                 }
+            }
+
+            if (document_view.is_empty ()) {
+                document_view.empty ();
             }
         }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -455,7 +455,7 @@ namespace Scratch {
             }
         }
 
-        public void restore_opened_documents () {
+        private void restore_opened_documents () {
             if (privacy_settings.get_boolean ("remember-recent-files")) {
                 var doc_infos = settings.get_value ("opened-files");
                 var doc_info_iter = new VariantIter (doc_infos);

--- a/src/Widgets/DocumentView.vala
+++ b/src/Widgets/DocumentView.vala
@@ -47,6 +47,7 @@ public class Scratch.Widgets.DocumentView : Granite.Widgets.DynamicNotebook {
         allow_duplication = true;
         group_name = Constants.PROJECT_NAME;
         this.window = window;
+        expand = true;
     }
 
     construct {


### PR DESCRIPTION
This stops critical warnings like:
`(io.elementary.code:100977): Gtk-CRITICAL **: 13:21:33.248: gtk_box_gadget_distribute: assertion 'size >= 0' failed in GtkNotebook`
when restoring documents at startup.

