### PR TITLE
DocumentView: simplify empty check

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -410,7 +410,7 @@ namespace Scratch {
                 restore_opened_documents ();
             });
 
-            document_view.empty.connect (() => {
+            document_view.request_placeholder.connect (() => {
                 content_stack.visible_child = welcome_view;
                 toolbar.title = app.app_cmd_name;
                 toolbar.document_available (false);
@@ -488,9 +488,7 @@ namespace Scratch {
                 }
             }
 
-            if (document_view.is_empty ()) {
-                document_view.empty ();
-            }
+            document_view.request_placeholder_if_empty ();
         }
 
         private bool on_key_pressed (Gdk.EventKey event) {

--- a/src/Widgets/DocumentView.vala
+++ b/src/Widgets/DocumentView.vala
@@ -20,7 +20,7 @@
 
 public class Scratch.Widgets.DocumentView : Granite.Widgets.DynamicNotebook {
     public signal void document_change (Services.Document? document, DocumentView parent);
-    public signal void empty ();
+    public signal void request_placeholder ();
 
     public unowned MainWindow window { get; construct set; }
 
@@ -277,8 +277,10 @@ public class Scratch.Widgets.DocumentView : Granite.Widgets.DynamicNotebook {
         }
     }
 
-    public bool is_empty () {
-        return docs.length () == 0;
+    public void request_placeholder_if_empty () {
+        if (docs.length () == 0) {
+            request_placeholder ();
+        }
     }
 
     public new void focus () {
@@ -301,10 +303,7 @@ public class Scratch.Widgets.DocumentView : Granite.Widgets.DynamicNotebook {
         doc.source_view.focus_in_event.disconnect (on_focus_in_event);
         doc.source_view.drag_data_received.disconnect (drag_received);
 
-        // Check if the view is empty
-        if (is_empty ()) {
-            empty ();
-        }
+        request_placeholder_if_empty ();
 
         if (!is_closing) {
             save_opened_files ();


### PR DESCRIPTION
There's only two places that we use `if_empty ()` and both of them only use it to signal `empty ()`, so might as well make `if_empty ()` do the thing

* Renamed `if_empty ()` to `request_placeholder_if_empty ()`, which is admittedly a bit verbose. Open to suggestions
* Renamed `empty ()` to `request_placeholder ()`, which is what this signal really does (for the most part)
* Made `request_placeholder_if_empty ()` signal `request_placeholder ()` so that we don't repeat ourselves