### PR TITLE
Fix occasional crash in SearchBar

### DIFF
--- a/src/Widgets/SearchBar.vala
+++ b/src/Widgets/SearchBar.vala
@@ -264,8 +264,8 @@ namespace Scratch.Widgets {
         }
 
         private void on_search_entry_text_changed () {
-            if (search_context == null) {
-                critical ("search entry changed with null context");
+            if (search_context == null) { // This can happen during start up
+                debug ("search entry changed with null context");
                 return;
             }
 

--- a/src/Widgets/SearchBar.vala
+++ b/src/Widgets/SearchBar.vala
@@ -354,7 +354,7 @@ namespace Scratch.Widgets {
         }
 
         public void highlight_none () {
-            if (search_context == null) {
+            if (search_context != null) {
                 search_context.highlight = false;
             }
         }

--- a/src/Widgets/SearchBar.vala
+++ b/src/Widgets/SearchBar.vala
@@ -187,12 +187,17 @@ namespace Scratch.Widgets {
         }
 
         public void set_text_view (Scratch.Widgets.SourceView? text_view) {
+            cancel_update_search_occurence_label ();
+            this.text_view = text_view;
+
             if (text_view == null) {
                 warning ("No SourceView is associated with SearchManager!");
+                search_context = null;
                 return;
+            } else if (this.text_buffer != null) {
+                this.text_buffer.changed.disconnect (on_text_buffer_changed);
             }
 
-            this.text_view = text_view;
             this.text_buffer = text_view.get_buffer ();
             this.text_buffer.changed.connect (on_text_buffer_changed);
             this.search_context = new Gtk.SourceSearchContext (text_buffer as Gtk.SourceBuffer, null);

--- a/src/Widgets/SearchBar.vala
+++ b/src/Widgets/SearchBar.vala
@@ -373,6 +373,7 @@ namespace Scratch.Widgets {
         private bool search_for_iter (Gtk.TextIter? start_iter, out Gtk.TextIter? end_iter) {
             if (search_context == null) {
                 critical ("Trying to search forwards with no search context");
+                return false;
             }
 
             end_iter = start_iter;
@@ -394,6 +395,7 @@ namespace Scratch.Widgets {
         private bool search_for_iter_backward (Gtk.TextIter? start_iter, out Gtk.TextIter? end_iter) {
             if (search_context == null) {
                 critical ("Trying to search backwards with no search context");
+                return false;
             }
 
             end_iter = start_iter;


### PR DESCRIPTION
Fixes #1173 

Check null search_context before using; 
Cancel search occurence label update before changing context or textview

This PR should not change any functionality.