### PR TITLE
l10n: Correctly setup the locales

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -67,6 +67,11 @@ namespace Scratch {
             settings = new GLib.Settings (Constants.PROJECT_NAME + ".settings");
             service_settings = new GLib.Settings (Constants.PROJECT_NAME + ".services");
             privacy_settings = new GLib.Settings ("org.gnome.desktop.privacy");
+
+            GLib.Intl.setlocale (LocaleCategory.ALL, "");
+            GLib.Intl.bindtextdomain (Constants.GETTEXT_PACKAGE, Constants.LOCALEDIR);
+            GLib.Intl.bind_textdomain_codeset (Constants.GETTEXT_PACKAGE, "UTF-8");
+            GLib.Intl.textdomain (Constants.GETTEXT_PACKAGE);
         }
 
         public override int handle_local_options (VariantDict options) {

--- a/src/config.vala.in
+++ b/src/config.vala.in
@@ -5,4 +5,5 @@ namespace Constants {
     public const string PLUGINDIR = @PLUGINDIR@;
     public const string INSTALL_PREFIX = @PREFIX@;
     public const string DATADIR = @DATADIR@;
+    public const string LOCALEDIR = @LOCALEDIR@;
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -5,6 +5,7 @@ conf_data.set_quoted('VERSION', meson.project_version())
 conf_data.set_quoted('PREFIX', get_option('prefix'))
 conf_data.set_quoted('PLUGINDIR', pluginsdir)
 conf_data.set_quoted('DATADIR', join_paths (get_option('prefix'), get_option('datadir')))
+conf_data.set_quoted('LOCALEDIR', join_paths (get_option('prefix'), get_option('localedir')))
 config_header = configure_file(
     input : 'config.vala.in',
     output : 'config.vala',


### PR DESCRIPTION
Provides the directory where the locales are actually installed.

We are [packaging this](https://github.com/NixOS/nixpkgs/pull/130380#issuecomment-895720580) in NixOS, and due to NixOS 's special `localedir`, we cannot apply the translations without this patch.

Thanks in advance for reviewing this :-)