### PR TITLE
Put branch name on separate line

### DIFF
--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -59,7 +59,7 @@ namespace Scratch.FolderManager {
             if (monitored_repo != null) {
                 //As SourceList items are not widgets we have to use markup to change appearance of text.
                 if (monitored_repo.head_is_branch) {
-                    markup = "%s <span size='small' weight='normal'>%s</span>".printf (
+                    markup = "<span size='larger'>%s</span>\n<span size='small' weight='normal'>%s</span>".printf (
                         name, monitored_repo.branch_name
                     );
                 } else { //Distinguish detached heads visually

--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -59,7 +59,7 @@ namespace Scratch.FolderManager {
             if (monitored_repo != null) {
                 //As SourceList items are not widgets we have to use markup to change appearance of text.
                 if (monitored_repo.head_is_branch) {
-                    markup = "<span size='larger'>%s</span>\n<span size='small' weight='normal'>%s</span>".printf (
+                    markup = "<span size='medium'>%s</span>\n<span size='small' weight='normal'>%s</span>".printf (
                         name, monitored_repo.branch_name
                     );
                 } else { //Distinguish detached heads visually

--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -59,7 +59,7 @@ namespace Scratch.FolderManager {
             if (monitored_repo != null) {
                 //As SourceList items are not widgets we have to use markup to change appearance of text.
                 if (monitored_repo.head_is_branch) {
-                    markup = "<span size='medium'>%s</span>\n<span size='small' weight='normal'>%s</span>".printf (
+                    markup = "%s\n<span size='small' weight='normal'>%s</span>".printf (
                         name, monitored_repo.branch_name
                     );
                 } else { //Distinguish detached heads visually

--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -63,7 +63,7 @@ namespace Scratch.FolderManager {
                         name, monitored_repo.branch_name
                     );
                 } else { //Distinguish detached heads visually
-                    markup = "%s <span size='small' weight='normal' style='italic'>%s</span>".printf (
+                    markup = "%s\n <span size='small' weight='normal' style='italic'>%s</span>".printf (
                         name, monitored_repo.branch_name
                     );
                 }


### PR DESCRIPTION
Fixes #574 

Makes current branch visible without excessive sidebar width when both project and branch have long names
![Screenshot from 2024-02-22 11 03 04](https://github.com/elementary/code/assets/10513844/64de1a03-ac85-42f0-bcef-f34b3d2b24a8)
