### PR TITLE
Change terminal working directory according to active project

### DIFF
--- a/data/io.elementary.code.gschema.xml
+++ b/data/io.elementary.code.gschema.xml
@@ -52,11 +52,6 @@
       <summary>Terminal visibility</summary>
       <description>Whether or not the terminal is shown</description>
     </key>
-    <key name="terminal-follows-project" type="b">
-      <default>true</default>
-      <summary>Terminal path changes according to active project</summary>
-      <description>Whether or not the terminal changes the working directory when the active project changes</description>
-    </key>
     <key name="outline-visible" type="b">
       <default>false</default>
       <summary>Symbol outline visibility</summary>
@@ -190,6 +185,11 @@
       <default>false</default>
       <summary>Whether to automatically remove trailing whitespace on saving</summary>
       <description>Whether trailing whitespace should be removed from a document whenever it is saved, including on autosave.</description>
+    </key>
+    <key name="terminal-follows-project" type="b">
+      <default>true</default>
+      <summary>Terminal path changes according to active project</summary>
+      <description>Whether or not the terminal changes the working directory when the active project changes</description>
     </key>
   </schema>
 

--- a/data/io.elementary.code.gschema.xml
+++ b/data/io.elementary.code.gschema.xml
@@ -47,6 +47,16 @@
       <summary>Sidebar visibility</summary>
       <description>Whether or not the sidebar is open</description>
     </key>
+    <key name="terminal-visible" type="b">
+      <default>false</default>
+      <summary>Terminal visibility</summary>
+      <description>Whether or not the terminal is shown</description>
+    </key>
+    <key name="terminal-follows-project" type="b">
+      <default>true</default>
+      <summary>Terminal path changes according to active project</summary>
+      <description>Whether or not the terminal changes the working directory when the active project changes</description>
+    </key>
     <key name="outline-visible" type="b">
       <default>false</default>
       <summary>Symbol outline visibility</summary>

--- a/data/io.elementary.code.gschema.xml
+++ b/data/io.elementary.code.gschema.xml
@@ -191,6 +191,11 @@
       <summary>Terminal path changes according to active project</summary>
       <description>Whether or not the terminal changes the working directory when the active project changes</description>
     </key>
+    <key name="terminal-enters-build" type="b">
+      <default>false</default>
+      <summary>Terminal path changes to build subdirectory of active project</summary>
+      <description>Whether or not the terminal changes the working directory to the root or build directory of active project</description>
+    </key>
   </schema>
 
   <schema path="/io/elementary/code/services/" id="io.elementary.code.services" gettext-domain="io.elementary.code">

--- a/src/Dialogs/PreferencesDialog.vala
+++ b/src/Dialogs/PreferencesDialog.vala
@@ -111,6 +111,7 @@ namespace Scratch.Dialogs {
             content.row_spacing = 6;
             content.column_spacing = 12;
 
+            // Editor settings
             var editor_header = new Granite.HeaderLabel (_("Editor"));
 
             var highlight_matching_brackets_label = new SettingsLabel (_("Highlight matching brackets:"));
@@ -136,6 +137,13 @@ namespace Scratch.Dialogs {
             Scratch.settings.bind ("right-margin-position", right_margin_position, "value", SettingsBindFlags.DEFAULT);
             Scratch.settings.bind ("show-right-margin", right_margin_position, "sensitive", SettingsBindFlags.DEFAULT);
 
+            // Terminal settings
+            var terminal_header = new Granite.HeaderLabel (_("Terminal"));
+
+            var follow_project_label = new SettingsLabel (_("Follow active project path:"));
+            var follow_project_switch = new SettingsSwitch ("terminal-follows-project");
+
+            // Font settings
             var font_header = new Granite.HeaderLabel (_("Font"));
 
             var use_custom_font_label = new SettingsLabel (_("Custom font:"));
@@ -160,11 +168,16 @@ namespace Scratch.Dialogs {
             content.attach (show_mini_map, 1, 5, 1, 1);
             content.attach (show_right_margin_label, 0, 6, 1, 1);
             content.attach (show_right_margin, 1, 6, 1, 1);
-            content.attach (right_margin_position, 2, 7, 1, 1);
-            content.attach (font_header, 0, 7, 3, 1);
-            content.attach (use_custom_font_label , 0, 9, 1, 1);
-            content.attach (use_custom_font, 1, 9, 1, 1);
-            content.attach (select_font, 2, 9, 1, 1);
+            content.attach (right_margin_position, 2, 6, 1, 1);
+
+            content.attach (terminal_header, 0, 7, 3, 1);
+            content.attach (follow_project_label, 0, 8, 1, 1);
+            content.attach (follow_project_switch, 1, 8, 1, 1);
+
+            content.attach (font_header, 0, 9, 3, 1);
+            content.attach (use_custom_font_label , 0, 10, 1, 1);
+            content.attach (use_custom_font, 1, 10, 1, 1);
+            content.attach (select_font, 2, 10, 1, 1);
 
             return content;
         }

--- a/src/Dialogs/PreferencesDialog.vala
+++ b/src/Dialogs/PreferencesDialog.vala
@@ -143,6 +143,11 @@ namespace Scratch.Dialogs {
             var follow_project_label = new SettingsLabel (_("Follow active project path:"));
             var follow_project_switch = new SettingsSwitch ("terminal-follows-project");
 
+            var enters_build_label = new SettingsLabel (_("Enter build subdirectory:"));
+            var enters_build_switch = new SettingsSwitch ("terminal-enters-build");
+            follow_project_switch.bind_property ("active", enters_build_label, "sensitive", BindingFlags.DEFAULT | BindingFlags.SYNC_CREATE);
+            follow_project_switch.bind_property ("active", enters_build_switch, "sensitive", BindingFlags.DEFAULT | BindingFlags.SYNC_CREATE);
+
             // Font settings
             var font_header = new Granite.HeaderLabel (_("Font"));
 
@@ -173,11 +178,13 @@ namespace Scratch.Dialogs {
             content.attach (terminal_header, 0, 7, 3, 1);
             content.attach (follow_project_label, 0, 8, 1, 1);
             content.attach (follow_project_switch, 1, 8, 1, 1);
+            content.attach (enters_build_label, 0, 9, 1, 1);
+            content.attach (enters_build_switch, 1, 9, 1, 1);
 
-            content.attach (font_header, 0, 9, 3, 1);
-            content.attach (use_custom_font_label , 0, 10, 1, 1);
-            content.attach (use_custom_font, 1, 10, 1, 1);
-            content.attach (select_font, 2, 10, 1, 1);
+            content.attach (font_header, 0, 10, 3, 1);
+            content.attach (use_custom_font_label , 0, 11, 1, 1);
+            content.attach (use_custom_font, 1, 11, 1, 1);
+            content.attach (select_font, 2, 11, 1, 1);
 
             return content;
         }

--- a/src/Widgets/Terminal.vala
+++ b/src/Widgets/Terminal.vala
@@ -90,7 +90,8 @@ public class Code.Terminal : Gtk.Box {
         var git_manager = Scratch.Services.GitManager.get_instance ();
         git_manager.notify["active-project-path"].connect (() => {
             if (settings.get_boolean ("terminal-follows-project")) {
-                var cmd = "cd '" + git_manager.active_project_path + "'\n";
+                var subdir = settings.get_boolean ("terminal-enters-build") ? "/build" : "";
+                var cmd = "cd '" + git_manager.active_project_path + subdir + "'\n";
                 // Assume no foreground process has been started in the terminal for simplicity
                 // Also assume the path is valid for now
                 terminal.feed_child (cmd.data);

--- a/src/Widgets/Terminal.vala
+++ b/src/Widgets/Terminal.vala
@@ -84,6 +84,11 @@ public class Code.Terminal : Gtk.Box {
         destroy.connect (() => {
             settings.set_string ("last-opened-path", get_shell_location ());
         });
+
+        Scratch.Services.GitManager.get_instance ().notify["active-project-path"].connect (() => {
+            var cmd = "cd '" + Scratch.Services.GitManager.get_instance ().active_project_path + "'\n";
+            terminal.feed_child (cmd.data);
+        });
     }
 
     private string get_shell_location () {


### PR DESCRIPTION
Fixes #600

 - [x] Implement persistent option for terminal working directory to follow active project
 - [x] Implement persistent option for terminal working directory to enter `build` subdirectory of active project.
 - [ ] Persistent visibility of terminal