### PR TITLE
Ensure active project at startup (include non-git folders)

### DIFF
--- a/src/FolderManager/FileView.vala
+++ b/src/FolderManager/FileView.vala
@@ -174,7 +174,7 @@ public class Scratch.FolderManager.FileView : Granite.Widgets.SourceList, Code.P
         foreach (var item in root.children) {
             if (item is ProjectFolderItem) {
                 var folder = (ProjectFolderItem)item;
-                if (folder.is_git_repo && folder.contains_file (file)) {
+                if (folder.contains_file (file)) {
                     return folder;
                 }
             }

--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -224,7 +224,11 @@ namespace Scratch.FolderManager {
             return menu;
         }
 
-        public void update_item_status (FolderItem? start_folder) requires (monitored_repo != null) {
+        public void update_item_status (FolderItem? start_folder) {
+            if (monitored_repo == null) {
+                debug ("Ignore non-git folders");
+                return;
+            }
             bool is_new = false;
             string start_path = start_folder != null ? start_folder.path : "";
             visible_item_list.@foreach ((visible_item) => {


### PR DESCRIPTION
Since commit 9e9c3ef5d9e8799fbe2b5aab3aec47e2d83ca282 the global search action is disabled at startup because the `active_project_path` has not been set in the GitManager (pre-existing hidden issue).

This PR ensures that at startup an active project path is set so long as at least one project folder is present in the sidebar.  To ensure this, it was necessary for some functions to be changed to handle non-git folders properly.  These now appear in the ProjectChooserButton as well as git projects.

