### PR TITLE
Show running branch if not master

### DIFF
--- a/data/io.elementary.code.desktop.in.in
+++ b/data/io.elementary.code.desktop.in.in
@@ -1,6 +1,6 @@
 [Desktop Entry]
 Type=Application
-Name=Code
+Name=@NAME@
 Comment=Edit code files
 GenericName=Code Editor
 Exec=@EXEC_NAME@ %U

--- a/data/meson.build
+++ b/data/meson.build
@@ -31,6 +31,12 @@ install_data(
 config_data = configuration_data()
 config_data.set('EXEC_NAME', meson.project_name())
 
+if (branch != '')
+    config_data.set('NAME', 'Code - ' + branch)
+else
+    config_data.set('NAME', 'Code')
+endif
+
 # Set the executable name and translate the desktop files
 desktop_in_file = configure_file(
     input: 'io.elementary.code.desktop.in.in',

--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,8 @@ project(
     version: '7.0.0'
 )
 
+development_focus = 'master'
+
 add_project_arguments([
         '-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name())
     ],

--- a/meson.build
+++ b/meson.build
@@ -4,8 +4,6 @@ project(
     version: '7.0.0'
 )
 
-development_focus = 'master'
-
 add_project_arguments([
         '-DGETTEXT_PACKAGE="@0@"'.format(meson.project_name())
     ],

--- a/meson.build
+++ b/meson.build
@@ -67,6 +67,13 @@ dependencies = [
     vte_dep
 ]
 
+git = find_program('git', required: false)
+branch = ''
+if get_option('development') and git.found ()
+    output = run_command('git','branch','--show-current', check: false)
+    branch = output.stdout().strip()
+endif
+
 subdir('data')
 subdir('src')
 if get_option('plugins')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
 option ('plugins', type : 'boolean', value : true)
 option('have_pkexec', type : 'boolean', value : 'true', description : 'Allow launching with pkexec. Should not be used in FlatPak')
+option('development', type : 'boolean', value : false, description : 'Build is a development branch')

--- a/src/Application.vala
+++ b/src/Application.vala
@@ -58,6 +58,9 @@ namespace Scratch {
             flags |= ApplicationFlags.HANDLES_COMMAND_LINE;
 
             application_id = Constants.PROJECT_NAME;
+            if (Constants.BRANCH != "") {
+                application_id += "." + Constants.BRANCH.replace ("/", ".").replace ("-", "_");
+            }
 
             add_main_option_entries (ENTRIES);
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -200,8 +200,7 @@ namespace Scratch {
             );
 
             if (Constants.BRANCH != "") {
-                // Put longer app info on second line to avoid ellipsizing
-                base_title = "\n%s (%s)".printf (Constants.PROJECT_NAME, Constants.BRANCH);
+                base_title = _("Code (%s)").printf (Constants.BRANCH);
             } else {
                 base_title = _("Code");
             }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -200,7 +200,8 @@ namespace Scratch {
             );
 
             if (Constants.BRANCH != "") {
-                base_title = _("Code") + " (%s)".printf (Constants.BRANCH);
+                // Put longer app info on second line to avoid ellipsizing
+                base_title = "\n%s (%s)".printf (Constants.PROJECT_NAME, Constants.BRANCH);
             } else {
                 base_title = _("Code");
             }

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -23,6 +23,7 @@ namespace Scratch {
         public const int FONT_SIZE_MAX = 72;
         public const int FONT_SIZE_MIN = 7;
         private const uint MAX_SEARCH_TEXT_LENGTH = 255;
+        private static string base_title;
 
         public Scratch.Application app { get; private set; }
         public bool restore_docs { get; construct; }
@@ -148,7 +149,6 @@ namespace Scratch {
         public MainWindow (bool restore_docs) {
             Object (
                 icon_name: Constants.PROJECT_NAME,
-                title: _("Code"),
                 restore_docs: restore_docs
             );
         }
@@ -199,12 +199,14 @@ namespace Scratch {
                 Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
             );
 
+            base_title = _("Code") + " (%s)".printf (Constants.BRANCH);
             Hdy.init ();
         }
 
         construct {
             application = ((Gtk.Application)(GLib.Application.get_default ()));
             app = (Scratch.Application)application;
+            title = base_title;
 
             weak Gtk.IconTheme default_theme = Gtk.IconTheme.get_default ();
             default_theme.add_resource_path ("/io/elementary/code");
@@ -340,7 +342,7 @@ namespace Scratch {
 
         private void init_layout () {
             toolbar = new Scratch.HeaderBar ();
-            toolbar.title = title;
+            toolbar.title = base_title;
 
             // SearchBar
             search_bar = new Scratch.Widgets.SearchBar (this);
@@ -482,7 +484,7 @@ namespace Scratch {
 
             document_view.request_placeholder.connect (() => {
                 content_stack.visible_child = welcome_view;
-                title = _("Code");
+                title = base_title;
                 toolbar.document_available (false);
                 set_widgets_sensitive (false);
             });
@@ -502,7 +504,8 @@ namespace Scratch {
                 if (doc != null) {
                     search_bar.set_text_view (doc.source_view);
                     // Update MainWindow title
-                    title = doc.get_basename ();
+                    /// TRANSLATORS: First placeholder is document name, second placeholder is app name
+                    title = _("%s - %s").printf (doc.get_basename (), base_title);
 
                     toolbar.set_document_focus (doc);
                     sidebar.choose_project_button.set_document (doc);
@@ -515,7 +518,7 @@ namespace Scratch {
                     Utils.action_from_group (ACTION_SAVE_AS, actions).set_enabled (doc.file != null);
                     doc.check_undoable_actions ();
                 } else {
-                    title = _("Code");
+                    title = base_title;
                     Utils.action_from_group (ACTION_SAVE_AS, actions).set_enabled (false);
                 }
             });

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -23,7 +23,6 @@ namespace Scratch {
         public const int FONT_SIZE_MAX = 72;
         public const int FONT_SIZE_MIN = 7;
         private const uint MAX_SEARCH_TEXT_LENGTH = 255;
-        private static string base_title;
 
         public Scratch.Application app { get; private set; }
         public bool restore_docs { get; construct; }
@@ -101,6 +100,7 @@ namespace Scratch {
         public const string ACTION_RESTORE_PROJECT_DOCS = "action_restore_project_docs";
 
         public static Gee.MultiMap<string, string> action_accelerators = new Gee.HashMultiMap<string, string> ();
+        private static string base_title;
 
         private const ActionEntry[] ACTION_ENTRIES = {
             { ACTION_FIND, action_fetch, "s" },
@@ -199,7 +199,12 @@ namespace Scratch {
                 Gdk.Screen.get_default (), provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION
             );
 
-            base_title = _("Code") + " (%s)".printf (Constants.BRANCH);
+            if (Constants.BRANCH != "") {
+                base_title = _("Code") + " (%s)".printf (Constants.BRANCH);
+            } else {
+                base_title = _("Code");
+            }
+
             Hdy.init ();
         }
 

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -250,21 +250,6 @@ public class Scratch.HeaderBar : Hdy.HeaderBar {
         pack_start (save_button);
         pack_start (save_as_button);
         pack_start (revert_button);
-
-        if (Constants.BRANCH != null &&
-            Constants.BRANCH != "" &&
-            Constants.BRANCH != "master" &&
-            Constants.BRANCH != "main") {
-
-            //TODO Decide on best place to expose this information
-            //Putting in headerbar for immediate visibility while developing
-            var branch_label = new Gtk.Label (Constants.BRANCH) {
-                tooltip_text = _("Branch of source code currently running")
-            };
-
-            pack_start (branch_label);
-        }
-
         pack_end (app_menu);
         pack_end (share_app_menu);
 

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -245,20 +245,26 @@ public class Scratch.HeaderBar : Hdy.HeaderBar {
         };
         set_custom_title (format_bar);
 
-        var branch_label = new Gtk.Label (
-            _("Running Development Branch: %s").printf (Constants.BRANCH)
-        );
-
-        if (branch_label.label == "master" || branch_label.label == "main") {
-            branch_label.visible = false;
-            branch_label.no_show_all = true;
-        }
         pack_start (open_button);
         pack_start (templates_button);
         pack_start (save_button);
         pack_start (save_as_button);
         pack_start (revert_button);
-        pack_start (branch_label);
+
+        if (Constants.BRANCH != null &&
+            Constants.BRANCH != "" &&
+            Constants.BRANCH != "master" &&
+            Constants.BRANCH != "main") {
+
+            //TODO Decide on best place to expose this information
+            //Putting in headerbar for immediate visibility while developing
+            var branch_label = new Gtk.Label (Constants.BRANCH) {
+                tooltip_text = _("Branch of source code currently running")
+            };
+
+            pack_start (branch_label);
+        }
+
         pack_end (app_menu);
         pack_end (share_app_menu);
 

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -245,11 +245,20 @@ public class Scratch.HeaderBar : Hdy.HeaderBar {
         };
         set_custom_title (format_bar);
 
+        var branch_label = new Gtk.Label (
+            _("Running Development Branch: %s").printf (Constants.BRANCH)
+        );
+
+        if (branch_label.label == "master" || branch_label.label == "main") {
+            branch_label.visible = false;
+            branch_label.no_show_all = true;
+        }
         pack_start (open_button);
         pack_start (templates_button);
         pack_start (save_button);
         pack_start (save_as_button);
         pack_start (revert_button);
+        pack_start (branch_label);
         pack_end (app_menu);
         pack_end (share_app_menu);
 

--- a/src/config.vala.in
+++ b/src/config.vala.in
@@ -6,4 +6,5 @@ namespace Constants {
     public const string INSTALL_PREFIX = @PREFIX@;
     public const string DATADIR = @DATADIR@;
     public const string LOCALEDIR = @LOCALEDIR@;
+    public const string BRANCH = @BRANCH@;
 }

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,5 +1,3 @@
-output = run_command('git','branch','--show-current')
-branch = output.stdout().strip()
 conf_data = configuration_data()
 conf_data.set_quoted('PROJECT_NAME', meson.project_name())
 conf_data.set_quoted('GETTEXT_PACKAGE', meson.project_name())
@@ -8,7 +6,15 @@ conf_data.set_quoted('PREFIX', get_option('prefix'))
 conf_data.set_quoted('PLUGINDIR', pluginsdir)
 conf_data.set_quoted('DATADIR', join_paths (get_option('prefix'), get_option('datadir')))
 conf_data.set_quoted('LOCALEDIR', join_paths (get_option('prefix'), get_option('localedir')))
-conf_data.set_quoted('BRANCH', branch)
+
+output = run_command('git','branch','--show-current')
+branch = output.stdout().strip()
+if branch == development_focus
+    conf_data.set_quoted('BRANCH', '')
+else
+    conf_data.set_quoted('BRANCH', branch)
+endif
+
 config_header = configure_file(
     input : 'config.vala.in',
     output : 'config.vala',

--- a/src/meson.build
+++ b/src/meson.build
@@ -7,12 +7,13 @@ conf_data.set_quoted('PLUGINDIR', pluginsdir)
 conf_data.set_quoted('DATADIR', join_paths (get_option('prefix'), get_option('datadir')))
 conf_data.set_quoted('LOCALEDIR', join_paths (get_option('prefix'), get_option('localedir')))
 conf_data.set_quoted('BRANCH', '')
+git = find_program('git', required: false)
+if git.found()
 output = run_command('git','branch','--show-current', check: false)
-if output.returncode() == 0
-    branch = output.stdout().strip()
-    if branch != development_focus
-        conf_data.set_quoted('BRANCH', branch)
-    endif
+branch = output.stdout().strip()
+if branch != development_focus
+    conf_data.set_quoted('BRANCH', branch)
+endif
 endif
 config_header = configure_file(
     input : 'config.vala.in',

--- a/src/meson.build
+++ b/src/meson.build
@@ -6,15 +6,14 @@ conf_data.set_quoted('PREFIX', get_option('prefix'))
 conf_data.set_quoted('PLUGINDIR', pluginsdir)
 conf_data.set_quoted('DATADIR', join_paths (get_option('prefix'), get_option('datadir')))
 conf_data.set_quoted('LOCALEDIR', join_paths (get_option('prefix'), get_option('localedir')))
-
-output = run_command('git','branch','--show-current')
-branch = output.stdout().strip()
-if branch == development_focus
-    conf_data.set_quoted('BRANCH', '')
-else
-    conf_data.set_quoted('BRANCH', branch)
+conf_data.set_quoted('BRANCH', '')
+output = run_command('git','branch','--show-current', check: false)
+if output.returncode() == 0
+    branch = output.stdout().strip()
+    if branch != development_focus
+        conf_data.set_quoted('BRANCH', branch)
+    endif
 endif
-
 config_header = configure_file(
     input : 'config.vala.in',
     output : 'config.vala',

--- a/src/meson.build
+++ b/src/meson.build
@@ -8,13 +8,13 @@ conf_data.set_quoted('DATADIR', join_paths (get_option('prefix'), get_option('da
 conf_data.set_quoted('LOCALEDIR', join_paths (get_option('prefix'), get_option('localedir')))
 conf_data.set_quoted('BRANCH', '')
 git = find_program('git', required: false)
-if git.found()
-output = run_command('git','branch','--show-current', check: false)
-branch = output.stdout().strip()
-if branch != development_focus
+
+if get_option('development') and git.found ()
+    output = run_command('git','branch','--show-current', check: false)
+    branch = output.stdout().strip()
     conf_data.set_quoted('BRANCH', branch)
 endif
-endif
+
 config_header = configure_file(
     input : 'config.vala.in',
     output : 'config.vala',

--- a/src/meson.build
+++ b/src/meson.build
@@ -6,14 +6,7 @@ conf_data.set_quoted('PREFIX', get_option('prefix'))
 conf_data.set_quoted('PLUGINDIR', pluginsdir)
 conf_data.set_quoted('DATADIR', join_paths (get_option('prefix'), get_option('datadir')))
 conf_data.set_quoted('LOCALEDIR', join_paths (get_option('prefix'), get_option('localedir')))
-conf_data.set_quoted('BRANCH', '')
-git = find_program('git', required: false)
-
-if get_option('development') and git.found ()
-    output = run_command('git','branch','--show-current', check: false)
-    branch = output.stdout().strip()
-    conf_data.set_quoted('BRANCH', branch)
-endif
+conf_data.set_quoted('BRANCH', branch)
 
 config_header = configure_file(
     input : 'config.vala.in',

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,3 +1,5 @@
+output = run_command('git','branch','--show-current')
+branch = output.stdout().strip()
 conf_data = configuration_data()
 conf_data.set_quoted('PROJECT_NAME', meson.project_name())
 conf_data.set_quoted('GETTEXT_PACKAGE', meson.project_name())
@@ -6,6 +8,7 @@ conf_data.set_quoted('PREFIX', get_option('prefix'))
 conf_data.set_quoted('PLUGINDIR', pluginsdir)
 conf_data.set_quoted('DATADIR', join_paths (get_option('prefix'), get_option('datadir')))
 conf_data.set_quoted('LOCALEDIR', join_paths (get_option('prefix'), get_option('localedir')))
+conf_data.set_quoted('BRANCH', branch)
 config_header = configure_file(
     input : 'config.vala.in',
     output : 'config.vala',


### PR DESCRIPTION
Another speculative development aid.

This makes it discoverable which branch of Code is running if not master.  This can be useful when switching between master and the development branch for comparison and there is no other visual cue.  Also for knowing which branch you are currently dogfooding.

For simplicity and compatibility with other apps, the branch is exposed in the window title.

In order for the modified window title to be shown, the project needs to be built with the meson option `-Ddevelopment=true`.