### PR TITLE
Define terminal menu items using GLib.MenuModel

### DIFF
--- a/src/Widgets/Terminal.vala
+++ b/src/Widgets/Terminal.vala
@@ -19,8 +19,6 @@ public class Code.Terminal : Gtk.Box {
     public SimpleActionGroup actions { get; construct; }
 
     private GLib.Pid child_pid;
-    private SimpleAction copy_action;
-    private SimpleAction paste_action;
     private Gtk.Clipboard current_clipboard;
 
     construct {
@@ -46,11 +44,11 @@ public class Code.Terminal : Gtk.Box {
             GLib.Application.get_default ().activate_action (Scratch.MainWindow.ACTION_PREFIX + Scratch.MainWindow.ACTION_TOGGLE_TERMINAL, null);
         });
 
-        copy_action = new SimpleAction (ACTION_COPY, null);
+        var copy_action = new SimpleAction (ACTION_COPY, null);
         copy_action.set_enabled (false);
         copy_action.activate.connect (() => copy ());
 
-        paste_action = new SimpleAction (ACTION_PASTE, null);
+        var paste_action = new SimpleAction (ACTION_PASTE, null);
         paste_action.activate.connect (() => paste ());
 
         actions = new SimpleActionGroup ();

--- a/src/Widgets/Terminal.vala
+++ b/src/Widgets/Terminal.vala
@@ -75,7 +75,6 @@ public class Code.Terminal : Gtk.Box {
         realize.connect (() => {
             current_clipboard = terminal.get_clipboard (Gdk.SELECTION_CLIPBOARD);
             copy_action.set_enabled (terminal.get_has_selection ());
-
         });
 
         terminal.selection_changed.connect (() => {

--- a/src/Widgets/Terminal.vala
+++ b/src/Widgets/Terminal.vala
@@ -46,10 +46,10 @@ public class Code.Terminal : Gtk.Box {
 
         var copy_action = new SimpleAction (ACTION_COPY, null);
         copy_action.set_enabled (false);
-        copy_action.activate.connect (() => copy ());
+        copy_action.activate.connect (() => terminal.copy_clipboard ());
 
         var paste_action = new SimpleAction (ACTION_PASTE, null);
-        paste_action.activate.connect (() => paste ());
+        paste_action.activate.connect (() => terminal.paste_clipboard ());
 
         actions = new SimpleActionGroup ();
         actions.add_action (copy_action);
@@ -95,14 +95,6 @@ public class Code.Terminal : Gtk.Box {
         });
 
         show_all ();
-    }
-
-    public void copy () {
-        terminal.copy_clipboard ();
-    }
-
-    public void paste () {
-        terminal.paste_clipboard ();
     }
 
     private void spawn_shell (string dir = GLib.Environment.get_current_dir ()) {


### PR DESCRIPTION
Replaces usage of Gtk.MenuItem with GLib.MenuModel in the Terminal widget as #1157 