### PR TITLE
Fix spurious external change warnings

### DIFF
--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -587,7 +587,7 @@ namespace Scratch.Services {
             return true;
         }
 
-        private async bool save_as () requires (!locked && is_saving)  {
+        private async bool save_as () requires (!locked && is_saving) {
             // New file
             if (!loaded) {
                 return false;


### PR DESCRIPTION
Since recent changes to external change handling it was noticed that spurious warnings of external changes were produced while editing.  This was traced to file status checking not completing before autosaving commenced because source loading is asynchronous.

This PR makes sure file status checking completes before saving starts when autosaving.