### PR TITLE
Fix crash when creating new window from tab drop

### DIFF
--- a/src/Widgets/DocumentView.vala
+++ b/src/Widgets/DocumentView.vala
@@ -288,7 +288,7 @@ public class Scratch.Widgets.DocumentView : Granite.Widgets.DynamicNotebook {
     }
 
     private bool find_unique_path (File f1, File f2, out string? path1, out string? path2) {
-        if (f1 == f2) {
+        if (f1.equal (f2)) {
             path1 = null;
             path2 = null;
             return false;


### PR DESCRIPTION
Fix #1095 

There's still some strange situations where the new window has the same file opened twice, but at least it does not crash anymore. I'll try finding a reproducible test case later. 