### PR TITLE
Search-bar enhancements (Regex Support)

### DIFF
--- a/src/Widgets/SearchBar.vala
+++ b/src/Widgets/SearchBar.vala
@@ -24,15 +24,9 @@ namespace Scratch.Widgets {
 
         private Gtk.Button tool_arrow_up;
         private Gtk.Button tool_arrow_down;
-
-        /**
-         * Is the search cyclic? e.g., when you are at the bottom, if you press
-         * "Down", it will go at the start of the file to search for the content
-         * of the search entry.
-         **/
-
+        public Gtk.ToggleButton tool_cycle_search { get; construct; }
         private Gtk.ToggleButton case_sensitive_button;
-        public Gtk.ToggleButton tool_cycle_search {get; construct;}
+        private Gtk.ToggleButton tool_regex_button;
 
         public Gtk.SearchEntry search_entry;
         public Gtk.SearchEntry replace_entry;
@@ -53,7 +47,7 @@ namespace Scratch.Widgets {
         /**
          * Create a new SearchBar widget.
          *
-         * following actions : Fetch, ShowGoTo, ShowRreplace, or null.
+         * following actions : Fetch, ShowGoTo, ShowReplace, or null.
          **/
         public SearchBar (MainWindow window) {
             Object (window: window);
@@ -97,6 +91,7 @@ namespace Scratch.Widgets {
                 image = new Gtk.Image.from_icon_name ("media-playlist-repeat-symbolic", Gtk.IconSize.SMALL_TOOLBAR),
                 tooltip_text = _("Cyclic Search")
             };
+            tool_cycle_search.clicked.connect (on_search_entry_text_changed);
 
             case_sensitive_button = new Gtk.ToggleButton () {
                 image = new Gtk.Image.from_icon_name ("font-select-symbolic", Gtk.IconSize.SMALL_TOOLBAR)
@@ -113,6 +108,12 @@ namespace Scratch.Widgets {
             );
             case_sensitive_button.clicked.connect (on_search_entry_text_changed);
 
+            tool_regex_button = new Gtk.ToggleButton () {
+                image = new Gtk.Image.from_icon_name ("text-html-symbolic", Gtk.IconSize.SMALL_TOOLBAR),
+                tooltip_text = _("Use regular expressions")
+            };
+            tool_regex_button.clicked.connect (on_search_entry_text_changed);
+
             var search_grid = new Gtk.Grid ();
             search_grid.margin = 3;
             search_grid.get_style_context ().add_class (Gtk.STYLE_CLASS_LINKED);
@@ -122,6 +123,7 @@ namespace Scratch.Widgets {
             search_grid.add (tool_arrow_up);
             search_grid.add (tool_cycle_search);
             search_grid.add (case_sensitive_button);
+            search_grid.add (tool_regex_button);
 
             var search_flow_box_child = new Gtk.FlowBoxChild ();
             search_flow_box_child.can_focus = false;
@@ -186,27 +188,18 @@ namespace Scratch.Widgets {
 
             this.text_view = text_view;
             this.text_buffer = text_view.get_buffer ();
+            this.text_buffer.changed.connect (on_text_buffer_changed);
             this.search_context = new Gtk.SourceSearchContext (text_buffer as Gtk.SourceBuffer, null);
             search_context.settings.wrap_around = tool_cycle_search.active;
-            search_context.settings.regex_enabled = false;
+            search_context.settings.regex_enabled = tool_regex_button.active;
             search_context.settings.search_text = search_entry.text;
+        }
 
-            // Determine the search entry color
-            bool found = (search_entry.text != "" && search_entry.text in this.text_buffer.text);
-            if (found) {
-                tool_arrow_down.sensitive = true;
-                tool_arrow_up.sensitive = false;
-                search_entry.get_style_context ().remove_class (Gtk.STYLE_CLASS_ERROR);
-                search_entry.primary_icon_name = "edit-find-symbolic";
-            } else {
-                if (search_entry.text != "") {
-                    search_entry.get_style_context ().add_class (Gtk.STYLE_CLASS_ERROR);
-                    search_entry.primary_icon_name = "dialog-error-symbolic";
-                }
-
-                tool_arrow_down.sensitive = false;
-                tool_arrow_up.sensitive = false;
-            }
+        private void on_text_buffer_changed () {
+            update_search_occurence_label ();
+            update_tool_arrows ();
+            bool matches = search ();
+            update_replace_tool_sensitivities (search_entry.text, matches);
         }
 
         private void on_replace_entry_activate () {
@@ -224,7 +217,7 @@ namespace Scratch.Widgets {
                     search_context.replace (start_iter, end_iter, replace_string, replace_string.length);
                     bool matches = search ();
                     update_replace_tool_sensitivities (search_entry.text, matches);
-                    update_tool_arrows (search_entry.text);
+                    update_tool_arrows ();
                     update_search_occurence_label ();
                     debug ("Replace \"%s\" with \"%s\"", search_entry.text, replace_entry.text);
                 } catch (Error e) {
@@ -243,7 +236,7 @@ namespace Scratch.Widgets {
             this.window.get_current_document ().toggle_changed_handlers (false);
             try {
                 search_context.replace_all (replace_string, replace_string.length);
-                update_tool_arrows (search_entry.text);
+                update_tool_arrows ();
                 update_search_occurence_label ();
                 update_replace_tool_sensitivities (search_entry.text, false);
             } catch (Error e) {
@@ -262,10 +255,12 @@ namespace Scratch.Widgets {
             search_context.settings.search_text = search_string;
             bool case_sensitive = is_case_sensitive (search_string);
             search_context.settings.case_sensitive = case_sensitive;
+            search_context.settings.regex_enabled = tool_regex_button.active;
 
             bool matches = search ();
             update_replace_tool_sensitivities (search_entry.text, matches);
-            update_tool_arrows (search_entry.text);
+            update_search_occurence_label ();
+            update_tool_arrows ();
 
             if (search_entry.text == "") {
                 search_empty ();
@@ -282,14 +277,11 @@ namespace Scratch.Widgets {
                 return false;
             }
 
-            Gtk.TextIter? start_iter, end_iter;
-            text_buffer.get_iter_at_offset (out start_iter, text_buffer.cursor_position);
+            Gtk.TextIter? iter, start_iter, end_iter;
+            text_buffer.get_iter_at_offset (out iter, text_buffer.cursor_position);
+            end_iter = iter;
 
-            end_iter = start_iter;
-            bool case_sensitive = is_case_sensitive (search_entry.text);
-            bool found = start_iter.forward_search (search_entry.text,
-                                                    case_sensitive ? 0 : Gtk.TextSearchFlags.CASE_INSENSITIVE,
-                                                    out start_iter, out end_iter, null);
+            bool found = search_context.forward (iter, out start_iter, out end_iter, null);
             if (found) {
                 search_entry.get_style_context ().remove_class (Gtk.STYLE_CLASS_ERROR);
                 search_entry.primary_icon_name = "edit-find-symbolic";
@@ -307,7 +299,6 @@ namespace Scratch.Widgets {
         public bool search () {
             /* So, first, let's check we can really search something. */
             string search_string = search_entry.text;
-            search_context.highlight = false;
             search_context.highlight = false;
 
             if (text_buffer == null || text_buffer.text == "" || search_string == "") {
@@ -383,14 +374,13 @@ namespace Scratch.Widgets {
             /* Get selection range */
             Gtk.TextIter? start_iter, end_iter;
             if (text_buffer != null) {
-                string search_string = search_entry.text;
                 text_buffer.get_selection_bounds (out start_iter, out end_iter);
                 if (!search_for_iter_backward (start_iter, out end_iter) && tool_cycle_search.active) {
                     text_buffer.get_end_iter (out start_iter);
                     search_for_iter_backward (start_iter, out end_iter);
                 }
 
-                update_tool_arrows (search_string);
+                update_tool_arrows ();
                 update_search_occurence_label ();
             }
         }
@@ -399,26 +389,31 @@ namespace Scratch.Widgets {
             /* Get selection range */
             Gtk.TextIter? start_iter, end_iter, end_iter_tmp;
             if (text_buffer != null) {
-                string search_string = search_entry.text;
                 text_buffer.get_selection_bounds (out start_iter, out end_iter);
                 if (!search_for_iter (end_iter, out end_iter_tmp) && tool_cycle_search.active) {
                     text_buffer.get_start_iter (out start_iter);
                     search_for_iter (start_iter, out end_iter);
                 }
 
-                update_tool_arrows (search_string);
+                update_tool_arrows ();
                 update_search_occurence_label ();
             }
         }
 
-        private void update_tool_arrows (string search_string) {
+        private void update_tool_arrows () {
             /* We don't need to compute the sensitive states of these widgets
              * if they don't exist. */
-            if (tool_arrow_up != null && tool_arrow_down != null) {
-                if (search_string == "") {
+             if (tool_arrow_up != null && tool_arrow_down != null) {
+                if (search_entry.text == "") {
                     tool_arrow_up.sensitive = false;
                     tool_arrow_down.sensitive = false;
                 } else if (text_buffer != null) {
+                    if (tool_cycle_search.active) {
+                        tool_arrow_down.sensitive = true;
+                        tool_arrow_up.sensitive = true;
+                        return;
+                    }
+
                     Gtk.TextIter? start_iter, end_iter;
                     Gtk.TextIter? tmp_start_iter, tmp_end_iter;
 
@@ -525,18 +520,14 @@ namespace Scratch.Widgets {
 
             update_search_label_timeout_id = Timeout.add (100, () => {
                 update_search_label_timeout_id = 0;
-                Gtk.TextIter? start_iter, end_iter;
-                text_buffer.get_iter_at_offset (out start_iter, text_buffer.cursor_position);
-
-                end_iter = start_iter;
-                bool case_sensitive = is_case_sensitive (search_entry.text);
-                start_iter.forward_search (search_entry.text,
-                                            case_sensitive ? 0 : Gtk.TextSearchFlags.CASE_INSENSITIVE,
-                                            out start_iter, out end_iter, null);
+                Gtk.TextIter? iter, start_iter, end_iter;
+                text_buffer.get_iter_at_offset (out iter, text_buffer.cursor_position);
 
                 int count_of_search = search_context.get_occurrences_count ();
+
                 int location_of_search = -1;
-                if (count_of_search > 0) {
+                bool found = search_context.forward (iter, out start_iter, out end_iter, null);
+                if (count_of_search > 0 && found) {
                     location_of_search = search_context.get_occurrence_position (start_iter, end_iter);
                 }
 

--- a/src/Widgets/SearchBar.vala
+++ b/src/Widgets/SearchBar.vala
@@ -24,6 +24,12 @@ namespace Scratch.Widgets {
 
         private Gtk.Button tool_arrow_up;
         private Gtk.Button tool_arrow_down;
+
+        /**
+         * Is the search cyclic? e.g., when you are at the bottom, if you press
+         * "Down", it will go at the start of the file to search for the content
+         * of the search entry.
+         **/
         public Gtk.ToggleButton tool_cycle_search { get; construct; }
         private Gtk.ToggleButton case_sensitive_button;
         private Gtk.ToggleButton tool_regex_button;


### PR DESCRIPTION
Add Regex Support for the search bar #533 
The PR adds some additional changes to the search bar.

- Regex Tool Button: When enabled, the _Find_ input accepts regular expressions, the **replace input doesnt** (The button toggles the `regex_enabled` property of the `Gtk.SourceSearchContext`
- Refresh search occurences on changed text: Connected to the `Gtk.TextBuffer.changed` signal to refresh the number of occurences, once the document text changes. This was only done when he `SourceView` got focused again
- Correct display of the occurence navigation arrows: on the last match, if cyclic search is enabled, the "Next" arrow is sensitive (and the "Previous" arrow on the first match) 
- Reenable replace actions on _Undo_: If a replace action is reverted, the replace (all) buttons would be disabled until the search input was changed, although there were matches to replace again