### PR TITLE
Style color buttons from theme data

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -16,43 +16,6 @@
 * Boston, MA 02110-1301 USA
 */
 
-.color-button radio,
-.color-button radio:checked {
-    border-color: alpha (#000, 0.3);
-    box-shadow:
-        inset 0 1px 0 0 alpha (@inset_dark_color, 0.7),
-        inset 0 0 0 1px alpha (@inset_dark_color, 0.3),
-        0 1px 0 0 alpha (@bg_highlight_color, 0.3);
-    padding: 10px;
-    -gtk-icon-shadow: none;
-}
-
-.color-button radio:focus {
-    border-color: @colorAccent;
-    box-shadow:
-        inset 0 1px 0 0 alpha (@inset_dark_color, 0.7),
-        inset 0 0 0 1px alpha (@inset_dark_color, 0.3),
-        inset 0 0 0 1px alpha (@bg_highlight_color, 0.05),
-        0 1px 0 0 alpha (@bg_highlight_color, 0.3),
-        0 0 0 1px alpha (@colorAccent, 0.25);
-}
-
-.color-dark radio {
-    background: #252E32;
-    border-color: #151B1C;
-    color: #fff;
-}
-
-.color-light radio {
-    background: #fdf6e3;
-    color: #4d4d4d;
-}
-
-.color-white radio {
-    background: #fff;
-    color: #000;
-}
-
 textview.scrubber {
     border: 0;
 }

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -129,27 +129,15 @@ namespace Scratch.Widgets {
 
             var color_button_white = new Gtk.RadioButton.from_widget (color_button_none);
             color_button_white.halign = Gtk.Align.CENTER;
-            color_button_white.tooltip_text = _("High Contrast");
-
-            var color_button_white_context = color_button_white.get_style_context ();
-            color_button_white_context.add_class ("color-button");
-            color_button_white_context.add_class ("color-white");
+            style_color_button (color_button_white, STYLE_SCHEME_HIGH_CONTRAST);
 
             var color_button_light = new Gtk.RadioButton.from_widget (color_button_none);
             color_button_light.halign = Gtk.Align.CENTER;
-            color_button_light.tooltip_text = _("Solarized Light");
-
-            var color_button_light_context = color_button_light.get_style_context ();
-            color_button_light_context.add_class ("color-button");
-            color_button_light_context.add_class ("color-light");
+            style_color_button (color_button_light, STYLE_SCHEME_LIGHT);
 
             var color_button_dark = new Gtk.RadioButton.from_widget (color_button_none);
             color_button_dark.halign = Gtk.Align.CENTER;
-            color_button_dark.tooltip_text = _("Solarized Dark");
-
-            var color_button_dark_context = color_button_dark.get_style_context ();
-            color_button_dark_context.add_class ("color-button");
-            color_button_dark_context.add_class ("color-dark");
+            style_color_button (color_button_dark, STYLE_SCHEME_DARK);
 
             var menu_separator = new Gtk.Separator (Gtk.Orientation.HORIZONTAL);
             menu_separator.margin_top = 12;
@@ -257,6 +245,49 @@ namespace Scratch.Widgets {
                 Scratch.settings.set_string ("style-scheme", STYLE_SCHEME_HIGH_CONTRAST);
                 gtk_settings.gtk_application_prefer_dark_theme = false;
             });
+        }
+
+        private void style_color_button (Gtk.Widget color_button, string style_id) {
+            string background = "#FFF";
+            string foreground = "#333";
+
+            var sssm = Gtk.SourceStyleSchemeManager.get_default ();
+            if (style_id in sssm.scheme_ids) {
+                var scheme = sssm.get_scheme (style_id);
+                color_button.tooltip_text = scheme.name;
+
+                var background_style = scheme.get_style ("background-pattern");
+                var foreground_style = scheme.get_style ("text");
+
+                if (background_style != null && background_style.background_set && !("rgba" in background_style.background)) {
+                    background = background_style.background;
+                }
+
+                if (foreground_style != null && foreground_style.foreground_set) {
+                    foreground = foreground_style.foreground;
+                }
+            }
+
+            var style_css = """
+                .color-button radio {
+                    background-color: %s;
+                    color: %s;
+                    padding: 10px;
+                    -gtk-icon-shadow: none;
+                }
+            """.printf (background, foreground);
+
+            var css_provider = new Gtk.CssProvider ();
+
+            try {
+                css_provider.load_from_data (style_css);
+            } catch (Error e) {
+                critical ("Unable to style color button: %s", e.message);
+            }
+
+            unowned var style_context = color_button.get_style_context ();
+            style_context.add_class (Granite.STYLE_CLASS_COLOR_BUTTON);
+            style_context.add_provider (css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
         }
 
         private void on_share_menu_changed () {


### PR DESCRIPTION
Based on some work David started in #434 

This styles (and tooltips) color buttons from theme data instead of hardcoding it. There's been some work in the stylesheet to make color buttons work without a ton of custom CSS

This doesn't attempt to make the color buttons customizable, but it's a step in that direction