### PR TITLE
ValaSymbolOutline: Lose global header

### DIFF
--- a/src/SymbolPane/SymbolOutline.vala
+++ b/src/SymbolPane/SymbolOutline.vala
@@ -27,8 +27,6 @@ public abstract class Scratch.Services.SymbolOutline : Object {
 
     construct {
         store = new Granite.Widgets.SourceList ();
-        root = new Granite.Widgets.SourceList.ExpandableItem (_("Symbols"));
-        store.root.add (root);
 
         set_up_css ();
     }

--- a/src/SymbolPane/Vala/ValaSymbolOutline.vala
+++ b/src/SymbolPane/Vala/ValaSymbolOutline.vala
@@ -91,7 +91,6 @@ public class Scratch.Services.ValaSymbolOutline : Scratch.Services.SymbolOutline
 
                         var new_child = new ValaSymbolItem (child.symbol);
                         if (child.parent.name == new_root.name && !(child.n_children > 0)) {
-                            var parent_symbol = new_child.symbol.parent_symbol;
                             var existing = find_existing (new_child.symbol, new_root, cancellable);
                             if (existing == null || existing.parent == new_root) {
                                 symbol_header.add (new_child);

--- a/src/SymbolPane/Vala/ValaSymbolOutline.vala
+++ b/src/SymbolPane/Vala/ValaSymbolOutline.vala
@@ -96,8 +96,6 @@ public class Scratch.Services.ValaSymbolOutline : Scratch.Services.SymbolOutline
                             if (existing == null || existing.parent == new_root) {
                                 symbol_header.add (new_child);
                             }
-                        } else {
-                            store.root.add (new_child);
                         }
                     }
 


### PR DESCRIPTION
Fixes #378 

Because SourceList requires the toplevel items to be headers, it seems, it was necessary to add another header "Other Symbols" when there are symbols that would not otherwise appear (e.g. those outside of classes or an existing namespace).  This complicates the code significantly.

The CSymbolOutline was not touched as there are usually a large number of symbols at the top level.