### PR TITLE
doc: bump libvala dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ You'll need the following dependencies:
 * libhandy-1-dev >= 0.90.0
 * libpeas-dev
 * libsoup2.4-dev
-* libvala-0.48-dev (or higher)
+* libvala-0.56-dev (or higher)
 * libvte-2.91-dev
 * valac
 


### PR DESCRIPTION
OS 8 doesn't seem to have `libvala-0.48-dev` anymore

```bash

user@pc:~$ sudo apt install libvala-0.48-dev
Lecture des listes de paquets... Fait
Construction de l'arbre des dépendances... Fait
Lecture des informations d'état... Fait      
E: Impossible de trouver le paquet libvala-0.48-dev
E: Impossible de trouver de paquet correspondant à l'expression rationnelle « libvala-0.48-dev »
```