### PR TITLE
Distinguish projects with same folder name

### DIFF
--- a/src/FolderManager/FileView.vala
+++ b/src/FolderManager/FileView.vala
@@ -196,6 +196,27 @@ namespace Scratch.FolderManager {
             }
         }
 
+
+    private void rename_items_with_same_name (Item it) {
+        string it_name = it.file.name;
+        foreach (var chi in this.root.children) {
+            string new_other_item_name, new_it_name;
+            var other_item = chi as ProjectFolderItem;
+
+            if (Utils.find_unique_path (it.file.file, other_item.file.file, out new_it_name, out new_other_item_name)) {
+                if (it_name.length < new_it_name.length) {
+                    it_name = new_it_name;
+                }
+
+                if (other_item.name.length < new_other_item_name.length) {
+                    other_item.name = new_other_item_name;
+                }
+            }
+
+        }
+        it.name = it_name;
+    }
+
         private void add_folder (File folder, bool expand) {
             if (is_open (folder)) {
                 warning ("Folder '%s' is already open.", folder.path);
@@ -207,11 +228,18 @@ namespace Scratch.FolderManager {
 
             var folder_root = new ProjectFolderItem (folder, this); // Constructor adds project to GitManager
             this.root.add (folder_root);
+            rename_items_with_same_name (folder_root);
 
             folder_root.expanded = expand;
             folder_root.closed.connect (() => {
                 close_all_docs_from_path (folder_root.file.path);
                 root.remove (folder_root);
+                foreach (var _folder in root.children) {
+                    var children_folder = _folder as ProjectFolderItem;
+                    if (children_folder.name != children_folder.file.name) {
+                        rename_items_with_same_name (children_folder);
+                    }
+                }
                 Scratch.Services.GitManager.get_instance ().remove_project (folder_root.file.file);
                 write_settings ();
             });

--- a/src/FolderManager/FileView.vala
+++ b/src/FolderManager/FileView.vala
@@ -240,7 +240,7 @@ namespace Scratch.FolderManager {
                         rename_items_with_same_name (children_folder);
                     }
                 }
-                Scratch.Services.GitManager.get_instance ().remove_project (folder_root.file.file);
+                Scratch.Services.GitManager.get_instance ().remove_project (folder_root);
                 write_settings ();
             });
 
@@ -249,7 +249,7 @@ namespace Scratch.FolderManager {
                     var project_folder_item = (ProjectFolderItem)child;
                     if (project_folder_item != folder_root) {
                         root.remove (project_folder_item);
-                        Scratch.Services.GitManager.get_instance ().remove_project (project_folder_item.file.file);
+                        Scratch.Services.GitManager.get_instance ().remove_project (project_folder_item);
                     }
                 }
 

--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -55,21 +55,26 @@ namespace Scratch.FolderManager {
             modified_icon = new ThemedIcon ("user-away");
         }
 
+        private void branch_or_name_changed () {
+            if (monitored_repo != null) {
+                //As SourceList items are not widgets we have to use markup to change appearance of text.
+                if (monitored_repo.head_is_branch) {
+                    markup = "%s <span size='small' weight='normal'>%s</span>".printf (
+                        name, monitored_repo.branch_name
+                    );
+                } else { //Distinguish detached heads visually
+                    markup = "%s <span size='small' weight='normal' style='italic'>%s</span>".printf (
+                        name, monitored_repo.branch_name
+                    );
+                }
+            }
+        }
+
         construct {
             monitored_repo = Scratch.Services.GitManager.get_instance ().add_project (this);
+            notify["name"].connect (branch_or_name_changed);
             if (monitored_repo != null) {
-                monitored_repo.branch_changed.connect (() => {
-                    //As SourceList items are not widgets we have to use markup to change appearance of text.
-                    if (monitored_repo.head_is_branch) {
-                        markup = "%s <span size='small' weight='normal'>%s</span>".printf (
-                            name, monitored_repo.branch_name
-                        );
-                    } else { //Distinguish detached heads visually
-                        markup = "%s <span size='small' weight='normal' style='italic'>%s</span>".printf (
-                            name, monitored_repo.branch_name
-                        );
-                    }
-                });
+                monitored_repo.branch_changed.connect (branch_or_name_changed);
                 monitored_repo.ignored_changed.connect ((deprioritize_git_ignored));
                 monitored_repo.file_status_change.connect (() => update_item_status (null));
                 monitored_repo.update_status_map ();

--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -62,11 +62,11 @@ namespace Scratch.FolderManager {
                     //As SourceList items are not widgets we have to use markup to change appearance of text.
                     if (monitored_repo.head_is_branch) {
                         markup = "%s <span size='small' weight='normal'>%s</span>".printf (
-                            file.name, monitored_repo.branch_name
+                            name, monitored_repo.branch_name
                         );
                     } else { //Distinguish detached heads visually
                         markup = "%s <span size='small' weight='normal' style='italic'>%s</span>".printf (
-                            file.name, monitored_repo.branch_name
+                            name, monitored_repo.branch_name
                         );
                     }
                 });

--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -56,7 +56,7 @@ namespace Scratch.FolderManager {
         }
 
         construct {
-            monitored_repo = Scratch.Services.GitManager.get_instance ().add_project (file.file);
+            monitored_repo = Scratch.Services.GitManager.get_instance ().add_project (this);
             if (monitored_repo != null) {
                 monitored_repo.branch_changed.connect (() => {
                     //As SourceList items are not widgets we have to use markup to change appearance of text.

--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -275,9 +275,14 @@ namespace Scratch.FolderManager {
             bool case_sensitive = false;
             Regex? pattern = null;
 
+            var folder_name = start_folder.get_basename ();
+            if (this.file.file.equal (start_folder)) {
+                folder_name = name;
+            }
+
             var dialog = new Scratch.Dialogs.GlobalSearchDialog (
                 null,
-                start_folder.get_basename (),
+                folder_name,
                 monitored_repo != null && monitored_repo.git_repo != null
             ) {
                 case_sensitive = case_sensitive,

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -142,4 +142,25 @@ namespace Scratch.Utils {
             return path;
         }
     }
+
+    public bool find_unique_path (File f1, File f2, out string? path1, out string? path2) {
+        if (f1.equal (f2)) {
+            path1 = null;
+            path2 = null;
+            return false;
+        }
+
+        var f1_parent = f1.get_parent ();
+        var f2_parent = f2.get_parent ();
+
+        while (f1_parent.get_relative_path (f1) == f2_parent.get_relative_path (f2)) {
+            f1_parent = f1_parent.get_parent ();
+            f2_parent = f2_parent.get_parent ();
+        }
+
+        path1 = f1_parent.get_relative_path (f1);
+        path2 = f2_parent.get_relative_path (f2);
+        return true;
+    }
+
 }

--- a/src/Widgets/ChooseProjectButton.vala
+++ b/src/Widgets/ChooseProjectButton.vala
@@ -109,8 +109,11 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
     }
 
     private Gtk.Widget create_project_row (GLib.Object object) {
-        unowned var project_folder = (File) object;
-        var project_row = new ProjectRow (project_folder.get_path ());
+        unowned var project_folder = (Scratch.FolderManager.ProjectFolderItem) object;
+
+        var project_row = new ProjectRow (project_folder.name);
+        project_folder.bind_property("name", project_row, "display-name", BindingFlags.DEFAULT);
+
         if (last_entry != null) {
             project_row.project_radio.join_group (last_entry.project_radio);
         }
@@ -149,6 +152,8 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
             }
         }
 
+        public string display_name {get;set;}
+
         public Gtk.RadioButton project_radio { get; construct; }
 
         public ProjectRow (string project_path) {
@@ -163,6 +168,9 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
 
         construct {
             project_radio = new Gtk.RadioButton.with_label (null, project_name);
+            notify["display-name"].connect (() => {
+                project_radio.label = display_name;
+            });
             add (project_radio);
             show_all ();
 

--- a/src/Widgets/ChooseProjectButton.vala
+++ b/src/Widgets/ChooseProjectButton.vala
@@ -111,8 +111,8 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
     private Gtk.Widget create_project_row (GLib.Object object) {
         unowned var project_folder = (Scratch.FolderManager.ProjectFolderItem) object;
 
-        var project_row = new ProjectRow (project_folder.name);
-        project_folder.bind_property("name", project_row, "display-name", BindingFlags.DEFAULT);
+        var project_row = new ProjectRow (project_folder.file.file.get_path ());
+        project_folder.bind_property("name", project_row, "project-name", BindingFlags.DEFAULT | BindingFlags.SYNC_CREATE);
 
         if (last_entry != null) {
             project_row.project_radio.join_group (last_entry.project_radio);
@@ -146,13 +146,7 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
     public class ProjectRow : Gtk.ListBoxRow {
         public bool active { get; set; }
         public string project_path { get; construct; }
-        public string project_name {
-            owned get {
-                return Path.get_basename (project_path);
-            }
-        }
-
-        public string display_name {get;set;}
+        public string project_name { get; set; }
 
         public Gtk.RadioButton project_radio { get; construct; }
 
@@ -160,6 +154,7 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
             Object (
                 project_path: project_path
             );
+            project_name = Path.get_basename (project_path);
         }
 
         class construct {
@@ -168,8 +163,8 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
 
         construct {
             project_radio = new Gtk.RadioButton.with_label (null, project_name);
-            notify["display-name"].connect (() => {
-                project_radio.label = display_name;
+            notify["project-name"].connect (() => {
+                project_radio.label = project_name;
             });
             add (project_radio);
             show_all ();

--- a/src/Widgets/DocumentView.vala
+++ b/src/Widgets/DocumentView.vala
@@ -287,32 +287,13 @@ public class Scratch.Widgets.DocumentView : Granite.Widgets.DynamicNotebook {
         current_document.focus ();
     }
 
-    private bool find_unique_path (File f1, File f2, out string? path1, out string? path2) {
-        if (f1.equal (f2)) {
-            path1 = null;
-            path2 = null;
-            return false;
-        }
-
-        var f1_parent = f1.get_parent ();
-        var f2_parent = f2.get_parent ();
-
-        while (f1_parent.get_relative_path (f1) == f2_parent.get_relative_path (f2)) {
-            f1_parent = f1_parent.get_parent ();
-            f2_parent = f2_parent.get_parent ();
-        }
-
-        path1 = f1_parent.get_relative_path (f1);
-        path2 = f2_parent.get_relative_path (f2);
-        return true;
-    }
 
     private void rename_tabs_with_same_title (Services.Document doc) {
         string doc_tab_name = doc.file.get_basename ();
         foreach (var d in docs) {
             string new_tabname_doc, new_tabname_d;
 
-            if (find_unique_path (d.file, doc.file, out new_tabname_d, out new_tabname_doc)) {
+            if (Utils.find_unique_path (d.file, doc.file, out new_tabname_d, out new_tabname_doc)) {
                 if (d.label.length < new_tabname_d.length) {
                     d.tab_name = new_tabname_d;
                 }


### PR DESCRIPTION
Fix #1021 

![code-projects-same-name](https://user-images.githubusercontent.com/221446/136123532-a0845ec4-f7eb-4c2c-9c31-96967ebbda16.gif)

This one turned out larger than expected because the folder name was being used in many places and the code was passing GLib.File instead of a ProjectFolderItem. This addresses the display name in global search dialog, project chooser buttton and file view.  