### PR TITLE
Handle only relevant settings key changes

### DIFF
--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -180,10 +180,11 @@ namespace Scratch.Services {
             source_map.set_view (source_view);
 
             hide_info_bar ();
+            set_minimap ();
+            set_strip_trailing_whitespace ();
+            settings.changed["show-mini-map"].connect (set_minimap);
+            settings.changed["strip-trailing-on-save"].connect (set_strip_trailing_whitespace);
 
-            restore_settings ();
-
-            settings.changed.connect (restore_settings);
             /* Block user editing while working */
             notify["working"].connect (() => {
                 source_view.sensitive = !working;
@@ -647,7 +648,7 @@ namespace Scratch.Services {
             return true;
         }
 
-        private void restore_settings () {
+        private void set_minimap () {
             if (Scratch.settings.get_boolean ("show-mini-map")) {
                 source_map.show ();
                 scroll.vscrollbar_policy = Gtk.PolicyType.EXTERNAL;
@@ -656,7 +657,9 @@ namespace Scratch.Services {
                 source_map.no_show_all = true;
                 scroll.vscrollbar_policy = Gtk.PolicyType.AUTOMATIC;
             }
+        }
 
+        private void set_strip_trailing_whitespace () {
             if (Scratch.settings.get_boolean ("strip-trailing-on-save")) {
                 strip_trailing_spaces ();
             }


### PR DESCRIPTION
Fixes #1208 

It was noticed that everytime a document was closed or opened `strip-trailing-whitespace` was called multiple times (at least once for each open document).  This was caused by `restore-settings` being called unnecessarily because the key `open-files` changed and causing a lot of unnecessary work if a lot of documents are open.

This PR uses more specific handlers for the `show-mini-map` and `strip-trailing -on-save` keys only.