### PR TITLE
Only focus the current document on open

### DIFF
--- a/src/Widgets/DocumentView.vala
+++ b/src/Widgets/DocumentView.vala
@@ -202,7 +202,7 @@ public class Scratch.Widgets.DocumentView : Granite.Widgets.DynamicNotebook {
         Idle.add_full (GLib.Priority.LOW, () => { // This helps ensures new tab is drawn before opening document.
             doc.open.begin (false, (obj, res) => {
                 doc.open.end (res);
-                if (focus) {
+                if (focus && doc == current_document) {
                     doc.focus ();
                 }
 


### PR DESCRIPTION
Fixes #1176 

There's a race condition here due to the `Idle.add`. Documents can be restored from saved state, one of which will have `focus == true`. At the same time, we could have started Code with an argument to open another document (i.e. "Open With" from Files), this will also have `focus == true`.

So instead of focusing all documents that have `focus == true` in an unpredictable manner due to the `Idle.add`, only focus the one that's set to `current_document` above in the synchronous code. 