### PR TITLE
Associate popover with foldermanager

### DIFF
--- a/plugins/fuzzy-search/fuzzy-search-popover.vala
+++ b/plugins/fuzzy-search/fuzzy-search-popover.vala
@@ -29,8 +29,7 @@ public class Scratch.FuzzySearchPopover : Gtk.Popover {
     public FuzzySearchPopover (Gee.HashMap<string, Services.SearchProject> pps, Scratch.MainWindow window) {
         Object (
             modal: true,
-            relative_to: window.sidebar,
-            constrain_to: Gtk.PopoverConstraint.WINDOW,
+            relative_to: window.document_view,
             width_request: 500,
             current_window: window
         );
@@ -85,6 +84,7 @@ public class Scratch.FuzzySearchPopover : Gtk.Popover {
     }
 
     construct {
+        pointing_to = { 0, 32, 1, 1 };
         this.get_style_context ().add_class ("fuzzy-popover");
 
         title_label = new Gtk.Label (_("Find project files"));
@@ -253,20 +253,6 @@ public class Scratch.FuzzySearchPopover : Gtk.Popover {
 
         scrolled.hide ();
         this.add (box);
-
-        closed.connect (() => {
-            current_window.sidebar.visible = sidebar_is_visible;
-        });
-    }
-
-    // Ensure popover has something to point to
-    public new void popup () {
-        sidebar_is_visible = current_window.sidebar.visible;
-        if (!sidebar_is_visible) {
-            current_window.sidebar.show ();
-        }
-
-        base.popup ();
     }
 
     private void handle_item_selection (int index) {

--- a/plugins/fuzzy-search/fuzzy-search-popover.vala
+++ b/plugins/fuzzy-search/fuzzy-search-popover.vala
@@ -20,7 +20,8 @@ public class Scratch.FuzzySearchPopover : Gtk.Popover {
     private bool should_distinguish_projects;
     private Gtk.EventControllerKey search_term_entry_key_controller;
     private Gtk.Label title_label;
-    private Scratch.MainWindow current_window;
+    public Scratch.MainWindow current_window { get; construct; }
+    public bool sidebar_is_visible { get; set; }
 
     public signal void open_file (string filepath);
     public signal void close_search ();
@@ -28,12 +29,11 @@ public class Scratch.FuzzySearchPopover : Gtk.Popover {
     public FuzzySearchPopover (Gee.HashMap<string, Services.SearchProject> pps, Scratch.MainWindow window) {
         Object (
             modal: true,
-            relative_to: window.toolbar,
+            relative_to: window.sidebar,
             constrain_to: Gtk.PopoverConstraint.WINDOW,
-            width_request: 500
+            width_request: 500,
+            current_window: window
         );
-
-        current_window = window;
 
         int height;
         current_window.get_size (null, out height);
@@ -253,6 +253,20 @@ public class Scratch.FuzzySearchPopover : Gtk.Popover {
 
         scrolled.hide ();
         this.add (box);
+
+        closed.connect (() => {
+            current_window.sidebar.visible = sidebar_is_visible;
+        });
+    }
+
+    // Ensure popover has something to point to
+    public new void popup () {
+        sidebar_is_visible = current_window.sidebar.visible;
+        if (!sidebar_is_visible) {
+            current_window.sidebar.show ();
+        }
+
+        base.popup ();
     }
 
     private void handle_item_selection (int index) {


### PR DESCRIPTION
 - Point popover to the folder manager since that is where it is searching
 - Show folder manager temporarily if it is hidden when popover is shown (else points to random position)


I am not sure about this one.  The issue I am trying to address is where the popover should point if the foldermanager or searchbar is hidden. Feel free to reject.