### PR TITLE
PreferencesDialog: make whitespace strings consistent

### DIFF
--- a/src/Dialogs/PreferencesDialog.vala
+++ b/src/Dialogs/PreferencesDialog.vala
@@ -93,7 +93,7 @@ public class Scratch.Dialogs.Preferences : Granite.Dialog {
             }
         });
 
-        var draw_spaces_label = new Gtk.Label (_("White space visible when not selected")) {
+        var draw_spaces_label = new Gtk.Label (_("Whitespace visible when not selected")) {
             halign = START,
             hexpand = true,
             mnemonic_widget = drawspaces_combobox


### PR DESCRIPTION
We use "whitespace" here, so this should maybe be the same? Or maybe that one should be changed? Or maybe they should both have a hyphen? :laughing: 

But I think they should at least be consistent.

https://github.com/elementary/code/blob/a03ec88be58ec125d6e009799fd522c63a47f344/src/Dialogs/PreferencesDialog.vala#L25