### PR TITLE
863: Set window title to title of currently focused document.

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -413,7 +413,7 @@ namespace Scratch {
 
             document_view.request_placeholder.connect (() => {
                 content_stack.visible_child = welcome_view;
-                toolbar.title = app.app_cmd_name;
+                title = _("Code");
                 toolbar.document_available (false);
                 set_widgets_sensitive (false);
             });

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -429,7 +429,7 @@ namespace Scratch {
 
                 search_bar.set_text_view (doc.source_view);
                 // Update MainWindow title
-                toolbar.title = doc.get_basename ();
+                title = doc.get_basename ();
 
                 if (doc != null) {
                     toolbar.set_document_focus (doc);


### PR DESCRIPTION
Resolves #863 

Multitasking uses the window title for the title shown in the multitasking view, not the toolbar title as we had set. This changes that assignment so we update the window title when we move between documents.