### PR TITLE
Fix styling when no documents

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -238,8 +238,11 @@ namespace Scratch {
             default_width = rect.width;
             default_height = rect.height;
 
-            var gtk_settings = Gtk.Settings.get_default ();
-            gtk_settings.gtk_application_prefer_dark_theme = Scratch.settings.get_boolean ("prefer-dark-style");
+
+            if (!Scratch.settings.get_boolean ("follow-system-style")) {
+                var gtk_settings = Gtk.Settings.get_default ();
+                gtk_settings.gtk_application_prefer_dark_theme = Scratch.settings.get_boolean ("prefer-dark-style");
+            }
 
             clipboard = Gtk.Clipboard.get_for_display (get_display (), Gdk.SELECTION_CLIPBOARD);
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -238,11 +238,10 @@ namespace Scratch {
             default_width = rect.width;
             default_height = rect.height;
 
-
-            if (!Scratch.settings.get_boolean ("follow-system-style")) {
-                var gtk_settings = Gtk.Settings.get_default ();
-                gtk_settings.gtk_application_prefer_dark_theme = Scratch.settings.get_boolean ("prefer-dark-style");
-            }
+            update_style ();
+            Scratch.settings.changed["follow-system-style"].connect (() => {
+                update_style ();
+            });
 
             clipboard = Gtk.Clipboard.get_for_display (get_display (), Gdk.SELECTION_CLIPBOARD);
 
@@ -297,6 +296,16 @@ namespace Scratch {
 
             Unix.signal_add (Posix.Signal.INT, quit_source_func, Priority.HIGH);
             Unix.signal_add (Posix.Signal.TERM, quit_source_func, Priority.HIGH);
+        }
+
+        private void update_style () {
+            var gtk_settings = Gtk.Settings.get_default ();
+            if (Scratch.settings.get_boolean ("follow-system-style")) {
+                var system_prefers_dark = Granite.Settings.get_default ().prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
+                gtk_settings.gtk_application_prefer_dark_theme = system_prefers_dark;
+            } else {
+                gtk_settings.gtk_application_prefer_dark_theme = Scratch.settings.get_boolean ("prefer-dark-style");
+            }
         }
 
         private void update_toolbar_button (string name, bool new_state) {

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -301,15 +301,12 @@ namespace Scratch.Widgets {
             var gtk_settings = Gtk.Settings.get_default ();
             if (settings.get_boolean ("follow-system-style")) {
                 var system_prefers_dark = Granite.Settings.get_default ().prefers_color_scheme == Granite.Settings.ColorScheme.DARK;
-                gtk_settings.gtk_application_prefer_dark_theme = system_prefers_dark;
-
                 if (system_prefers_dark) {
                     source_buffer.style_scheme = style_scheme_manager.get_scheme ("elementary-dark");
                 } else {
                     source_buffer.style_scheme = style_scheme_manager.get_scheme ("elementary-light");
                 }
             } else {
-                gtk_settings.gtk_application_prefer_dark_theme = settings.get_boolean ("prefer-dark-style");
                 var scheme = style_scheme_manager.get_scheme (Scratch.settings.get_string ("style-scheme"));
                 source_buffer.style_scheme = scheme ?? style_scheme_manager.get_scheme ("classic");
             }


### PR DESCRIPTION
Fixes #1270 

Transfer responsibility for reacting to "follow-system-style" setting to MainWindow so works when no documents.