### PR TITLE
Meson: remove positional arguments from i18n.merge_file

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -64,7 +64,6 @@ if get_option ('have_pkexec')
     )
 
     i18n.merge_file(
-        'policy',
         input: policy_in,
         output: meson.project_name() + '.policy',
         po_dir: join_paths(meson.source_root (), 'po', 'extra'),


### PR DESCRIPTION
`i18n.merge_file` has been ignoring positional arguments for a time and explicitly rejects with error since meson 0.60.0.