### PR TITLE
ChooseProjectButton: Deactivate all project rows before selecting new active project

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -107,6 +107,7 @@ namespace Scratch {
 
         private ulong color_scheme_listener_handler_id = 0;
 
+        private Services.GitManager git_manager;
 
         private const ActionEntry[] ACTION_ENTRIES = {
             { ACTION_FIND, action_fetch, "s" },
@@ -236,6 +237,7 @@ namespace Scratch {
             default_theme.add_resource_path ("/io/elementary/code");
 
             document_manager = Scratch.Services.DocumentManager.get_instance ();
+            git_manager = Services.GitManager.get_instance ();
 
             actions = new SimpleActionGroup ();
             actions.add_action_entries (ACTION_ENTRIES, this);
@@ -586,7 +588,9 @@ namespace Scratch {
                     title = _("%s - %s").printf (doc.get_basename (), base_title);
 
                     toolbar.set_document_focus (doc);
-                    sidebar.choose_project_button.set_document (doc);
+                    // sidebar.choose_project_button.set_document (doc);
+                    warning ("WINDOW: set active project _path %s", doc.source_view.project.path);
+                    git_manager.active_project_path = doc.source_view.project.path;
                     folder_manager_view.select_path (doc.file.get_path ());
 
                     // Must follow setting focus document for editorconfig plug
@@ -1162,7 +1166,7 @@ namespace Scratch {
                 Utils.action_from_group (ACTION_FIND_NEXT, actions).set_enabled (is_current_doc);
                 Utils.action_from_group (ACTION_FIND_PREVIOUS, actions).set_enabled (is_current_doc);
 
-                var is_active_project = Services.GitManager.get_instance ().active_project_path != "";
+                var is_active_project = git_manager.active_project_path != "";
                 Utils.action_from_group (ACTION_FIND_GLOBAL, actions).set_enabled (is_active_project);
                 return Source.REMOVE;
             });
@@ -1330,7 +1334,7 @@ namespace Scratch {
              }
 
              if (path == "") { // Happens when keyboard accelerator is used
-                 path = Services.GitManager.get_instance ().active_project_path;
+                 path = git_manager.active_project_path;
                  if (path == null) {
                      var current_doc = get_current_document ();
                      if (current_doc != null) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -588,8 +588,6 @@ namespace Scratch {
                     title = _("%s - %s").printf (doc.get_basename (), base_title);
 
                     toolbar.set_document_focus (doc);
-                    // sidebar.choose_project_button.set_document (doc);
-                    warning ("WINDOW: set active project _path %s", doc.source_view.project.path);
                     git_manager.active_project_path = doc.source_view.project.path;
                     folder_manager_view.select_path (doc.file.get_path ());
 

--- a/src/Widgets/ChooseProjectButton.vala
+++ b/src/Widgets/ChooseProjectButton.vala
@@ -116,6 +116,13 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
 
         project_listbox.row_activated.connect ((row) => {
             var project_entry = ((ProjectRow) row);
+            int index = 0;
+            ProjectRow project_row = ((ProjectRow)(project_listbox.get_row_at_index (index++)));
+            while (project_row != null) {
+                project_row.active = false;
+                project_row = ((ProjectRow)(project_listbox.get_row_at_index (index++)));
+            }
+
             select_project (project_entry);
             project_chosen ();
         });

--- a/src/Widgets/ChooseProjectButton.vala
+++ b/src/Widgets/ChooseProjectButton.vala
@@ -167,9 +167,6 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
         return project_row;
     }
 
-    private void select_project (ProjectRow project_entry) {
-    }
-
     public class ProjectRow : Gtk.ListBoxRow {
         public bool active {
             get {

--- a/src/Widgets/ChooseProjectButton.vala
+++ b/src/Widgets/ChooseProjectButton.vala
@@ -114,7 +114,7 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
             }
         });
 
-        project_listbox.row_activated.connect ((row) => {
+        project_listbox.row_selected.connect ((row) => {
             var project_entry = ((ProjectRow) row);
             int index = 0;
             var project_row = ((ProjectRow)(project_listbox.get_row_at_index (index++)));
@@ -123,6 +123,7 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
                 project_row = ((ProjectRow)(project_listbox.get_row_at_index (index++)));
             }
 
+            project_entry.active = true;
             select_project (project_entry);
             project_chosen ();
         });
@@ -130,6 +131,7 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
 
     private Gtk.Widget create_project_row (Scratch.FolderManager.ProjectFolderItem project_folder) {
         var project_row = new ProjectRow (project_folder.file.file.get_path ());
+        // Handle renaming of project;
         project_folder.bind_property ("name", project_row.project_radio, "label", BindingFlags.DEFAULT | BindingFlags.SYNC_CREATE,
             (binding, srcval, ref targetval) => {
                 var label = srcval.get_string ();
@@ -137,6 +139,7 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
                 if (project_row.active) {
                     label_widget.label = label;
                 }
+
                 return true;
             }
         );
@@ -150,12 +153,11 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
     }
 
     private void select_project (ProjectRow project_entry) {
-        project_listbox.select_row (project_entry);
         label_widget.label = project_entry.project_name;
         var tooltip_text = Scratch.Utils.replace_home_with_tilde (project_entry.project_path);
         label_widget.tooltip_text = _("Active Git project: %s").printf (tooltip_text);
-        project_entry.active = true;
         Scratch.Services.GitManager.get_instance ().active_project_path = project_entry.project_path;
+        project_listbox.select_row (project_entry);
     }
 
     public void set_document (Scratch.Services.Document doc) {

--- a/src/Widgets/ChooseProjectButton.vala
+++ b/src/Widgets/ChooseProjectButton.vala
@@ -117,7 +117,7 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
         project_listbox.row_activated.connect ((row) => {
             var project_entry = ((ProjectRow) row);
             int index = 0;
-            ProjectRow project_row = ((ProjectRow)(project_listbox.get_row_at_index (index++)));
+            var project_row = ((ProjectRow)(project_listbox.get_row_at_index (index++)));
             while (project_row != null) {
                 project_row.active = false;
                 project_row = ((ProjectRow)(project_listbox.get_row_at_index (index++)));


### PR DESCRIPTION
Fixes #1413 

Although the list box is in SINGLE selection mode, the radio buttons in the project rows are not affected by this so have to be explicitly unchecked when a new active project is chosen.

This PR makes the GitManager the source of truth regarding the active_project_path.  Some public access is removed. It also simplifies the ProjectRows and makes sure they remain grouped even when projects are removed and are re-added.