### PR TITLE
GlobalSearchDialog: set active_window as transient parent

### DIFF
--- a/src/Dialogs/GlobalSearchDialog.vala
+++ b/src/Dialogs/GlobalSearchDialog.vala
@@ -49,6 +49,7 @@ public class Scratch.Dialogs.GlobalSearchDialog : Granite.MessageDialog {
 
     public GlobalSearchDialog (string folder_name, bool is_repo) {
         Object (
+            transient_for: ((Gtk.Application) GLib.Application.get_default ()).active_window,
             folder_name: folder_name,
             is_repo: is_repo,
             image_icon: new ThemedIcon ("edit-find")
@@ -102,8 +103,6 @@ public class Scratch.Dialogs.GlobalSearchDialog : Granite.MessageDialog {
         search_button.can_default = true;
         search_button.has_default = true;
         search_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
-
-        transient_for = ((Gtk.Application) GLib.Application.get_default ()).active_window;
 
         search_term_entry.bind_property (
             "is-valid", search_button, "sensitive", BindingFlags.DEFAULT | BindingFlags.SYNC_CREATE

--- a/src/Dialogs/GlobalSearchDialog.vala
+++ b/src/Dialogs/GlobalSearchDialog.vala
@@ -47,9 +47,8 @@ public class Scratch.Dialogs.GlobalSearchDialog : Granite.MessageDialog {
         }
     }
 
-    public GlobalSearchDialog (Gtk.Window? parent, string folder_name, bool is_repo) {
+    public GlobalSearchDialog (string folder_name, bool is_repo) {
         Object (
-            transient_for: parent,
             folder_name: folder_name,
             is_repo: is_repo,
             image_icon: new ThemedIcon ("edit-find")
@@ -103,6 +102,8 @@ public class Scratch.Dialogs.GlobalSearchDialog : Granite.MessageDialog {
         search_button.can_default = true;
         search_button.has_default = true;
         search_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
+
+        transient_for = ((Gtk.Application) GLib.Application.get_default ()).active_window;
 
         search_term_entry.bind_property (
             "is-valid", search_button, "sensitive", BindingFlags.DEFAULT | BindingFlags.SYNC_CREATE

--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -281,7 +281,6 @@ namespace Scratch.FolderManager {
             }
 
             var dialog = new Scratch.Dialogs.GlobalSearchDialog (
-                null,
                 folder_name,
                 monitored_repo != null && monitored_repo.git_repo != null
             ) {


### PR DESCRIPTION
Fixes #1127

We can't `get_toplevel ()` from `ProjectFolderItem` so it passes null. We can instead get the active window from Gtk.Application