### PR TITLE
[Feature] Implement default build directory setting

### DIFF
--- a/data/io.elementary.code.gschema.xml
+++ b/data/io.elementary.code.gschema.xml
@@ -151,6 +151,11 @@
       <summary>Remember the last focused document.</summary>
       <description>Restore the focused document from a previous session when opening Code.</description>
     </key>
+    <key name="default-build-directory" type="s">
+      <default>''</default>
+      <summary>The default build directory's relative path.</summary>
+      <description>The directory, relative to the project root, at which to open the terminal pane and where to run build commands by default.</description>
+    </key>
     <key name="prefer-dark-style" type="b">
       <default>false</default>
       <summary>Request dark Gtk stylesheet variant</summary>

--- a/src/Dialogs/PreferencesDialog.vala
+++ b/src/Dialogs/PreferencesDialog.vala
@@ -56,6 +56,7 @@ namespace Scratch.Dialogs {
                 halign = START
             };
 
+            Scratch.settings.bind ("default-build-directory", build_dir_entry, "text", DEFAULT);
             var general_grid = new Gtk.Grid ();
 
             general_grid.column_spacing = 12;

--- a/src/Dialogs/PreferencesDialog.vala
+++ b/src/Dialogs/PreferencesDialog.vala
@@ -49,7 +49,15 @@ namespace Scratch.Dialogs {
             var indent_width = new Gtk.SpinButton.with_range (1, 24, 1);
             Scratch.settings.bind ("indent-width", indent_width, "value", SettingsBindFlags.DEFAULT);
 
+            var buid_dir_label = new SettingsLabel (_("Default build directory"));
+            var build_dir_entry = new Gtk.Entry () {
+                placeholder_text = ".",
+                margin = 12,
+                halign = START
+            };
+
             var general_grid = new Gtk.Grid ();
+
             general_grid.column_spacing = 12;
             general_grid.row_spacing = 6;
             general_grid.attach (new Granite.HeaderLabel (_("General")), 0, 0, 3);
@@ -67,9 +75,13 @@ namespace Scratch.Dialogs {
             general_grid.attach (new SettingsSwitch ("strip-trailing-on-save"), 1, 6, 2);
             general_grid.attach (new SettingsLabel (_("Tab width:")), 0, 7);
             general_grid.attach (indent_width, 1, 7, 2);
+            general_grid.attach (new Granite.HeaderLabel (_("Projects")), 0, 8);
+            general_grid.attach (buid_dir_label, 0, 9);
+            general_grid.attach (build_dir_entry, 1, 9, 2);
 
             main_stack = new Gtk.Stack () {
-                margin = 12
+                margin = 12,
+                vhomogeneous = true
             };
             main_stack.add_titled (general_grid, "behavior", _("Behavior"));
             main_stack.add_titled (get_editor_box (), "interface", _("Interface"));

--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -120,9 +120,10 @@ namespace Scratch.FolderManager {
                _("Open in Terminal Pane"),
                 MainWindow.ACTION_PREFIX + MainWindow.ACTION_OPEN_IN_TERMINAL + "::"
             );
+
             var open_in_terminal_pane_item = new Gtk.MenuItem () {
                 action_name = MainWindow.ACTION_PREFIX + MainWindow.ACTION_OPEN_IN_TERMINAL,
-                action_target = new Variant.string (file.file.get_path ())
+                action_target = new Variant.string (Services.GitManager.get_instance ().get_default_build_dir (path))
             };
             open_in_terminal_pane_item.add (open_in_terminal_pane_label);
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1309,9 +1309,9 @@ namespace Scratch {
                 toggle_terminal_action.activate (null);
             }
 
-            //If param is null or empty, the active project path is returned or failing that
+            //If param is null or empty, the active project path build dir is returned or failing that
             //the active document path
-            var target_path = get_target_path_for_actions (param);
+            var target_path = get_target_path_for_actions (param, true);
             terminal.change_location (target_path);
             terminal.terminal.grab_focus ();
         }
@@ -1342,7 +1342,7 @@ namespace Scratch {
             folder_manager_view.new_branch (get_target_path_for_actions (param));
         }
 
-        private string? get_target_path_for_actions (Variant? path_variant) {
+        private string? get_target_path_for_actions (Variant? path_variant, bool use_build_dir = false) {
              string? path = "";
              if (path_variant != null) {
                  path = path_variant.get_string ();
@@ -1350,6 +1350,10 @@ namespace Scratch {
 
              if (path == "") { // Happens when keyboard accelerator is used
                  path = git_manager.active_project_path;
+                 if (use_build_dir) {
+                     path = git_manager.get_default_build_dir (path);
+                 }
+
                  if (path == null) {
                      var current_doc = get_current_document ();
                      if (current_doc != null) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -605,7 +605,8 @@ namespace Scratch {
                 folder_manager_view.collapse_other_projects ();
                 if (terminal.visible) {
                     var open_in_terminal_action = Utils.action_from_group (ACTION_OPEN_IN_TERMINAL, actions);
-                    open_in_terminal_action.activate (null);
+                    var param = new Variant.string (Services.GitManager.get_instance ().get_default_build_dir (null));
+                    open_in_terminal_action.activate (param);
                 }
             });
 

--- a/src/Services/GitManager.vala
+++ b/src/Services/GitManager.vala
@@ -98,5 +98,16 @@ namespace Scratch.Services {
                 project_gitrepo_map.unset (root_path);
             }
         }
+
+        public string get_default_build_dir (string project_path) {
+            var build_path = project_path;
+            var default_build_dir = Scratch.settings.get_string ("default-build-directory");
+            var build_file = GLib.File.new_for_path (Path.build_filename (project_path, default_build_dir));
+            if (build_file.query_exists ()) {
+                build_path = build_file.get_path ();
+            }
+
+            return build_path;
+        }
     }
 }

--- a/src/Services/GitManager.vala
+++ b/src/Services/GitManager.vala
@@ -99,12 +99,15 @@ namespace Scratch.Services {
             }
         }
 
-        public string get_default_build_dir (string project_path) {
-            var build_path = project_path;
+        // @project_path is the root of a project or null
+        public string get_default_build_dir (string? project_path) {
+            string build_path = project_path != null ? project_path : active_project_path;
             var default_build_dir = Scratch.settings.get_string ("default-build-directory");
-            var build_file = GLib.File.new_for_path (Path.build_filename (project_path, default_build_dir));
+            var build_file = GLib.File.new_for_path (Path.build_filename (build_path, default_build_dir));
             if (build_file.query_exists ()) {
                 build_path = build_file.get_path ();
+            } else {
+                warning ("build path not found %s", build_file.get_path ());
             }
 
             return build_path;


### PR DESCRIPTION
This PR allows the setting of a global default build directory (relative to the root of projects) so that when the path of the terminal pane is changed by manually selecting the active project or using the ProjectFolderItem context menu, the desired build location within the project is automatically used.

![Screenshot from 2024-01-24 18 48 32](https://github.com/elementary/code/assets/10513844/a442482d-a709-4d9a-ad9e-38f7f7fa27e5)
