### PR TITLE
Fix creating duplicates of unwritable files

### DIFF
--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -372,7 +372,7 @@ namespace Scratch.Services {
 
             // Focus in event for SourceView
             this.source_view.focus_in_event.connect (() => {
-                if (!locked) {
+                if (!working && !locked) {
                     check_file_status ();
                     check_undoable_actions ();
                 }
@@ -503,12 +503,15 @@ namespace Scratch.Services {
             var old_uri = file.get_uri ();
             var old_locked = locked;
             locked = false;  // Can always try to save as a different file
+            working = true; // Prevent premature status check when focus in after dialog closes
             var result = yield save_with_hold (true, true);
             if (!result) {
                 file = File.new_for_uri (old_uri);
                 locked = old_locked;
             }
 
+            working = false;
+            check_file_status ();
             return result;
         }
 


### PR DESCRIPTION
Fixes #1316

The issue was caused by the `focus-in-event` handler checking the file status before the duplicate has been created resulting in a further error dialog. This was fixed by putting the document in a `working` state while duplicate creation is in progress and ignoring focus in events in that state.  The file status is checked after save-as completes instead.

