### PR TITLE
Check for null doc in action_find_global

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -990,6 +990,9 @@ namespace Scratch {
 
         private void action_find_global (SimpleAction action, Variant? param) {
             var current_doc = get_current_document ();
+            if (current_doc == null) {
+                return;
+            }
             var selected_text = current_doc.get_selected_text (false);
             if (selected_text != "") {
                 selected_text = selected_text.split ("\n", 2)[0];


### PR DESCRIPTION
Fixes #1248

 - [x] Guard against null current doc
 - [ ] Disable action (insensitive button) when no docs