### PR TITLE
Make fuzzy-find less fuzzy in some respects

### DIFF
--- a/plugins/fuzzy-search/fuzzy-finder.vala
+++ b/plugins/fuzzy-search/fuzzy-finder.vala
@@ -6,11 +6,11 @@
  *              Colin Kiama <colinkiama@gmail.com>
  */
 
-const int SEQUENTIAL_BONUS = 15; // bonus for adjacent matches
 const int SEPARATOR_BONUS = 30; // bonus if match occurs after a separator
+const int SEQUENTIAL_BONUS = 40; // bonus for adjacent matches
+const int CURRENT_PROJECT_PRIORITY_BONUS = 40; // Bonus if search result is for current project
 const int CAMEL_BONUS = 30; // bonus if match is uppercase and prev is lower
 const int FIRST_LETTER_BONUS = 15; // bonus if the first letter is matched
-const int CURRENT_PROJECT_PRIORITY_BONUS = 20; // Bonus if search result is for current project
 const int LEADING_LETTER_PENALTY = -5; // penalty applied for every letter in str before the first match
 const int MAX_LEADING_LETTER_PENALTY = -15; // maximum penalty for leading letters
 const int UNMATCHED_LETTER_PENALTY = -1;

--- a/plugins/fuzzy-search/fuzzy-finder.vala
+++ b/plugins/fuzzy-search/fuzzy-finder.vala
@@ -74,6 +74,13 @@ public class Scratch.Services.FuzzyFinder {
 
                 // Match found.
                 if (lower_case_char == lower_case_str_char) {
+                    // specified directory must match at start
+                    if (dir_length > 0 && pattern_current_index == 0) {
+                        if ( str_current_index > 0 && str.get_char (str_current_index - 1).tolower () != Path.DIR_SEPARATOR) {
+                            break;
+                        }
+                    }
+
                     allowed_separators = false;
                     if (next_match >= max_matches) {
                         return new SearchResult (false, out_score);
@@ -114,9 +121,9 @@ public class Scratch.Services.FuzzyFinder {
 
                     ++next_match;
                     ++pattern_current_index;
-                } else if (pattern_current_index <= dir_length) {
+                } else if (pattern_current_index <= dir_length) { // specified dir must match sequentially
                     break;
-                } else if (lower_case_str_char == Path.DIR_SEPARATOR && !allowed_separators) {
+                } else if (lower_case_str_char == Path.DIR_SEPARATOR && !allowed_separators) { // no splitting across directories
                     break;
                 }
 

--- a/plugins/fuzzy-search/fuzzy-finder.vala
+++ b/plugins/fuzzy-search/fuzzy-finder.vala
@@ -52,7 +52,7 @@ public class Scratch.Services.FuzzyFinder {
             var best_recursive_score = 0;
             // Loop through pattern and str looking for a match.
             bool first_match = true;
-
+            bool allowed_separators = true;
             recursion_count++;
             if (cancellable.is_cancelled () || limit_reached ()) {
                 return new SearchResult (false, out_score);
@@ -71,8 +71,10 @@ public class Scratch.Services.FuzzyFinder {
                 var lower_case_char = pattern.get_char (pattern_current_index).tolower ();
                 var lower_case_str_char = str.get_char (str_current_index).tolower ();
 
+
                 // Match found.
                 if (lower_case_char == lower_case_str_char) {
+                    allowed_separators = false;
                     if (next_match >= max_matches) {
                         return new SearchResult (false, out_score);
                     }
@@ -113,6 +115,8 @@ public class Scratch.Services.FuzzyFinder {
                     ++next_match;
                     ++pattern_current_index;
                 } else if (pattern_current_index <= dir_length) {
+                    break;
+                } else if (lower_case_str_char == Path.DIR_SEPARATOR && !allowed_separators) {
                     break;
                 }
 

--- a/plugins/fuzzy-search/fuzzy-finder.vala
+++ b/plugins/fuzzy-search/fuzzy-finder.vala
@@ -195,14 +195,14 @@ public class Scratch.Services.FuzzyFinder {
       project_paths = pps;
     }
 
-    public async Gee.ArrayList<SearchResult> fuzzy_find_async (string search_str,
+    public async Gee.ArrayList<SearchResult> fuzzy_find_async (string search_str, string dir,
                                                                string current_project,
                                                                GLib.Cancellable cancellable) {
         var results = new Gee.ArrayList<SearchResult> ();
 
         SourceFunc callback = fuzzy_find_async.callback;
         new Thread<void> ("fuzzy-find", () => {
-            results = fuzzy_find (search_str, current_project, cancellable);
+            results = fuzzy_find (search_str, dir, current_project, cancellable);
             Idle.add ((owned) callback);
         });
 
@@ -210,7 +210,7 @@ public class Scratch.Services.FuzzyFinder {
         return results;
     }
 
-    public Gee.ArrayList<SearchResult> fuzzy_find (string search_str,
+    public Gee.ArrayList<SearchResult> fuzzy_find (string search_str, string dir,
                                                    string current_project,
                                                    GLib.Cancellable cancellable) {
         var results = new Gee.ArrayList<SearchResult> ();
@@ -268,7 +268,7 @@ public class Scratch.Services.FuzzyFinder {
                     path_search_result.relative_path = path;
                     path_search_result.full_path = @"$root_path/$path";
                     path_search_result.project = project_name;
-                    path_search_result.score = (int) (path_search_result.score * 0.5) +
+                    path_search_result.score = (int) (path_search_result.score * 0.2) +
                         (project.root_path == current_project
                             ? CURRENT_PROJECT_PRIORITY_BONUS
                             : 0);

--- a/plugins/fuzzy-search/fuzzy-search-popover.vala
+++ b/plugins/fuzzy-search/fuzzy-search-popover.vala
@@ -166,9 +166,27 @@ public class Scratch.FuzzySearchPopover : Gtk.Popover {
                 }
 
                 Timeout.add (1, () => {
+                        // If the entry is empty or the text has changed
+                        // since searching, do nothing
+                        if (previous_text.length == 0 || previous_text != search_term_entry.text) {
+                            return Source.REMOVE;
+                        }
+
                         var next_cancellable = new GLib.Cancellable ();
                         cancellables.add (next_cancellable);
-                        fuzzy_finder.fuzzy_find_async.begin (search_term_entry.text,
+
+                        var dir = "", term = "";
+                        var parts = search_term_entry.text.split (Path.DIR_SEPARATOR_S, 0);
+                        if (parts.length > 2) {
+                            return Source.REMOVE;
+                        } else if (parts.length == 2) {
+                            dir = parts[0];
+                            term = parts[1];
+                        } else {
+                            term = parts[0];
+                        }
+
+                        fuzzy_finder.fuzzy_find_async.begin (term, dir,
                                                              get_current_project (),
                                                              next_cancellable,
                                                              (obj, res) => {
@@ -184,11 +202,7 @@ public class Scratch.FuzzySearchPopover : Gtk.Popover {
 
                         bool first = true;
 
-                        // If the entry is empty or the text has changed
-                        // since searching, do nothing
-                        if (previous_text.length == 0 || previous_text != search_term_entry.text) {
-                            return;
-                        }
+
 
                         foreach (var c in search_result_container.get_children ()) {
                             search_result_container.remove (c);

--- a/plugins/fuzzy-search/fuzzy-search-popover.vala
+++ b/plugins/fuzzy-search/fuzzy-search-popover.vala
@@ -177,10 +177,9 @@ public class Scratch.FuzzySearchPopover : Gtk.Popover {
 
                         var dir_length = 0, term = search_term_entry.text;
                         var parts = term.split (Path.DIR_SEPARATOR_S, 0);
-                        if (parts.length > 2) {
-                            return Source.REMOVE;
-                        } else if (parts.length == 2) {
-                            dir_length = parts[0].length + 1;
+                        var rev_parts = term.reverse ().split (Path.DIR_SEPARATOR_S, 2);
+                        if (rev_parts.length == 2) {
+                            dir_length = rev_parts[0].length + 1;
                         }
 
                         fuzzy_finder.fuzzy_find_async.begin (term, dir_length,

--- a/plugins/fuzzy-search/fuzzy-search-popover.vala
+++ b/plugins/fuzzy-search/fuzzy-search-popover.vala
@@ -175,18 +175,15 @@ public class Scratch.FuzzySearchPopover : Gtk.Popover {
                         var next_cancellable = new GLib.Cancellable ();
                         cancellables.add (next_cancellable);
 
-                        var dir = "", term = "";
-                        var parts = search_term_entry.text.split (Path.DIR_SEPARATOR_S, 0);
+                        var dir_length = 0, term = search_term_entry.text;
+                        var parts = term.split (Path.DIR_SEPARATOR_S, 0);
                         if (parts.length > 2) {
                             return Source.REMOVE;
                         } else if (parts.length == 2) {
-                            dir = parts[0];
-                            term = parts[1];
-                        } else {
-                            term = parts[0];
+                            dir_length = parts[0].length + 1;
                         }
 
-                        fuzzy_finder.fuzzy_find_async.begin (term, dir,
+                        fuzzy_finder.fuzzy_find_async.begin (term, dir_length,
                                                              get_current_project (),
                                                              next_cancellable,
                                                              (obj, res) => {


### PR DESCRIPTION
- Prioritise sequential matches at start of filename
 - Match folder exactly if specified
 - Do not split matched parts across directory separator in path


With this PR if you enter something like "src/c" it will find files starting c (or containing) in or below the "src" folder.  

"src/w" will also match all files in "src/Widgets/" and any other folder containing "w" and any file below "src" containing "w" which I am not sure is a desirable behaviour but that can be fixed separately if not.

Multiple directory separators are now accepted but note that only the first folder must be an exact match.  So "src/w/s"
Will match all filenames containing "s" in foldername containing "w" below "src" .

 "cool" in "code/po/lu.po" is not now matched