### PR TITLE
Persist search settings

### DIFF
--- a/data/io.elementary.code.gschema.xml
+++ b/data/io.elementary.code.gschema.xml
@@ -10,6 +10,11 @@
     <value nick="For Selection" value="1" />
     <value nick="Always" value="2" />
   </enum>
+  <enum id="io.elementary.code.case-sensitive-mode">
+    <value nick="Never" value="0" />
+    <value nick="Mixed Case" value="1" />
+    <value nick="Always" value="2" />
+  </enum>
 
   <schema path="/io/elementary/code/saved-state/" id="io.elementary.code.saved-state" gettext-domain="io.elementary.code">
     <key name="window-state" enum="io.elementary.code.window-states">
@@ -154,6 +159,11 @@
       <default>false</default>
       <summary>Whether search is cyclic</summary>
       <description>Whether text searching should cycle back to the beginning of the document after reaching the end of the document.</description>
+    </key>
+    <key name="case-sensitive-search" enum="io.elementary.code.case-sensitive-mode">
+      <default>"Mixed Case"</default>
+      <summary>When text search is case sensitive</summary>
+      <description>Whether the text search is case sensitive never, always or only when search term is mixed case</description>
     </key>
     <key name="strip-trailing-on-save" type="b">
       <default>false</default>

--- a/data/io.elementary.code.gschema.xml
+++ b/data/io.elementary.code.gschema.xml
@@ -160,6 +160,11 @@
       <summary>Whether search is cyclic</summary>
       <description>Whether text searching should cycle back to the beginning of the document after reaching the end of the document.</description>
     </key>
+    <key name="wholeword-search" type="b">
+      <default>false</default>
+      <summary>Whether search is for whole words</summary>
+      <description>Whether the search should only match whole words.</description>
+    </key>
     <key name="case-sensitive-search" enum="io.elementary.code.case-sensitive-mode">
       <default>"Mixed Case"</default>
       <summary>When text search is case sensitive</summary>

--- a/data/io.elementary.code.gschema.xml
+++ b/data/io.elementary.code.gschema.xml
@@ -165,6 +165,11 @@
       <summary>Whether search is for whole words</summary>
       <description>Whether the search should only match whole words.</description>
     </key>
+    <key name="regex-search" type="b">
+      <default>false</default>
+      <summary>Whether search term is a regex expression</summary>
+      <description>Whether the search should use the search term as a regex expression for matching.</description>
+    </key>
     <key name="case-sensitive-search" enum="io.elementary.code.case-sensitive-mode">
       <default>"Mixed Case"</default>
       <summary>When text search is case sensitive</summary>

--- a/data/io.elementary.code.gschema.xml
+++ b/data/io.elementary.code.gschema.xml
@@ -11,9 +11,9 @@
     <value nick="Always" value="2" />
   </enum>
   <enum id="io.elementary.code.case-sensitive-mode">
-    <value nick="Never" value="0" />
-    <value nick="Mixed Case" value="1" />
-    <value nick="Always" value="2" />
+    <value nick="never" value="0" />
+    <value nick="mixed" value="1" />
+    <value nick="always" value="2" />
   </enum>
 
   <schema path="/io/elementary/code/saved-state/" id="io.elementary.code.saved-state" gettext-domain="io.elementary.code">
@@ -171,7 +171,7 @@
       <description>Whether the search should use the search term as a regex expression for matching.</description>
     </key>
     <key name="case-sensitive-search" enum="io.elementary.code.case-sensitive-mode">
-      <default>"Mixed Case"</default>
+      <default>'mixed'</default>
       <summary>When text search is case sensitive</summary>
       <description>Whether the text search is case sensitive never, always or only when search term is mixed case</description>
     </key>

--- a/src/Widgets/SearchBar.vala
+++ b/src/Widgets/SearchBar.vala
@@ -169,6 +169,7 @@ namespace Scratch.Widgets {
             regex_search_button.toggled.connect (on_search_entry_text_changed);
 
             Scratch.settings.bind ("cyclic-search", cycle_search_button, "active", SettingsBindFlags.DEFAULT);
+            Scratch.settings.bind ("wholeword-search", whole_word_search_button, "active", SettingsBindFlags.DEFAULT);
             Scratch.settings.bind_with_mapping (
                 "case-sensitive-search",
                 case_sensitive_search_button, "active",

--- a/src/Widgets/SearchBar.vala
+++ b/src/Widgets/SearchBar.vala
@@ -170,6 +170,7 @@ namespace Scratch.Widgets {
 
             Scratch.settings.bind ("cyclic-search", cycle_search_button, "active", SettingsBindFlags.DEFAULT);
             Scratch.settings.bind ("wholeword-search", whole_word_search_button, "active", SettingsBindFlags.DEFAULT);
+            Scratch.settings.bind ("regex-search", regex_search_button, "active", SettingsBindFlags.DEFAULT);
             Scratch.settings.bind_with_mapping (
                 "case-sensitive-search",
                 case_sensitive_search_button, "active",

--- a/src/Widgets/SearchBar.vala
+++ b/src/Widgets/SearchBar.vala
@@ -24,33 +24,7 @@ namespace Scratch.Widgets {
         enum CaseSensitiveMode {
             NEVER,
             MIXED,
-            ALWAYS;
-
-            public string to_string () {
-                switch (this) {
-                    case NEVER:
-                        return "Never";
-                    case MIXED:
-                        return "Mixed Case";
-                    case ALWAYS:
-                        return "Always";
-                    default:
-                        assert_not_reached ();
-                }
-            }
-
-            public static CaseSensitiveMode from_string (string s) {
-                switch (s) {
-                    case "Never":
-                        return NEVER;
-                    case "Mixed Case":
-                        return MIXED;
-                    case "Always":
-                        return ALWAYS;
-                    default:
-                        assert_not_reached ();
-                }
-            }
+            ALWAYS
         }
 
         public weak MainWindow window { get; construct; }
@@ -125,9 +99,9 @@ namespace Scratch.Widgets {
             cycle_search_button = new Granite.SwitchModelButton (_("Cyclic Search"));
 
             case_sensitive_search_button = new Gtk.ComboBoxText ();
-            case_sensitive_search_button.append (null, _("Never"));
-            case_sensitive_search_button.append (null, _("Mixed Case"));
-            case_sensitive_search_button.append (null, _("Always"));
+            case_sensitive_search_button.append ("never", _("Never"));
+            case_sensitive_search_button.append ("mixed", _("Mixed Case"));
+            case_sensitive_search_button.append ("always", _("Always"));
             case_sensitive_search_button.active = 1;
 
             var case_sensitive_search_label = new Gtk.Label (_("Case Sensitive"));
@@ -171,20 +145,7 @@ namespace Scratch.Widgets {
             Scratch.settings.bind ("cyclic-search", cycle_search_button, "active", SettingsBindFlags.DEFAULT);
             Scratch.settings.bind ("wholeword-search", whole_word_search_button, "active", SettingsBindFlags.DEFAULT);
             Scratch.settings.bind ("regex-search", regex_search_button, "active", SettingsBindFlags.DEFAULT);
-            Scratch.settings.bind_with_mapping (
-                "case-sensitive-search",
-                case_sensitive_search_button, "active",
-                SettingsBindFlags.DEFAULT,
-                (to_val, from_variant) => {
-                    to_val.set_int (CaseSensitiveMode.from_string (from_variant.get_string ()));
-                    return true;
-                },
-                (from_val, vartype) => {
-                    var mode_s = ((CaseSensitiveMode)(from_val.get_int ())).to_string ();
-                    return new Variant.string (mode_s);
-                },
-                null, null
-            );
+            Scratch.settings.bind ("case-sensitive-search", case_sensitive_search_button, "active-id", SettingsBindFlags.DEFAULT);
 
             var search_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0) {
                 margin_top = 3,

--- a/src/Widgets/SearchBar.vala
+++ b/src/Widgets/SearchBar.vala
@@ -24,7 +24,33 @@ namespace Scratch.Widgets {
         enum CaseSensitiveMode {
             NEVER,
             MIXED,
-            ALWAYS
+            ALWAYS;
+
+            public string to_string () {
+                switch (this) {
+                    case NEVER:
+                        return "Never";
+                    case MIXED:
+                        return "Mixed Case";
+                    case ALWAYS:
+                        return "Always";
+                    default:
+                        assert_not_reached ();
+                }
+            }
+
+            public static CaseSensitiveMode from_string (string s) {
+                switch (s) {
+                    case "Never":
+                        return NEVER;
+                    case "Mixed Case":
+                        return MIXED;
+                    case "Always":
+                        return ALWAYS;
+                    default:
+                        assert_not_reached ();
+                }
+            }
         }
 
         public weak MainWindow window { get; construct; }
@@ -143,6 +169,20 @@ namespace Scratch.Widgets {
             regex_search_button.toggled.connect (on_search_entry_text_changed);
 
             Scratch.settings.bind ("cyclic-search", cycle_search_button, "active", SettingsBindFlags.DEFAULT);
+            Scratch.settings.bind_with_mapping (
+                "case-sensitive-search",
+                case_sensitive_search_button, "active",
+                SettingsBindFlags.DEFAULT,
+                (to_val, from_variant) => {
+                    to_val.set_int (CaseSensitiveMode.from_string (from_variant.get_string ()));
+                    return true;
+                },
+                (from_val, vartype) => {
+                    var mode_s = ((CaseSensitiveMode)(from_val.get_int ())).to_string ();
+                    return new Variant.string (mode_s);
+                },
+                null, null
+            );
 
             var search_box = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 0) {
                 margin_top = 3,


### PR DESCRIPTION
Adds case sensitive mode, whole word search and regex search settings to the existing cyclic search setting to the "io.elementary.code.settings" schema so that these settings now also persist.

