### PR TITLE
Refocus textview after Escape pressed in Search

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -653,7 +653,9 @@ namespace Scratch {
                     if (search_revealer.get_child_revealed ()) {
                         var fetch_action = Utils.action_from_group (ACTION_SHOW_FIND, actions);
                         fetch_action.set_state (false);
+                        document_view.current_document.source_view.grab_focus ();
                     }
+
                     break;
             }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -38,7 +38,7 @@ namespace Scratch {
         private Code.Terminal terminal;
         private FolderManager.FileView folder_manager_view;
         private Scratch.Services.DocumentManager document_manager;
-
+        private Gtk.EventControllerKey key_controller;
         // Plugins
         private Scratch.Services.PluginsManager plugins;
 
@@ -263,7 +263,10 @@ namespace Scratch {
 
             plugins = new Scratch.Services.PluginsManager (this);
 
-            key_press_event.connect (on_key_pressed);
+            key_controller = new Gtk.EventControllerKey (this) {
+                propagation_phase = CAPTURE
+            };
+            key_controller.key_pressed.connect (on_key_pressed);
 
             // Set up layout
             init_layout ();
@@ -643,8 +646,9 @@ namespace Scratch {
             });
         }
 
-        private bool on_key_pressed (Gdk.EventKey event) {
-            switch (Gdk.keyval_name (event.keyval)) {
+        // private bool on_key_pressed (Gdk.EventKey event) {
+        private bool on_key_pressed (uint keyval, uint keycode, Gdk.ModifierType state) {
+            switch (Gdk.keyval_name (keyval)) {
                 case "Escape":
                     if (search_revealer.get_child_revealed ()) {
                         var fetch_action = Utils.action_from_group (ACTION_SHOW_FIND, actions);

--- a/src/Widgets/SearchBar.vala
+++ b/src/Widgets/SearchBar.vala
@@ -497,9 +497,6 @@ namespace Scratch.Widgets {
                 case "Down":
                     search_next ();
                     return true;
-                case "Escape":
-                    text_view.grab_focus ();
-                    return true;
                 case "Tab":
                     if (search_entry.is_focus) {
                         replace_entry.grab_focus ();
@@ -523,9 +520,6 @@ namespace Scratch.Widgets {
                     return true;
                 case "Down":
                     search_next ();
-                    return true;
-                case "Escape":
-                    text_view.grab_focus ();
                     return true;
                 case "Tab":
                     if (replace_entry.is_focus) {


### PR DESCRIPTION
FIxes #1387 

The existing code appears to do this but it does not work - probably because the MainWindow also handles "Escape".

This fixes the issue by refocusing the text view using the MainWindow handler. 

In preparation for Gtk4 an EventControllerKey is used to trigger the handler.