### PR TITLE
MainWindow: Fix assertion message about choose_project_button

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -342,10 +342,6 @@ namespace Scratch {
             toolbar = new Scratch.HeaderBar ();
             toolbar.title = title;
 
-            sidebar.choose_project_button.project_chosen.connect (() => {
-                folder_manager_view.collapse_other_projects ();
-            });
-
             // SearchBar
             search_bar = new Scratch.Widgets.SearchBar (this);
             search_revealer = new Gtk.Revealer ();
@@ -394,6 +390,10 @@ namespace Scratch {
 
             sidebar.add_tab (folder_manager_view);
             folder_manager_view.show_all ();
+
+            sidebar.choose_project_button.project_chosen.connect (() => {
+                folder_manager_view.collapse_other_projects ();
+            });
 
             folder_manager_view.select.connect ((a) => {
                 var file = new Scratch.FolderManager.File (a);


### PR DESCRIPTION
Fixes the following messages on launch:

```
user@veos7d:~/code/builddir$ io.elementary.code 

** (io.elementary.code:10279): CRITICAL **: 11:55:50.768: code_sidebar_get_choose_project_button: assertion 'self != NULL' failed

(io.elementary.code:10279): GLib-GObject-WARNING **: 11:55:50.768: invalid (NULL) pointer instance

(io.elementary.code:10279): GLib-GObject-CRITICAL **: 11:55:50.768: g_signal_connect_object: assertion 'G_TYPE_CHECK_INSTANCE (instance)' failed
```