### PR TITLE
Ensure Welcome buttons work when shown at start up

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -488,7 +488,10 @@ namespace Scratch {
                 }
             }
 
-            document_view.request_placeholder_if_empty ();
+            Idle.add (() => {
+                document_view.request_placeholder_if_empty ();
+                return Source.REMOVE;
+            });
         }
 
         private bool on_key_pressed (Gdk.EventKey event) {


### PR DESCRIPTION
Fixes #1065

Emit placeholder_request signal in Idle loop when inside restore docs signal handler.

Possibly an obscure side effect of #1060