### PR TITLE
Synchronise and save symbol outline width.

### DIFF
--- a/data/io.elementary.code.gschema.xml
+++ b/data/io.elementary.code.gschema.xml
@@ -47,6 +47,11 @@
       <summary>Symbol outline visibility</summary>
       <description>Whether or not the symbol outline is visible</description>
     </key>
+    <key name="outline-width" type="i">
+      <default>160</default>
+      <summary>Symbol outline width</summary>
+      <description>Width of the symbol outline sidebar</description>
+    </key>
     <key name="last-opened-path" type="s">
       <default>''</default>
       <summary>Last opened path</summary>

--- a/src/Widgets/DocumentView.vala
+++ b/src/Widgets/DocumentView.vala
@@ -41,6 +41,7 @@ public class Scratch.Widgets.DocumentView : Granite.Widgets.DynamicNotebook {
 
     public bool is_closing = false;
     public bool outline_visible { get; set; default = false; }
+    public int outline_width { get; set; }
 
     private Gtk.CssProvider style_provider;
 
@@ -108,7 +109,12 @@ public class Scratch.Widgets.DocumentView : Granite.Widgets.DynamicNotebook {
         granite_settings.notify["prefers-color-scheme"].connect (update_inline_tab_colors);
 
         notify["outline-visible"].connect (update_outline_visible);
-
+        Scratch.saved_state.bind ("outline-width", this, "outline-width", DEFAULT);
+        this.notify["outline-width"].connect (() => {
+            foreach (var doc in docs) {
+                doc.set_outline_width (outline_width);
+            }
+        });
         // Handle Drag-and-drop of files onto add-tab button to create document
         Gtk.TargetEntry uris = {"text/uri-list", 0, TargetType.URI_LIST};
         Gtk.drag_dest_set (this, Gtk.DestDefaults.ALL, {uris}, Gdk.DragAction.COPY);


### PR DESCRIPTION
Fixes #1329 

 - Add a new saved-state key `outline-width`
 - Bind to corresponding property of DocumentView
 - Keep Documents, DocumentView and saved-state settings in sync


A consequence of the PR having a single setting is that the outline pane width is always the same in all documents rather than individually adjustable but this is unlikely to be an issue. 
