### PR TITLE
Application: Localize go-to option

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -38,7 +38,7 @@ namespace Scratch {
             { "new-tab", 't', 0, OptionArg.NONE, null, N_("New Tab"), null },
             { "new-window", 'n', 0, OptionArg.NONE, null, N_("New Window"), null },
             { "version", 'v', 0, OptionArg.NONE, null, N_("Print version info and exit"), null },
-            { "go-to", 'g', 0, OptionArg.STRING, null, "Open file at specified selection range", "<start_line[.start_column][-end_line[.end_column]]>" },
+            { "go-to", 'g', 0, OptionArg.STRING, null, N_("Open file at specified selection range"), N_("<START_LINE[.START_COLUMN][-END_LINE[.END_COLUMN]]>") },
             { GLib.OPTION_REMAINING, 0, 0, OptionArg.FILENAME_ARRAY, null, null, N_("[FILE…]") },
             { null }
         };


### PR DESCRIPTION
Other options are localized, so I guess we should localized this string too for consistency.
Also use UPPER_SNAKE_CASE for parameters which is commonly used case in other commands like cp, tar, etc.