### PR TITLE
Fix typo in metainfo

### DIFF
--- a/data/code.metainfo.xml.in
+++ b/data/code.metainfo.xml.in
@@ -80,7 +80,7 @@
           <li>Trying to save a document to an unwritable location is now handled better</li>
           <li>The system style is now followed by the symbol outline and when launched without open documents</li>
           <li>Mixed case sensitive search now works as expected</li>
-          <li>The search results no longer change unexpectedly when focussing a document</li>
+          <li>The search results no longer change unexpectedly when focusing a document</li>
           <li>Now there is always an active project at startup if there are projects in the sidebar</li>
           <li>If a development branch is running this shows in the window title and in the dock tooltip</li>
           <li>Ctrl+PageUp and Ctrl+PageDown shortcuts now switch tabs</li>


### PR DESCRIPTION
Just a small typo I stumbled upon. Feels a bit weird to "contribute" such a small change but my ocd kicked in