### PR TITLE
Close root folder if externally deleted or renamed

### DIFF
--- a/src/FolderManager/FolderItem.vala
+++ b/src/FolderManager/FolderItem.vala
@@ -253,7 +253,7 @@ namespace Scratch.FolderManager {
             has_dummy = false;
         }
 
-        private void on_changed (GLib.File source, GLib.File? dest, GLib.FileMonitorEvent event) {
+        protected virtual void on_changed (GLib.File source, GLib.File? dest, GLib.FileMonitorEvent event) {
             if (source.get_basename ().has_prefix (".goutputstream")) {
                 return; // Ignore changes due to temp files and streams
             }

--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -82,6 +82,14 @@ namespace Scratch.FolderManager {
             }
         }
 
+        protected override void on_changed (GLib.File source, GLib.File? dest, GLib.FileMonitorEvent event) {
+            if (source.equal (file.file) && event == DELETED) {
+                closed ();
+            } else {
+                base.on_changed (source, dest, event);
+            }
+        }
+
         public void child_folder_changed (FolderItem folder) {
             if (monitored_repo != null) {
                 monitored_repo.update_status_map ();


### PR DESCRIPTION
Fixes #818 

Renaming a project folder externally results in it receiving a DELETED file monitor event and there is no obvious way of knowing what the new name is so the only solution is to close it.