### PR TITLE
Document: Set Filechooser Dialog as Transient for Main Window

### DIFF
--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -493,7 +493,7 @@ namespace Scratch.Services {
 
             var file_chooser = new Gtk.FileChooserNative (
                 _("Save File"),
-                null,
+                (Gtk.Window) this.get_toplevel (),
                 Gtk.FileChooserAction.SAVE,
                 _("Save"),
                 _("Cancel")


### PR DESCRIPTION
This was the only location where the Gtk.FileChooserNative wasn't created with a parent window, fixes https://github.com/elementary/files/pull/1899#issuecomment-973996508