### PR TITLE
Git ignore flatpak build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 build
 src/config.vala
 *~
-
+.flatpak
+.flatpak-builder


### PR DESCRIPTION
If Flatpak build files are generated in the root of the source then they get searched in a global search slowing it greatly and resulting in warnings when committing changes.  To avoid this they are added to the `.gitignore` file.