### PR TITLE
Fix hang when two project names share the same prefix

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1087,7 +1087,7 @@ namespace Scratch {
         private void close_project_docs (string project_path, bool make_restorable) {
             unowned var docs = document_view.docs;
             docs.foreach ((doc) => {
-                if (doc.file.get_path ().has_prefix (project_path)) {
+                if (doc.file.get_path ().has_prefix (project_path + Path.DIR_SEPARATOR_S)) {
                     document_view.close_document (doc);
                     if (make_restorable) {
                         document_manager.make_restorable (doc);

--- a/src/Widgets/ChooseProjectButton.vala
+++ b/src/Widgets/ChooseProjectButton.vala
@@ -141,12 +141,13 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
     }
 
     private void set_active_path (string active_path) {
-        project_listbox.get_children ().foreach ((child) => {
+        foreach (var child in project_listbox.get_children ()) {
             var project_entry = ((ProjectRow) child);
-            if (active_path.has_prefix (project_entry.project_path)) {
+            if (active_path.has_prefix (project_entry.project_path + Path.DIR_SEPARATOR_S)) {
                 project_listbox.row_activated (project_entry);
+                break;
             }
-        });
+        }
     }
 
     private Gtk.Widget create_project_row (Scratch.FolderManager.ProjectFolderItem project_folder) {


### PR DESCRIPTION
* Match complete directory name for prefix in two places
* Ensure set active path only activates one row