### PR TITLE
Remove unused properties

### DIFF
--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -33,7 +33,7 @@ namespace Scratch.FolderManager {
         public Scratch.Services.MonitoredRepository? monitored_repo { get; private set; default = null; }
         // Cache the visible item in the project.
         private List<VisibleItem?> visible_item_list = null;
-        public string top_level_path { get; construct; }
+
         public bool is_git_repo {
             get {
                 return monitored_repo != null;

--- a/src/Widgets/SourceGutterRenderer.vala
+++ b/src/Widgets/SourceGutterRenderer.vala
@@ -11,11 +11,6 @@ public class Scratch.Widgets.SourceGutterRenderer : Gtk.SourceGutterRenderer {
     public Gee.HashMap<int, Services.VCStatus> line_status_map;
     public Gee.HashMap<Services.VCStatus, Gdk.RGBA?> status_color_map;
     public FolderManager.ProjectFolderItem? project { get; set; default = null; }
-    public string workdir_path {
-        get {
-            return project != null ? project.top_level_path : "";
-        }
-    }
 
     static construct {
         fallback_scheme = Gtk.SourceStyleSchemeManager.get_default ().get_scheme ("classic"); // We can assume this always exists


### PR DESCRIPTION
The properties `ProjectFolderItem.top_level_path` and `SourceGutterRenderer.workdir_path` are never used.