### PR TITLE
Fix startup warnings

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -342,10 +342,6 @@ namespace Scratch {
             toolbar = new Scratch.HeaderBar ();
             toolbar.title = title;
 
-            sidebar.choose_project_button.project_chosen.connect (() => {
-                folder_manager_view.collapse_other_projects ();
-            });
-
             // SearchBar
             search_bar = new Scratch.Widgets.SearchBar (this);
             search_revealer = new Gtk.Revealer ();
@@ -516,6 +512,10 @@ namespace Scratch {
                     title = _("Code");
                     Utils.action_from_group (ACTION_SAVE_AS, actions).set_enabled (false);
                 }
+            });
+
+            sidebar.choose_project_button.project_chosen.connect (() => {
+                folder_manager_view.collapse_other_projects ();
             });
 
             set_widgets_sensitive (false);

--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -295,7 +295,6 @@ namespace Scratch.Services {
 
             var buffer = new Gtk.SourceBuffer (null); /* Faster to load into a separate buffer */
 
-            assert (load_timout_id == 0);
             load_timout_id = Timeout.add_seconds_full (GLib.Priority.HIGH, 5, () => {
                 if (load_cancellable != null && !load_cancellable.is_cancelled ()) {
                     var title = _("Loading File \"%s\" Is Taking a Long Time").printf (get_basename ());

--- a/src/Services/GitManager.vala
+++ b/src/Services/GitManager.vala
@@ -41,6 +41,7 @@ namespace Scratch.Services {
         }
 
         private GitManager () {
+            // Used to populate the ChooseProject popover in sorted order
             project_liststore = new ListStore (typeof (FolderManager.ProjectFolderItem));
         }
 

--- a/src/Widgets/ChooseProjectButton.vala
+++ b/src/Widgets/ChooseProjectButton.vala
@@ -90,12 +90,13 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
         var model = Scratch.Services.GitManager.get_instance ().project_liststore;
 
         model.items_changed.connect ((pos, n_removed, n_added) => {
-            // This model is get in sort order by the GitManager so model pos the same as listbox index
+            // This model is put in sort order by the GitManager so model pos the same as listbox index
             var project_folder = (Scratch.FolderManager.ProjectFolderItem)(model.get_item (pos));
             if (n_added > 0) {
                 var row = create_project_row (project_folder);
                 project_listbox.insert (row, (int)pos);
             } else {
+                // Double check we are removing correct row (do not rely on pos)
                 var row = find_row_for_path (project_folder.file.file.get_path ());
                 if (row != null) {
                     project_listbox.remove (row);

--- a/src/Widgets/ChooseProjectButton.vala
+++ b/src/Widgets/ChooseProjectButton.vala
@@ -87,10 +87,21 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
 
         popover = project_popover;
 
-        project_listbox.bind_model (
-            Scratch.Services.GitManager.get_instance ().project_liststore,
-            create_project_row
-        );
+        var model = Scratch.Services.GitManager.get_instance ().project_liststore;
+
+        model.items_changed.connect ((pos, n_removed, n_added) => {
+            // This model is get in sort order by the GitManager so model pos the same as listbox index
+            var project_folder = (Scratch.FolderManager.ProjectFolderItem)(model.get_item (pos));
+            if (n_added > 0) {
+                var row = create_project_row (project_folder);
+                project_listbox.insert (row, (int)pos);
+            } else {
+                var row = find_row_for_path (project_folder.file.file.get_path ());
+                if (row != null) {
+                    project_listbox.remove (row);
+                }
+            }
+        });
 
         project_listbox.remove.connect ((row) => {
             var project_row = row as ProjectRow;
@@ -109,9 +120,7 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
         });
     }
 
-    private Gtk.Widget create_project_row (GLib.Object object) {
-        unowned var project_folder = (Scratch.FolderManager.ProjectFolderItem) object;
-
+    private Gtk.Widget create_project_row (Scratch.FolderManager.ProjectFolderItem project_folder) {
         var project_row = new ProjectRow (project_folder.file.file.get_path ());
         project_folder.bind_property ("name", project_row.project_radio, "label", BindingFlags.DEFAULT | BindingFlags.SYNC_CREATE,
             (binding, srcval, ref targetval) => {
@@ -130,6 +139,19 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
         last_entry = project_row;
 
         return project_row;
+    }
+
+    private ProjectRow? find_row_for_path (string project_path) {
+        foreach (var child in project_listbox.get_children ()) {
+            if (child is ProjectRow) {
+                var row = (ProjectRow)child;
+                if (row.project_path == project_path) {
+                    return row;
+                }
+            }
+        }
+
+        return null;
     }
 
     private void select_project (ProjectRow project_entry) {


### PR DESCRIPTION
Fixes startup warnings in terminal

Still a close down warning that I have not been able to track down yet.

One warning required reworking the ChooseProject Button (cannot have both a bound model and a filter func on a listbox).