### PR TITLE
Jeremypw/fix cancel folder creation

### DIFF
--- a/src/FolderManager/FolderItem.vala
+++ b/src/FolderManager/FolderItem.vala
@@ -252,8 +252,8 @@ namespace Scratch.FolderManager {
 
             view.ignore_next_select = true;
             ((Code.Widgets.SourceList.ExpandableItem)this).remove (item);
-            // Add back dummy if empty unless we are removing a rename item
-            if (!(item is RenameItem || has_dummy || n_children > 0)) {
+            // Add back dummy if empty
+            if (!(has_dummy || n_children > 0)) {
                 ((Code.Widgets.SourceList.ExpandableItem)this).add (dummy);
                 has_dummy = true;
             }

--- a/src/Utils.vala
+++ b/src/Utils.vala
@@ -172,8 +172,12 @@ namespace Scratch.Utils {
             return false;
         }
 
+        var content_type = info.get_content_type ();
         if (info.get_file_type () == FileType.REGULAR &&
-            ContentType.is_a (info.get_content_type (), "text/*")) {
+            ContentType.is_a (content_type, "text/*") ||
+            ContentType.is_a (content_type, "application/x-zerosize")
+            ) {
+
             return true;
         }
 


### PR DESCRIPTION
Fixes #1436 

The dummy entry for an empty folder gets removed during new file creation/renaming but was not being replaced if the file never got created resulting the parent not being visible.  This PR fixes that.

Also fixes issue in OS8 where an empty file no longer has a text content type so was not being shown in the sidebar.