### PR TITLE
Add saved and renamed docs to RecentManager

### DIFF
--- a/src/FolderManager/FileView.vala
+++ b/src/FolderManager/FileView.vala
@@ -322,6 +322,9 @@ public class Scratch.FolderManager.FileView : Code.Widgets.SourceList, Code.Pane
                 selected.disconnect (once);
                 var new_path = Path.get_dirname (path) + Path.DIR_SEPARATOR_S + new_name;
                 this.toplevel_action_group.activate_action (MainWindow.ACTION_CLOSE_TAB, new Variant.string (path));
+                // RecentManager requires valid URI
+                var new_uri = "file://" + new_path; // Code only edits local files
+                Gtk.RecentManager.get_default ().add_item (new_uri);
                 this.select (new_path);
             });
         }

--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -580,8 +580,6 @@ namespace Scratch.Services {
         }
 
         private async bool save (bool force = false, bool saving_as = false) requires (!locked && is_saving) {
-            Gtk.RecentManager recent_manager = Gtk.RecentManager.get_default ();
-
             if (completion_shown ||
                 !force && (source_view.buffer.get_modified () == false ||
                 !loaded)) {
@@ -637,7 +635,7 @@ namespace Scratch.Services {
             }
 
 
-            recent_manager.add_item (get_uri ());
+            Gtk.RecentManager.get_default ().add_item (get_uri ());
             debug ("File “%s” saved successfully", get_basename ());
 
             return true;

--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -580,6 +580,8 @@ namespace Scratch.Services {
         }
 
         private async bool save (bool force = false, bool saving_as = false) requires (!locked && is_saving) {
+            Gtk.RecentManager recent_manager = Gtk.RecentManager.get_default ();
+
             if (completion_shown ||
                 !force && (source_view.buffer.get_modified () == false ||
                 !loaded)) {
@@ -635,7 +637,7 @@ namespace Scratch.Services {
             }
 
 
-
+            recent_manager.add_item (get_uri ());
             debug ("File “%s” saved successfully", get_basename ());
 
             return true;


### PR DESCRIPTION
Fix #1281 

Completes #1461 

Emulates GEdit behaviour when *not* Flatpak, except that the file is added on save not immediately on opening.  So the file is not added if it is opened and closed without saving or renaming. This can be modified if required.
