### PR TITLE
Fix searchterm reverts

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1006,6 +1006,7 @@ namespace Scratch {
         /** Not a toggle action - linked to keyboard short cut (Ctrl-f). **/
         private string current_search_term = "";
         private void action_fetch (SimpleAction action, Variant? param) {
+
             current_search_term = param.get_string ();
             if (!search_revealer.child_revealed) {
                 var show_find_action = Utils.action_from_group (ACTION_SHOW_FIND, actions);
@@ -1073,6 +1074,10 @@ namespace Scratch {
                 search_bar.search_entry.text = current_search_term;
                 search_bar.search_entry.grab_focus ();
                 search_bar.search_next ();
+            } else if (search_bar.search_entry.text != "") {
+                // Always search on what is showing in search entry
+                current_search_term = search_bar.search_entry.text;
+                search_bar.search_entry.grab_focus ();
             } else {
                 var current_doc = get_current_document ();
                 // This is also called when all documents are closed.
@@ -1080,6 +1085,7 @@ namespace Scratch {
                     var selected_text = current_doc.get_selected_text (false);
                     if (selected_text != "" && selected_text.length < MAX_SEARCH_TEXT_LENGTH) {
                         current_search_term = selected_text.split ("\n", 2)[0];
+                        warning ("current search term now %s", current_search_term);
                         search_bar.search_entry.text = current_search_term;
                     }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -62,6 +62,7 @@ namespace Scratch {
         public const string ACTION_FIND_NEXT = "action_find_next";
         public const string ACTION_FIND_PREVIOUS = "action_find_previous";
         public const string ACTION_FIND_GLOBAL = "action_find_global";
+        public const string ACTION_FIND_CLEAR = "action_find_clear";
         public const string ACTION_OPEN = "action_open";
         public const string ACTION_OPEN_FOLDER = "action_open_folder";
         public const string ACTION_COLLAPSE_ALL_FOLDERS = "action_collapse_all_folders";
@@ -108,6 +109,7 @@ namespace Scratch {
             { ACTION_FIND_NEXT, action_find_next },
             { ACTION_FIND_PREVIOUS, action_find_previous },
             { ACTION_FIND_GLOBAL, action_find_global, "s" },
+            { ACTION_FIND_CLEAR, action_find_clear },
             { ACTION_OPEN, action_open },
             { ACTION_OPEN_FOLDER, action_open_folder },
             { ACTION_COLLAPSE_ALL_FOLDERS, action_collapse_all_folders },
@@ -160,6 +162,7 @@ namespace Scratch {
             action_accelerators.set (ACTION_FIND_NEXT, "<Control>g");
             action_accelerators.set (ACTION_FIND_PREVIOUS, "<Control><shift>g");
             action_accelerators.set (ACTION_FIND_GLOBAL + "::", "<Control><shift>f");
+            action_accelerators.set (ACTION_FIND_CLEAR, "<Alt>f");
             action_accelerators.set (ACTION_OPEN, "<Control>o");
             action_accelerators.set (ACTION_REVERT, "<Control><shift>o");
             action_accelerators.set (ACTION_SAVE, "<Control>s");
@@ -1052,6 +1055,11 @@ namespace Scratch {
             }
 
             folder_manager_view.search_global (get_target_path_for_actions (param), term);
+        }
+
+        private void action_find_clear () {
+            search_bar.search_entry.text = "";
+            current_search_term = "";
         }
 
         private void update_find_actions () {


### PR DESCRIPTION
Fixes #1335 

In order to fix this issue, the behaviour in relation to searching for the current selection had to change because any search entry text always takes priority.  Now the current selection is only searched for if the search entry is empty.  To make clearing the entry easier a keyboard shortcut is added.