### PR TITLE
Drop folder onto sidebar to open as project

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -109,7 +109,7 @@ namespace Scratch {
             { ACTION_FIND_PREVIOUS, action_find_previous },
             { ACTION_FIND_GLOBAL, action_find_global, "s" },
             { ACTION_OPEN, action_open },
-            { ACTION_OPEN_FOLDER, action_open_folder },
+            { ACTION_OPEN_FOLDER, action_open_folder, "s" },
             { ACTION_COLLAPSE_ALL_FOLDERS, action_collapse_all_folders },
             { ACTION_ORDER_FOLDERS, action_order_folders },
             { ACTION_PREFERENCES, action_preferences },
@@ -863,23 +863,28 @@ namespace Scratch {
             }
         }
 
-        private void action_open_folder () {
-            var chooser = new Gtk.FileChooserNative (
-                "Select a folder.", this, Gtk.FileChooserAction.SELECT_FOLDER,
-                _("_Open"),
-                _("_Cancel")
-            );
+        private void action_open_folder (SimpleAction action, Variant? param) {
+            var path = param.get_string ();
+            if (path == "") {
+                var chooser = new Gtk.FileChooserNative (
+                    "Select a folder.", this, Gtk.FileChooserAction.SELECT_FOLDER,
+                    _("_Open"),
+                    _("_Cancel")
+                );
 
-            chooser.select_multiple = true;
+                chooser.select_multiple = true;
 
-            if (chooser.run () == Gtk.ResponseType.ACCEPT) {
-                chooser.get_files ().foreach ((glib_file) => {
-                    var foldermanager_file = new FolderManager.File (glib_file.get_path ());
-                    folder_manager_view.open_folder (foldermanager_file);
-                });
+                if (chooser.run () == Gtk.ResponseType.ACCEPT) {
+                    chooser.get_files ().foreach ((glib_file) => {
+                        var foldermanager_file = new FolderManager.File (glib_file.get_path ());
+                        folder_manager_view.open_folder (foldermanager_file);
+                    });
+                }
+
+                chooser.destroy ();
+            } else {
+                folder_manager_view.open_folder (new FolderManager.File (path));
             }
-
-            chooser.destroy ();
         }
 
         private void action_collapse_all_folders () {

--- a/src/Widgets/Sidebar.vala
+++ b/src/Widgets/Sidebar.vala
@@ -18,6 +18,11 @@
  */
 
 public class Code.Sidebar : Gtk.Grid {
+public class Code.Sidebar : Gtk.Box {
+    public enum TargetType {
+        URI_LIST
+    }
+
     public Gtk.Stack stack { get; private set; }
     public Code.ChooseProjectButton choose_project_button { get; private set; }
     public Hdy.HeaderBar headerbar { get; private set; }
@@ -53,6 +58,7 @@ public class Code.Sidebar : Gtk.Grid {
 
         var add_folder_button = new Gtk.Button.from_icon_name ("folder-open-symbolic", Gtk.IconSize.SMALL_TOOLBAR) {
             action_name = Scratch.MainWindow.ACTION_PREFIX + Scratch.MainWindow.ACTION_OPEN_FOLDER,
+            action_target = new Variant.string (""),
             always_show_image = true,
             label = _("Open Folder…")
         };
@@ -105,6 +111,42 @@ public class Code.Sidebar : Gtk.Grid {
                     break;
             }
         });
+
+        Gtk.TargetEntry uris = {"text/uri-list", 0, TargetType.URI_LIST};
+        Gtk.drag_dest_set (this, Gtk.DestDefaults.ALL, {uris}, Gdk.DragAction.COPY);
+        drag_data_received.connect (drag_received);
+    }
+
+    private void drag_received (Gtk.Widget w,
+                                Gdk.DragContext ctx,
+                                int x,
+                                int y,
+                                Gtk.SelectionData sel,
+                                uint info,
+                                uint time) {
+
+        if (info == TargetType.URI_LIST) {
+            var uri_list = sel.get_uris ();
+            GLib.List<GLib.File> folder_list = null;
+            foreach (unowned var uri in uri_list) {
+                var file = GLib.File.new_for_uri (uri);
+                // Blocking but for simplicity omit cancellable for now
+                var ftype = file.query_file_type (FileQueryInfoFlags.NOFOLLOW_SYMLINKS);
+                if (ftype == GLib.FileType.DIRECTORY) {
+                  folder_list.prepend (file);
+                }
+            }
+
+            foreach (var folder in folder_list) {
+                var win_group = get_action_group (Scratch.MainWindow.ACTION_GROUP);
+                win_group.activate_action (
+                    Scratch.MainWindow.ACTION_OPEN_FOLDER,
+                    new Variant.string (folder.get_path ())
+                );
+            }
+
+            Gtk.drag_finish (ctx, folder_list.length () > 0, false, time);
+        }
     }
 
     public void add_tab (Code.PaneSwitcher tab) {


### PR DESCRIPTION
Fixes #1338 

Simple implementation of opening a folder as a project by dropping the uri from the file manager onto the sidebar.  Uses default behaviour so no drag icon or previewing of data etc.  This can be refined later if desired.