### PR TITLE
Remove hyphen and underscore from delimiters in word completion plugin

### DIFF
--- a/plugins/word-completion/engine.vala
+++ b/plugins/word-completion/engine.vala
@@ -22,7 +22,7 @@ public class Euclide.Completion.Parser : GLib.Object {
     public const int MINIMUM_WORD_LENGTH = 1;
     public const int MAX_TOKENS = 1000000;
 
-    public const string DELIMITERS = " .,;:?{}[]()0123456789+-=&|-<>*\\/\n\t\'\"";
+    public const string DELIMITERS = " .,;:?{}[]()0123456789+=&|<>*\\/\n\t\'\"";
     public bool is_delimiter (unichar c) {
         return DELIMITERS.index_of_char (c) >= 0;
     }


### PR DESCRIPTION
Fixes #1147