### PR TITLE
Get diff gutter colors from SourceStyleScheme if possible

### DIFF
--- a/src/Services/MonitoredRepository.vala
+++ b/src/Services/MonitoredRepository.vala
@@ -22,32 +22,25 @@ namespace Scratch.Services {
     public enum VCStatus {
         NONE,
         ADDED,
-        MODIFIED,
-        DELETED, // Cannot show in normal SourceView but for future use in Diff view?
+        CHANGED,
+        REMOVED, // Cannot show in normal SourceView but for future use in Diff view?
         REPLACES_DELETED, // For unmodified lines that replace deleted lines
         OTHER;
 
-        public Gdk.RGBA to_rgba () {
-            var color = Gdk.RGBA ();
+        public string get_default_rgba_s () {
+
             switch (this) {
                 case ADDED:
-                    color.parse ("#68b723"); //Lime 500
-                    break;
-                case MODIFIED:
-                    color.parse ("#f37329"); //Orange 500
-                    break;
-                case DELETED:
-                    color.parse ("#c6262e"); //Strawberry 500
-                    break;
+                    return "#68b723"; //Lime 500
+                case CHANGED:
+                    return "#f37329"; //Orange 500
+                case REMOVED:
+                    return "#c6262e"; //Strawberry 500
                 case REPLACES_DELETED:
-                    color.parse ("#3689e6"); //Blueberry 500
-                    break;
+                    return "#3689e6"; //Blueberry 500
                 default:
-                    color.parse ("#00000000"); //Transparent
-                    break;
+                    return "#00000000"; //Transparent
             }
-
-            return color;
         }
     }
 
@@ -337,7 +330,7 @@ namespace Scratch.Services {
                 if (line_type == Ggit.DiffLineType.ADDITION) { //Line added
                     prev_additions++;
                     if (prev_deletions >= prev_additions) {
-                        line_status_map.set (new_line_no, VCStatus.MODIFIED);
+                        line_status_map.set (new_line_no, VCStatus.CHANGED);
                         prev_deletions--;
                     } else {
                         line_status_map.set (new_line_no, VCStatus.ADDED);

--- a/src/Services/MonitoredRepository.vala
+++ b/src/Services/MonitoredRepository.vala
@@ -26,22 +26,6 @@ namespace Scratch.Services {
         REMOVED, // Cannot show in normal SourceView but for future use in Diff view?
         REPLACES_DELETED, // For unmodified lines that replace deleted lines
         OTHER;
-
-        public string get_default_rgba_s () {
-
-            switch (this) {
-                case ADDED:
-                    return "#68b723"; //Lime 500
-                case CHANGED:
-                    return "#f37329"; //Orange 500
-                case REMOVED:
-                    return "#c6262e"; //Strawberry 500
-                case REPLACES_DELETED:
-                    return "#3689e6"; //Blueberry 500
-                default:
-                    return "#00000000"; //Transparent
-            }
-        }
     }
 
     public class MonitoredRepository : Object {

--- a/src/Widgets/SourceGutterRenderer.vala
+++ b/src/Widgets/SourceGutterRenderer.vala
@@ -17,14 +17,6 @@ public class Scratch.Widgets.SourceGutterRenderer : Gtk.SourceGutterRenderer {
         }
     }
 
-    public void set_style_scheme (Gtk.SourceStyleScheme? scheme) {
-        update_status_color_map (Services.VCStatus.ADDED, scheme, ADDED_STYLE_ID);
-        update_status_color_map (Services.VCStatus.REMOVED, scheme, REMOVED_STYLE_ID);
-        update_status_color_map (Services.VCStatus.CHANGED, scheme, CHANGED_STYLE_ID);
-        update_status_color_map (Services.VCStatus.REPLACES_DELETED, scheme, REPLACES_DELETED_STYLE_ID);
-        update_status_color_map (Services.VCStatus.NONE, scheme, NONE_STYLE_ID, false);
-    }
-
     static construct {
         fallback_scheme = Gtk.SourceStyleSchemeManager.get_default ().get_scheme ("classic"); // We can assume this always exists
     }
@@ -35,6 +27,14 @@ public class Scratch.Widgets.SourceGutterRenderer : Gtk.SourceGutterRenderer {
 
         set_size (5);
         set_visible (true);
+    }
+
+    public void set_style_scheme (Gtk.SourceStyleScheme? scheme) {
+        update_status_color_map (Services.VCStatus.ADDED, scheme, ADDED_STYLE_ID);
+        update_status_color_map (Services.VCStatus.REMOVED, scheme, REMOVED_STYLE_ID);
+        update_status_color_map (Services.VCStatus.CHANGED, scheme, CHANGED_STYLE_ID);
+        update_status_color_map (Services.VCStatus.REPLACES_DELETED, scheme, REPLACES_DELETED_STYLE_ID);
+        update_status_color_map (Services.VCStatus.NONE, scheme, NONE_STYLE_ID, false);
     }
 
     private void update_status_color_map (Services.VCStatus status,

--- a/src/Widgets/SourceGutterRenderer.vala
+++ b/src/Widgets/SourceGutterRenderer.vala
@@ -1,5 +1,14 @@
 public class Scratch.Widgets.SourceGutterRenderer : Gtk.SourceGutterRenderer {
+    public const string ADDED_STYLE_ID = "diff:added-line";
+    public const string REMOVED_STYLE_ID = "diff:removed-line";
+    public const string CHANGED_STYLE_ID = "diff:changed-line";
+    public const string REPLACES_DELETED_STYLE_ID = "diff:removed-line";
+    public const string NONE_STYLE_ID = "background-pattern";
+
+    private static Gtk.SourceStyleScheme? fallback_scheme;
+
     public Gee.HashMap<int, Services.VCStatus> line_status_map;
+    public Gee.HashMap<Services.VCStatus, Gdk.RGBA?> status_color_map;
     public FolderManager.ProjectFolderItem? project { get; set; default = null; }
     public string workdir_path {
         get {
@@ -7,10 +16,64 @@ public class Scratch.Widgets.SourceGutterRenderer : Gtk.SourceGutterRenderer {
         }
     }
 
+    public void set_style_scheme (Gtk.SourceStyleScheme? scheme) {
+            update_status_color_map (Services.VCStatus.ADDED, get_style (scheme, ADDED_STYLE_ID), true);
+            update_status_color_map (Services.VCStatus.REMOVED, get_style (scheme, REMOVED_STYLE_ID), true);
+            update_status_color_map (Services.VCStatus.CHANGED, get_style (scheme, CHANGED_STYLE_ID), true);
+            update_status_color_map (Services.VCStatus.REPLACES_DELETED, get_style (scheme, REPLACES_DELETED_STYLE_ID), true);
+            update_status_color_map (Services.VCStatus.NONE, get_style (scheme, NONE_STYLE_ID, false), false);
+    }
+
+    static construct {
+        fallback_scheme = Gtk.SourceStyleSchemeManager.get_default ().get_scheme ("classic"); // Assume this always exists?
+    }
+
     construct {
         line_status_map = new Gee.HashMap<int, Services.VCStatus> ();
+        status_color_map = new Gee.HashMap<Services.VCStatus, Gdk.RGBA?> ();
+
         set_size (3);
         set_visible (true);
+    }
+
+    private Gtk.SourceStyle? get_style (Gtk.SourceStyleScheme? scheme, string style_id, bool use_foreground = true) {
+        if (scheme != null) {
+            var style = scheme.get_style (style_id);
+            if (style != null) {
+                if (use_foreground && style.foreground != null || !use_foreground && style.background != null) {
+                    return style;
+                }
+            }
+        }
+
+        if (fallback_scheme != null) {
+            var style = fallback_scheme.get_style (style_id);
+            if (use_foreground && style.foreground != null || !use_foreground && style.background != null) {
+                return style;
+            }
+        }
+
+        return null;
+    }
+
+    private void update_status_color_map (Services.VCStatus status, Gtk.SourceStyle? style, bool use_foreground = true) {
+        var color = Gdk.RGBA ();
+        string? spec = null;
+        if (style != null) {
+            if (use_foreground) {
+                spec = style.foreground;
+            } else {
+                spec = style.background;
+            }
+        }
+
+        if (spec == null) {
+            spec = status.get_default_rgba_s ();
+        }
+
+        color.parse (spec);
+        status_color_map.unset (status);
+        status_color_map.set (status, color);
     }
 
     public override void draw (Cairo.Context cr,
@@ -23,9 +86,14 @@ public class Scratch.Widgets.SourceGutterRenderer : Gtk.SourceGutterRenderer {
         //Gutter and diff lines numbers start at one, source lines start at 0
         var gutter_line_no = start.get_line () + 1;
         if (line_status_map.has_key (gutter_line_no)) {
-            set_background (line_status_map.get (gutter_line_no).to_rgba ());
+            var status = line_status_map [gutter_line_no];
+            if (status_color_map.has_key (status)) {
+                var color = status_color_map[status];
+                set_background (color);
+            }
+            set_background (status_color_map[line_status_map[gutter_line_no]]);
         } else {
-            set_background (Services.VCStatus.NONE.to_rgba ());
+            set_background (status_color_map [Services.VCStatus.NONE]);
         }
 
         base.draw (cr, bg, area, start, end, state);

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -79,6 +79,10 @@ namespace Scratch.Widgets {
         }
 
         construct {
+            // Make the gutter renderer and insert into the left side of the source view.
+            git_diff_gutter_renderer = new SourceGutterRenderer ();
+            get_gutter (Gtk.TextWindowType.LEFT).insert (git_diff_gutter_renderer, 1);
+
             space_drawer.enable_matrix = true;
 
             expand = true;
@@ -181,10 +185,6 @@ namespace Scratch.Widgets {
                     });
                 }
             });
-
-            // Make the gutter renderer and insert into the left side of the source view.
-            git_diff_gutter_renderer = new SourceGutterRenderer ();
-            get_gutter (Gtk.TextWindowType.LEFT).insert (git_diff_gutter_renderer, 1);
 
             notify["project"].connect (() => {
                 //Assuming project will not change again
@@ -292,7 +292,9 @@ namespace Scratch.Widgets {
                 critical (e.message);
             }
 
-            source_buffer.style_scheme = style_scheme_manager.get_scheme (Scratch.settings.get_string ("style-scheme"));
+            var scheme = style_scheme_manager.get_scheme (Scratch.settings.get_string ("style-scheme"));
+            source_buffer.style_scheme = scheme ?? style_scheme_manager.get_scheme ("classic");
+            git_diff_gutter_renderer.set_style_scheme (source_buffer.style_scheme);
             style_changed (source_buffer.style_scheme);
         }
 


### PR DESCRIPTION
This PR attempts to get colors defined in the current or fallback SourceStyleScheme for ids "diff:added-line" etc otherwise use hard-coded colors.

Unfortunately of the three styles built into Code, only "classic" contains the relevant style ids and none contain a style explicitly for unchanged lines that replace lines that have been deleted, so the gutter colors do not currently actually change when the style is changed.

Not sure whether it is worth using a fallback SourceStyleScheme or should just immediately fallback to hard-coded colors.