### PR TITLE
changing the order of the right click new items menu

### DIFF
--- a/src/FolderManager/FolderItem.vala
+++ b/src/FolderManager/FolderItem.vala
@@ -215,15 +215,15 @@ namespace Scratch.FolderManager {
         }
 
         protected Gtk.MenuItem create_submenu_for_new () {
-            var new_folder_item = new Gtk.MenuItem.with_label (_("Folder"));
-            new_folder_item.activate.connect (() => on_add_new (true));
-
             var new_file_item = new Gtk.MenuItem.with_label (_("Empty File"));
             new_file_item.activate.connect (() => on_add_new (false));
 
+            var new_folder_item = new Gtk.MenuItem.with_label (_("Folder"));
+            new_folder_item.activate.connect (() => on_add_new (true));
+
             var new_menu = new Gtk.Menu ();
-            new_menu.append (new_folder_item);
             new_menu.append (new_file_item);
+            new_menu.append (new_folder_item);
 
             var new_item = new Gtk.MenuItem.with_label (_("New"));
             new_item.set_submenu (new_menu);


### PR DESCRIPTION
I am updating the order of the 'right-click' menu items in Code when right -clicking on a folder in the file pane.  The items were out of alphabetical order, but also, I feel people are more likely to create a new file vs a new folder, thus making navigating/mousing this menu easier.

I also swapped the order of the Gtk.MenuItem in the source (lines 218-223) to maintain the order following the menu creation and readability, however it isn't necessary.  Only a swap of lines 225 and 226 are truly needed for this change.