### PR TITLE
Fix "go to line" behaviour when column number is not explicitly set

### DIFF
--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -320,7 +320,9 @@ namespace Scratch.Widgets {
         public void go_to_line (int line, int offset = 0) {
             Gtk.TextIter it;
             buffer.get_iter_at_line (out it, line - 1);
-            it.forward_chars (offset);
+            // Ensures offset is set to start of line when column is not set
+            // offset = column - 1
+            it.forward_chars (offset == -1 ? 0 : offset);
             scroll_to_iter (it, 0, false, 0, 0);
             buffer.place_cursor (it);
         }


### PR DESCRIPTION
When the value of `offset` in the SourceView widget's `go_to_line` method is less than 0, use `0` as the character position instead of `offset` to prevent cursor being moved to the line before the intended line number to go to.