### PR TITLE
Update appdata with recent changes

### DIFF
--- a/data/io.elementary.code.appdata.xml.in
+++ b/data/io.elementary.code.appdata.xml.in
@@ -26,6 +26,27 @@
     </ul>
   </description>
   <releases>
+    <release version="6.2.0" date="2022-03-24" urgency="medium">
+      <description>
+        <p>Improvements:</p>
+        <ul>
+          <li>The current document filename is now shown as the window title in multitasking view</li>
+          <li>Hidden folders are now shown in the project sidebar</li>
+          <li>The currently selected result and the number of results is displayed while searching</li>
+          <li>The search bar now has a regular expression mode</li>
+        </ul>
+        <p>Fixes:</p>
+        <ul>
+          <li>It is now possible to change Git branch with untracked files present in a project</li>
+          <li>Crashes are prevented while searching in large projects</li>
+          <li>The correct document is now focused after opening Code from an external program</li>
+        </ul>
+        <p>Minor updates:</p>
+        <ul>
+          <li>Updated translations</li>
+        </ul>
+      </description>
+    </release>
     <release version="6.1.0" date="2021-11-23" urgency="medium">
       <description>
         <p>Improvements:</p>


### PR DESCRIPTION
Noticed that none of the recent changes to Code have been captured in the AppData yet. There's some good stuff in here, so we should probably prepare a release soon.

This includes a line for #1177 which hasn't been merged yet, so ideally would be merged after that.