### PR TITLE
Lose libpeas dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     - name: Install Dependencies
       run: |
         apt update
-        apt install -y exuberant-ctags libeditorconfig-dev libgail-3-dev libgee-0.8-dev libgit2-glib-1.0-dev libgranite-dev libgtk-3-dev libgtksourceview-4-dev libgtkspell3-3-dev libhandy-1-dev libpeas-dev libsoup2.4-dev libvala-dev libvte-2.91-dev meson valac polkitd libpolkit-gobject-1-dev
+        apt install -y exuberant-ctags libeditorconfig-dev libgail-3-dev libgee-0.8-dev libgit2-glib-1.0-dev libgranite-dev libgtk-3-dev libgtksourceview-4-dev libgtkspell3-3-dev libhandy-1-dev libsoup2.4-dev libvala-dev libvte-2.91-dev meson valac polkitd libpolkit-gobject-1-dev
     - name: Build
       env:
         DESTDIR: out

--- a/README.md
+++ b/README.md
@@ -15,7 +15,6 @@ You'll need the following dependencies:
 * libgtkspell3-3-dev
 * libgranite-dev >= 6.0.0
 * libhandy-1-dev >= 0.90.0
-* libpeas-dev
 * libsoup2.4-dev
 * libvala-0.48-dev (or higher)
 * libvte-2.91-dev

--- a/io.elementary.code.yml
+++ b/io.elementary.code.yml
@@ -33,17 +33,6 @@ modules:
         url: https://gitlab.gnome.org/GNOME/gtksourceview.git
         tag: '4.8.4'
 
-  - name: peas
-    buildsystem: meson
-    config-opts:
-      - '-Dgtk_doc=false'
-      - '-Ddemos=false'
-      - '-Dvapi=true'
-    sources:
-      - type: git
-        url: https://gitlab.gnome.org/GNOME/libpeas.git
-        tag: libpeas-1.34.0
-
   - name: git2-glib
     buildsystem: meson
     builddir: true

--- a/meson.build
+++ b/meson.build
@@ -27,14 +27,13 @@ gnome = import('gnome')
 i18n = import('i18n')
 
 glib_dep = dependency('glib-2.0', version: '>=2.30.0')
+gmodule_dep = dependency('gmodule-2.0', version: '>=2.30.0')
 gio_unix_dep = dependency('gio-unix-2.0', version: '>=2.20')
 gee_dep = dependency('gee-0.8', version: '>=0.8.5')
 gtk_dep = dependency('gtk+-3.0', version: '>=3.6.0')
 granite_dep = dependency('granite', version: '>=6.0.0')
 handy_dep = dependency('libhandy-1', version: '>=0.90.0')
 gtksourceview_dep = dependency('gtksourceview-4')
-peas_dep = dependency('libpeas-1.0')
-peasgtk_dep = dependency('libpeas-gtk-1.0')
 git_dep = dependency('libgit2-glib-1.0')
 fontconfig_dep = dependency('fontconfig')
 pangofc_dep = dependency('pangoft2')
@@ -52,14 +51,13 @@ vala_dep = dependency('libvala-@0@'.format(vala_version))
 
 dependencies = [
     glib_dep,
+    gmodule_dep,
     gio_unix_dep,
     gee_dep,
     gtk_dep,
     granite_dep,
     handy_dep,
     gtksourceview_dep,
-    peas_dep,
-    peasgtk_dep,
     git_dep,
     fontconfig_dep,
     pangofc_dep,

--- a/plugins/brackets-completion/brackets-completion.vala
+++ b/plugins/brackets-completion/brackets-completion.vala
@@ -35,6 +35,7 @@ public class Scratch.Plugins.BracketsCompletion : Scratch.Plugins.PluginBase {
         base (info, iface);
     }
 
+    ulong doc_hook_handler = 0;
     protected override void activate_internal () {
         brackets = new Gee.HashMap<string, string> ();
         brackets["("] = ")";
@@ -59,7 +60,7 @@ public class Scratch.Plugins.BracketsCompletion : Scratch.Plugins.PluginBase {
     }
 
     protected override void deactivate_internal () {
-        iface.hook_document.disconnect (on_hook_document);
+        this.disconnect (doc_hook_handler);
     }
 
     void on_hook_document (Scratch.Services.Document doc) {

--- a/plugins/brackets-completion/brackets-completion.vala
+++ b/plugins/brackets-completion/brackets-completion.vala
@@ -18,7 +18,7 @@
   END LICENSE
 ***/
 
-public class Scratch.Plugins.BracketsCompletion : Peas.ExtensionBase, Peas.Activatable {
+public class Scratch.Plugins.BracketsCompletion : PluginBase {
     Gee.HashMap<string, string> brackets;
     Gee.HashMap<uint, string> keys;
     const string[] VALID_NEXT_CHARS = {
@@ -30,10 +30,8 @@ public class Scratch.Plugins.BracketsCompletion : Peas.ExtensionBase, Peas.Activ
 
     private string previous_selection = "";
 
-    Scratch.Services.Interface plugins;
-    public Object object { owned get; construct; }
-
-    public void update_state () {}
+    Scratch.Plugins.Interface plugins;
+    // public Object object { owned get; construct; }
 
     public void activate () {
         brackets = new Gee.HashMap<string, string> ();
@@ -55,7 +53,7 @@ public class Scratch.Plugins.BracketsCompletion : Peas.ExtensionBase, Peas.Activ
         keys[Gdk.Key.quotedbl] = "\"";
         keys[Gdk.Key.grave] = "`";
 
-        plugins = (Scratch.Services.Interface) object;
+        // plugins = (Scratch.Plugins.Interface) object;
         plugins.hook_document.connect (on_hook_document);
     }
 
@@ -275,9 +273,13 @@ public class Scratch.Plugins.BracketsCompletion : Peas.ExtensionBase, Peas.Activ
     }
 }
 
-[ModuleInit]
-public void peas_register_types (GLib.TypeModule module) {
-    var objmodule = module as Peas.ObjectModule;
-    objmodule.register_extension_type (typeof (Peas.Activatable),
-                                     typeof (Scratch.Plugins.BracketsCompletion));
+public Scratch.Plugins.PluginBase module_init (Scratch.Plugins.PluginInfo info) {
+    return new Scratch.Plugins.BracketsCompletion (info);
 }
+
+// [ModuleInit]
+// public void peas_register_types (GLib.TypeModule module) {
+//     var objmodule = module as Peas.ObjectModule;
+//     objmodule.register_extension_type (typeof (Peas.Activatable),
+//                                      typeof (Scratch.Plugins.BracketsCompletion));
+// }

--- a/plugins/brackets-completion/brackets-completion.vala
+++ b/plugins/brackets-completion/brackets-completion.vala
@@ -55,11 +55,11 @@ public class Scratch.Plugins.BracketsCompletion : Scratch.Plugins.PluginBase {
         keys[Gdk.Key.quotedbl] = "\"";
         keys[Gdk.Key.grave] = "`";
 
-        plugins.hook_document.connect (on_hook_document);
+        iface.hook_document.connect (on_hook_document);
     }
 
     protected override void deactivate_internal () {
-        plugins.hook_document.disconnect (on_hook_document);
+        iface.hook_document.disconnect (on_hook_document);
     }
 
     void on_hook_document (Scratch.Services.Document doc) {

--- a/plugins/brackets-completion/brackets-completion.vala
+++ b/plugins/brackets-completion/brackets-completion.vala
@@ -31,13 +31,11 @@ public class Scratch.Plugins.BracketsCompletion : Scratch.Plugins.PluginBase {
 
     private string previous_selection = "";
 
-    Scratch.Plugins.Interface plugins;
-
     public BracketsCompletion (PluginInfo info, Interface iface) {
         base (info, iface);
     }
 
-    public override void activate () {
+    protected override void activate_internal () {
         brackets = new Gee.HashMap<string, string> ();
         brackets["("] = ")";
         brackets["["] = "]";
@@ -60,7 +58,7 @@ public class Scratch.Plugins.BracketsCompletion : Scratch.Plugins.PluginBase {
         plugins.hook_document.connect (on_hook_document);
     }
 
-    public override void deactivate () {
+    protected override  void deactivate_internal () {
         plugins.hook_document.disconnect (on_hook_document);
     }
 

--- a/plugins/brackets-completion/brackets-completion.vala
+++ b/plugins/brackets-completion/brackets-completion.vala
@@ -2,7 +2,8 @@
 /***
   BEGIN LICENSE
 
-  Copyright (C) 2013 Mario Guerriero <mario@elementaryos.org>
+  Copyright (C) 2019-24 elementary, Inc. <https://elementary.io>
+                2013 Mario Guerriero <mario@elementaryos.org>
   This program is free software: you can redistribute it and/or modify it
   under the terms of the GNU Lesser General Public License version 3, as published
   by the Free Software Foundation.
@@ -31,7 +32,6 @@ public class Scratch.Plugins.BracketsCompletion : Scratch.Plugins.PluginBase {
     private string previous_selection = "";
 
     Scratch.Plugins.Interface plugins;
-    // public Object object { owned get; construct; }
 
     public BracketsCompletion (PluginInfo info, Interface iface) {
         base (info, iface);
@@ -57,7 +57,6 @@ public class Scratch.Plugins.BracketsCompletion : Scratch.Plugins.PluginBase {
         keys[Gdk.Key.quotedbl] = "\"";
         keys[Gdk.Key.grave] = "`";
 
-        // plugins = (Scratch.Plugins.Interface) object;
         plugins.hook_document.connect (on_hook_document);
     }
 
@@ -283,10 +282,3 @@ public Scratch.Plugins.PluginBase module_init (
 ) {
     return new Scratch.Plugins.BracketsCompletion (info, iface);
 }
-
-// [ModuleInit]
-// public void peas_register_types (GLib.TypeModule module) {
-//     var objmodule = module as Peas.ObjectModule;
-//     objmodule.register_extension_type (typeof (Peas.Activatable),
-//                                      typeof (Scratch.Plugins.BracketsCompletion));
-// }

--- a/plugins/brackets-completion/brackets-completion.vala
+++ b/plugins/brackets-completion/brackets-completion.vala
@@ -56,11 +56,11 @@ public class Scratch.Plugins.BracketsCompletion : Scratch.Plugins.PluginBase {
         keys[Gdk.Key.quotedbl] = "\"";
         keys[Gdk.Key.grave] = "`";
 
-        iface.hook_document.connect (on_hook_document);
+        doc_hook_handler = iface.hook_document.connect (on_hook_document);
     }
 
     protected override void deactivate_internal () {
-        this.disconnect (doc_hook_handler);
+        iface.disconnect (doc_hook_handler);
     }
 
     void on_hook_document (Scratch.Services.Document doc) {

--- a/plugins/brackets-completion/brackets-completion.vala
+++ b/plugins/brackets-completion/brackets-completion.vala
@@ -58,7 +58,7 @@ public class Scratch.Plugins.BracketsCompletion : Scratch.Plugins.PluginBase {
         plugins.hook_document.connect (on_hook_document);
     }
 
-    protected override  void deactivate_internal () {
+    protected override void deactivate_internal () {
         plugins.hook_document.disconnect (on_hook_document);
     }
 

--- a/plugins/brackets-completion/brackets-completion.vala
+++ b/plugins/brackets-completion/brackets-completion.vala
@@ -18,7 +18,7 @@
   END LICENSE
 ***/
 
-public class Scratch.Plugins.BracketsCompletion : PluginBase {
+public class Scratch.Plugins.BracketsCompletion : Scratch.Plugins.PluginBase {
     Gee.HashMap<string, string> brackets;
     Gee.HashMap<uint, string> keys;
     const string[] VALID_NEXT_CHARS = {
@@ -33,7 +33,11 @@ public class Scratch.Plugins.BracketsCompletion : PluginBase {
     Scratch.Plugins.Interface plugins;
     // public Object object { owned get; construct; }
 
-    public void activate () {
+    public BracketsCompletion (PluginInfo info, Interface iface) {
+        base (info, iface);
+    }
+
+    public override void activate () {
         brackets = new Gee.HashMap<string, string> ();
         brackets["("] = ")";
         brackets["["] = "]";
@@ -57,7 +61,7 @@ public class Scratch.Plugins.BracketsCompletion : PluginBase {
         plugins.hook_document.connect (on_hook_document);
     }
 
-    public void deactivate () {
+    public override void deactivate () {
         plugins.hook_document.disconnect (on_hook_document);
     }
 
@@ -273,8 +277,11 @@ public class Scratch.Plugins.BracketsCompletion : PluginBase {
     }
 }
 
-public Scratch.Plugins.PluginBase module_init (Scratch.Plugins.PluginInfo info) {
-    return new Scratch.Plugins.BracketsCompletion (info);
+public Scratch.Plugins.PluginBase module_init (
+    Scratch.Plugins.PluginInfo info,
+    Scratch.Plugins.Interface iface
+) {
+    return new Scratch.Plugins.BracketsCompletion (info, iface);
 }
 
 // [ModuleInit]

--- a/plugins/detect-indent/detect-indent.vala
+++ b/plugins/detect-indent/detect-indent.vala
@@ -87,7 +87,7 @@ public class Scratch.Plugins.DetectIndent: Scratch.Plugins.PluginBase {
     }
 
     protected override void deactivate_internal () {
-        this.disconnect (doc_hook_handler);
+        iface.disconnect (doc_hook_handler);
     }
 }
 

--- a/plugins/detect-indent/detect-indent.vala
+++ b/plugins/detect-indent/detect-indent.vala
@@ -1,16 +1,33 @@
+// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
+/***
+  BEGIN LICENSE
+
+  Copyright (C) 2019-24 elementary, Inc. <https://elementary.io>
+                2013 LemonBoy <thatlemon@gmail.com>
+  This program is free software: you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License version 3, as published
+  by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranties of
+  MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+  PURPOSE.  See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program.  If not, see <http://www.gnu.org/licenses/>
+
+  END LICENSE
+***/
 public class Scratch.Plugins.DetectIndent: Scratch.Plugins.PluginBase {
     const int MAX_LINES = 500;
 
     Scratch.Plugins.Interface plugins;
-    // public Object object {owned get; construct;}
 
     public DetectIndent (PluginInfo info, Interface iface) {
         base (info, iface);
     }
 
     public override void activate () {
-        // plugins = (Scratch.Plugins.Interface) object;
-
         plugins.hook_document.connect ((d) => {
             var view = d.source_view;
 
@@ -82,13 +99,3 @@ public Scratch.Plugins.PluginBase module_init (
 ) {
     return new Scratch.Plugins.DetectIndent (info, iface);
 }
-
-
-// [ModuleInit]
-// public void peas_register_types (GLib.TypeModule module) {
-//     var objmodule = module as Peas.ObjectModule;
-//     objmodule.register_extension_type (
-//         typeof (Peas.Activatable),
-//         typeof (Scratch.Plugins.DetectIndent)
-//     );
-// }

--- a/plugins/detect-indent/detect-indent.vala
+++ b/plugins/detect-indent/detect-indent.vala
@@ -7,7 +7,7 @@ public class Scratch.Plugins.DetectIndent: Scratch.Plugins.PluginBase {
     public DetectIndent (PluginInfo info, Interface iface) {
         base (info, iface);
     }
-    
+
     public override void activate () {
         // plugins = (Scratch.Plugins.Interface) object;
 

--- a/plugins/detect-indent/detect-indent.vala
+++ b/plugins/detect-indent/detect-indent.vala
@@ -25,8 +25,9 @@ public class Scratch.Plugins.DetectIndent: Scratch.Plugins.PluginBase {
         base (info, iface);
     }
 
+    ulong doc_hook_handler = 0;
     protected override void activate_internal () {
-        plugins.hook_document.connect ((d) => {
+        doc_hook_handler = iface.hook_document.connect ((d) => {
             var view = d.source_view;
 
             if (!view.get_editable ()) {
@@ -83,6 +84,10 @@ public class Scratch.Plugins.DetectIndent: Scratch.Plugins.PluginBase {
                 view.set_insert_spaces_instead_of_tabs (sr > tr);
             }
         });
+    }
+    
+    protected override void deactivate_internal () {
+        this.disconnect (doc_hook_handler);
     }
 }
 

--- a/plugins/detect-indent/detect-indent.vala
+++ b/plugins/detect-indent/detect-indent.vala
@@ -21,13 +21,11 @@
 public class Scratch.Plugins.DetectIndent: Scratch.Plugins.PluginBase {
     const int MAX_LINES = 500;
 
-    Scratch.Plugins.Interface plugins;
-
     public DetectIndent (PluginInfo info, Interface iface) {
         base (info, iface);
     }
 
-    public override void activate () {
+    protected override  void activate_internal () {
         plugins.hook_document.connect ((d) => {
             var view = d.source_view;
 
@@ -86,11 +84,6 @@ public class Scratch.Plugins.DetectIndent: Scratch.Plugins.PluginBase {
             }
         });
     }
-
-    public override void deactivate () {
-
-    }
-
 }
 
 public Scratch.Plugins.PluginBase module_init (

--- a/plugins/detect-indent/detect-indent.vala
+++ b/plugins/detect-indent/detect-indent.vala
@@ -25,7 +25,7 @@ public class Scratch.Plugins.DetectIndent: Scratch.Plugins.PluginBase {
         base (info, iface);
     }
 
-    protected override  void activate_internal () {
+    protected override void activate_internal () {
         plugins.hook_document.connect ((d) => {
             var view = d.source_view;
 

--- a/plugins/detect-indent/detect-indent.vala
+++ b/plugins/detect-indent/detect-indent.vala
@@ -85,7 +85,7 @@ public class Scratch.Plugins.DetectIndent: Scratch.Plugins.PluginBase {
             }
         });
     }
-    
+
     protected override void deactivate_internal () {
         this.disconnect (doc_hook_handler);
     }

--- a/plugins/detect-indent/detect-indent.vala
+++ b/plugins/detect-indent/detect-indent.vala
@@ -1,14 +1,11 @@
-public class Scratch.Plugins.DetectIndent: Peas.ExtensionBase, Peas.Activatable {
+public class Scratch.Plugins.DetectIndent: PluginBase {
     const int MAX_LINES = 500;
 
-    Scratch.Services.Interface plugins;
-    public Object object {owned get; construct;}
-
-    public void update_state () {
-    }
+    Scratch.Plugins.Interface plugins;
+    // public Object object {owned get; construct;}
 
     public void activate () {
-        plugins = (Scratch.Services.Interface) object;
+        plugins = (Scratch.Plugins.Interface) object;
 
         plugins.hook_document.connect ((d) => {
             var view = d.source_view;
@@ -75,11 +72,15 @@ public class Scratch.Plugins.DetectIndent: Peas.ExtensionBase, Peas.Activatable 
 
 }
 
-[ModuleInit]
-public void peas_register_types (GLib.TypeModule module) {
-    var objmodule = module as Peas.ObjectModule;
-    objmodule.register_extension_type (
-        typeof (Peas.Activatable),
-        typeof (Scratch.Plugins.DetectIndent)
-    );
+public Scratch.Plugins.PluginBase module_init (Scratch.Plugins.PluginInfo info) {
+    return new Scratch.Plugins.DetectIndent (info);
 }
+
+// [ModuleInit]
+// public void peas_register_types (GLib.TypeModule module) {
+//     var objmodule = module as Peas.ObjectModule;
+//     objmodule.register_extension_type (
+//         typeof (Peas.Activatable),
+//         typeof (Scratch.Plugins.DetectIndent)
+//     );
+// }

--- a/plugins/detect-indent/detect-indent.vala
+++ b/plugins/detect-indent/detect-indent.vala
@@ -1,11 +1,15 @@
-public class Scratch.Plugins.DetectIndent: PluginBase {
+public class Scratch.Plugins.DetectIndent: Scratch.Plugins.PluginBase {
     const int MAX_LINES = 500;
 
     Scratch.Plugins.Interface plugins;
     // public Object object {owned get; construct;}
 
-    public void activate () {
-        plugins = (Scratch.Plugins.Interface) object;
+    public DetectIndent (PluginInfo info, Interface iface) {
+        base (info, iface);
+    }
+    
+    public override void activate () {
+        // plugins = (Scratch.Plugins.Interface) object;
 
         plugins.hook_document.connect ((d) => {
             var view = d.source_view;
@@ -66,15 +70,19 @@ public class Scratch.Plugins.DetectIndent: PluginBase {
         });
     }
 
-    public void deactivate () {
+    public override void deactivate () {
 
     }
 
 }
 
-public Scratch.Plugins.PluginBase module_init (Scratch.Plugins.PluginInfo info) {
-    return new Scratch.Plugins.DetectIndent (info);
+public Scratch.Plugins.PluginBase module_init (
+    Scratch.Plugins.PluginInfo info,
+    Scratch.Plugins.Interface iface
+) {
+    return new Scratch.Plugins.DetectIndent (info, iface);
 }
+
 
 // [ModuleInit]
 // public void peas_register_types (GLib.TypeModule module) {

--- a/plugins/editorconfig/editorconfig.vala
+++ b/plugins/editorconfig/editorconfig.vala
@@ -26,7 +26,7 @@ public class Scratch.Plugins.EditorConfigPlugin: Scratch.Plugins.PluginBase {
     public EditorConfigPlugin (PluginInfo info, Interface iface) {
         base (info, iface);
     }
-    
+
     public override void activate () {
         // plugins = (Scratch.Plugins.Interface) object;
 

--- a/plugins/editorconfig/editorconfig.vala
+++ b/plugins/editorconfig/editorconfig.vala
@@ -80,7 +80,7 @@ public class Scratch.Plugins.EditorConfigPlugin: Scratch.Plugins.PluginBase {
             }
         });
     }
-    
+
     protected override void deactivate_internal () {
         this.disconnect (doc_hook_handler);
     }

--- a/plugins/editorconfig/editorconfig.vala
+++ b/plugins/editorconfig/editorconfig.vala
@@ -19,17 +19,13 @@
 ***/
 
 public class Scratch.Plugins.EditorConfigPlugin: Scratch.Plugins.PluginBase {
-    Scratch.Plugins.Interface plugins;
     private Code.FormatBar format_bar;
 
     public EditorConfigPlugin (PluginInfo info, Interface iface) {
         base (info, iface);
     }
 
-    public override void activate () {
-        plugins.hook_toolbar.connect ((tb) => {
-            format_bar = tb.format_bar;
-        });
+    protected override void activate_internal () {
 
         plugins.hook_document.connect ((d) => {
             // Ensure use global settings by default
@@ -84,8 +80,6 @@ public class Scratch.Plugins.EditorConfigPlugin: Scratch.Plugins.PluginBase {
             }
         });
     }
-
-    public override void deactivate () { }
 }
 
 public Scratch.Plugins.PluginBase module_init (

--- a/plugins/editorconfig/editorconfig.vala
+++ b/plugins/editorconfig/editorconfig.vala
@@ -86,7 +86,7 @@ public class Scratch.Plugins.EditorConfigPlugin: Scratch.Plugins.PluginBase {
     }
 
     protected override void deactivate_internal () {
-        this.disconnect (doc_hook_handler);
+        iface.disconnect (doc_hook_handler);
     }
 }
 

--- a/plugins/editorconfig/editorconfig.vala
+++ b/plugins/editorconfig/editorconfig.vala
@@ -17,15 +17,18 @@
 * Boston, MA 02110-1301 USA
 */
 
-public class Scratch.Plugins.EditorConfigPlugin: PluginBase {
+public class Scratch.Plugins.EditorConfigPlugin: Scratch.Plugins.PluginBase {
     Scratch.Plugins.Interface plugins;
     // public Object object { owned get; construct; }
     private Code.FormatBar format_bar;
 
     // public void update_state () { }
-
-    public void activate () {
-        plugins = (Scratch.Plugins.Interface) object;
+    public EditorConfigPlugin (PluginInfo info, Interface iface) {
+        base (info, iface);
+    }
+    
+    public override void activate () {
+        // plugins = (Scratch.Plugins.Interface) object;
 
         plugins.hook_toolbar.connect ((tb) => {
             format_bar = tb.format_bar;
@@ -85,12 +88,16 @@ public class Scratch.Plugins.EditorConfigPlugin: PluginBase {
         });
     }
 
-    public void deactivate () { }
+    public override void deactivate () { }
 }
 
-public Scratch.Plugins.PluginBase module_init (Scratch.Plugins.PluginInfo info) {
-    return new Scratch.Plugins.EditorConfigPlugin (info);
+public Scratch.Plugins.PluginBase module_init (
+    Scratch.Plugins.PluginInfo info,
+    Scratch.Plugins.Interface iface
+) {
+    return new Scratch.Plugins.EditorConfigPlugin (info, iface);
 }
+
 
 // [ModuleInit]
 // public void peas_register_types (GLib.TypeModule module) {

--- a/plugins/editorconfig/editorconfig.vala
+++ b/plugins/editorconfig/editorconfig.vala
@@ -17,15 +17,15 @@
 * Boston, MA 02110-1301 USA
 */
 
-public class Scratch.Plugins.EditorConfigPlugin: Peas.ExtensionBase, Peas.Activatable {
-    Scratch.Services.Interface plugins;
-    public Object object { owned get; construct; }
+public class Scratch.Plugins.EditorConfigPlugin: PluginBase {
+    Scratch.Plugins.Interface plugins;
+    // public Object object { owned get; construct; }
     private Code.FormatBar format_bar;
 
-    public void update_state () { }
+    // public void update_state () { }
 
     public void activate () {
-        plugins = (Scratch.Services.Interface) object;
+        plugins = (Scratch.Plugins.Interface) object;
 
         plugins.hook_toolbar.connect ((tb) => {
             format_bar = tb.format_bar;
@@ -88,8 +88,12 @@ public class Scratch.Plugins.EditorConfigPlugin: Peas.ExtensionBase, Peas.Activa
     public void deactivate () { }
 }
 
-[ModuleInit]
-public void peas_register_types (GLib.TypeModule module) {
-    var objmodule = module as Peas.ObjectModule;
-    objmodule.register_extension_type (typeof (Peas.Activatable), typeof (Scratch.Plugins.EditorConfigPlugin));
+public Scratch.Plugins.PluginBase module_init (Scratch.Plugins.PluginInfo info) {
+    return new Scratch.Plugins.EditorConfigPlugin (info);
 }
+
+// [ModuleInit]
+// public void peas_register_types (GLib.TypeModule module) {
+//     var objmodule = module as Peas.ObjectModule;
+//     objmodule.register_extension_type (typeof (Peas.Activatable), typeof (Scratch.Plugins.EditorConfigPlugin));
+// }

--- a/plugins/editorconfig/editorconfig.vala
+++ b/plugins/editorconfig/editorconfig.vala
@@ -79,6 +79,10 @@ public class Scratch.Plugins.EditorConfigPlugin: Scratch.Plugins.PluginBase {
                 }
             }
         });
+
+        iface.hook_toolbar.connect ((tb) => {
+            format_bar = tb.format_bar;
+        });
     }
 
     protected override void deactivate_internal () {

--- a/plugins/editorconfig/editorconfig.vala
+++ b/plugins/editorconfig/editorconfig.vala
@@ -25,9 +25,9 @@ public class Scratch.Plugins.EditorConfigPlugin: Scratch.Plugins.PluginBase {
         base (info, iface);
     }
 
+    ulong doc_hook_handler = 0;
     protected override void activate_internal () {
-
-        plugins.hook_document.connect ((d) => {
+        doc_hook_handler = iface.hook_document.connect ((d) => {
             // Ensure use global settings by default
             format_bar.tab_style_set_by_editor_config = false;
             format_bar.tab_width_set_by_editor_config = false;
@@ -79,6 +79,10 @@ public class Scratch.Plugins.EditorConfigPlugin: Scratch.Plugins.PluginBase {
                 }
             }
         });
+    }
+    
+    protected override void deactivate_internal () {
+        this.disconnect (doc_hook_handler);
     }
 }
 

--- a/plugins/editorconfig/editorconfig.vala
+++ b/plugins/editorconfig/editorconfig.vala
@@ -1,35 +1,32 @@
-/*
-* Copyright (c) 2018 elementary LLC. (https://github.com/elementary)
-*
-* This program is free software; you can redistribute it and/or
-* modify it under the terms of the GNU General Public
-* License as published by the Free Software Foundation; either
-* version 3 of the License, or (at your option) any later version.
-*
-* This program is distributed in the hope that it will be useful,
-* but WITHOUT ANY WARRANTY; without even the implied warranty of
-* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-* General Public License for more details.
-*
-* You should have received a copy of the GNU General Public
-* License along with this program; if not, write to the
-* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
-* Boston, MA 02110-1301 USA
-*/
+// -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
+/***
+  BEGIN LICENSE
+
+  Copyright (C) 2018-24 elementary, Inc. <https://elementary.io>
+  This program is free software: you can redistribute it and/or modify it
+  under the terms of the GNU Lesser General Public License version 3, as published
+  by the Free Software Foundation.
+
+  This program is distributed in the hope that it will be useful, but
+  WITHOUT ANY WARRANTY; without even the implied warranties of
+  MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+  PURPOSE.  See the GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License along
+  with this program.  If not, see <http://www.gnu.org/licenses/>
+
+  END LICENSE
+***/
 
 public class Scratch.Plugins.EditorConfigPlugin: Scratch.Plugins.PluginBase {
     Scratch.Plugins.Interface plugins;
-    // public Object object { owned get; construct; }
     private Code.FormatBar format_bar;
 
-    // public void update_state () { }
     public EditorConfigPlugin (PluginInfo info, Interface iface) {
         base (info, iface);
     }
 
     public override void activate () {
-        // plugins = (Scratch.Plugins.Interface) object;
-
         plugins.hook_toolbar.connect ((tb) => {
             format_bar = tb.format_bar;
         });
@@ -97,10 +94,3 @@ public Scratch.Plugins.PluginBase module_init (
 ) {
     return new Scratch.Plugins.EditorConfigPlugin (info, iface);
 }
-
-
-// [ModuleInit]
-// public void peas_register_types (GLib.TypeModule module) {
-//     var objmodule = module as Peas.ObjectModule;
-//     objmodule.register_extension_type (typeof (Peas.Activatable), typeof (Scratch.Plugins.EditorConfigPlugin));
-// }

--- a/plugins/fuzzy-search/fuzzy-search.vala
+++ b/plugins/fuzzy-search/fuzzy-search.vala
@@ -73,7 +73,7 @@ public class Scratch.Plugins.FuzzySearch: Scratch.Plugins.PluginBase {
         if (cancellable != null) {
             cancellable.cancel ();
         }
-        
+
         this.disconnect (window_hook_handler);
         this.disconnect (folder_hook_handler);
     }

--- a/plugins/fuzzy-search/fuzzy-search.vala
+++ b/plugins/fuzzy-search/fuzzy-search.vala
@@ -39,7 +39,7 @@ public class Scratch.Plugins.FuzzySearch: Scratch.Plugins.PluginBase {
     public FuzzySearch (PluginInfo info, Interface iface) {
         base (info, iface);
     }
-    
+
     public override void activate () {
         // plugins = (Scratch.Plugins.Interface) object;
 

--- a/plugins/fuzzy-search/fuzzy-search.vala
+++ b/plugins/fuzzy-search/fuzzy-search.vala
@@ -12,7 +12,6 @@ public class Scratch.Plugins.FuzzySearch: Scratch.Plugins.PluginBase {
 
     private Scratch.Services.FuzzySearchIndexer indexer;
     private MainWindow window = null;
-    private Scratch.Plugins.Interface plugins;
     private GLib.MenuItem fuzzy_menuitem;
     private GLib.Cancellable cancellable;
 
@@ -36,7 +35,7 @@ public class Scratch.Plugins.FuzzySearch: Scratch.Plugins.PluginBase {
         base (info, iface);
     }
 
-    public override void activate () {
+    protected override void activate_internal () {
         plugins.hook_window.connect ((w) => {
             if (window != null) {
                 return;
@@ -65,7 +64,7 @@ public class Scratch.Plugins.FuzzySearch: Scratch.Plugins.PluginBase {
         });
     }
 
-    public override void deactivate () {
+    protected override void deactivate_internal () {
         folder_settings.changed["opened-folders"].disconnect (handle_opened_projects_change);
         remove_actions ();
         if (cancellable != null) {

--- a/plugins/fuzzy-search/fuzzy-search.vala
+++ b/plugins/fuzzy-search/fuzzy-search.vala
@@ -39,7 +39,6 @@ public class Scratch.Plugins.FuzzySearch: Scratch.Plugins.PluginBase {
     ulong folder_hook_handler = 0;
     protected override void activate_internal () {
         window_hook_handler = iface.hook_window.connect ((w) => {
-        warning ("fuzzy search - hook window");
             if (window != null) {
                 return;
             }

--- a/plugins/fuzzy-search/fuzzy-search.vala
+++ b/plugins/fuzzy-search/fuzzy-search.vala
@@ -1,13 +1,12 @@
 /*
  * SPDX-License-Identifier: GPL-3.0-or-later
- * SPDX-FileCopyrightText: 2023 elementary, Inc. <https://elementary.io>
+ * SPDX-FileCopyrightText: 2023-24 elementary, Inc. <https://elementary.io>
  *
  * Authored by: Marvin Ahlgrimm
  */
 
 
 public class Scratch.Plugins.FuzzySearch: Scratch.Plugins.PluginBase {
-    // public Object object { owned get; construct; }
     private const uint ACCEL_KEY = Gdk.Key.F;
     private const Gdk.ModifierType ACCEL_MODTYPE = Gdk.ModifierType.MOD1_MASK;
 
@@ -33,16 +32,11 @@ public class Scratch.Plugins.FuzzySearch: Scratch.Plugins.PluginBase {
         action_accelerators.set (ACTION_SHOW, @"<Alt>$(Gdk.keyval_name (ACCEL_KEY))");
     }
 
-    // public void update_state () {
-
-    // }
     public FuzzySearch (PluginInfo info, Interface iface) {
         base (info, iface);
     }
 
     public override void activate () {
-        // plugins = (Scratch.Plugins.Interface) object;
-
         plugins.hook_window.connect ((w) => {
             if (window != null) {
                 return;
@@ -162,12 +156,3 @@ public Scratch.Plugins.PluginBase module_init (
 ) {
     return new Scratch.Plugins.FuzzySearch (info, iface);
 }
-
-// [ModuleInit]
-// public void peas_register_types (GLib.TypeModule module) {
-//     var objmodule = module as Peas.ObjectModule;
-//     objmodule.register_extension_type (
-//         typeof (Peas.Activatable),
-//         typeof (Scratch.Plugins.FuzzySearch)
-//     );
-// }

--- a/plugins/fuzzy-search/fuzzy-search.vala
+++ b/plugins/fuzzy-search/fuzzy-search.vala
@@ -6,14 +6,14 @@
  */
 
 
-public class Scratch.Plugins.FuzzySearch: Peas.ExtensionBase, Peas.Activatable {
-    public Object object { owned get; construct; }
+public class Scratch.Plugins.FuzzySearch: PluginBase {
+    // public Object object { owned get; construct; }
     private const uint ACCEL_KEY = Gdk.Key.F;
     private const Gdk.ModifierType ACCEL_MODTYPE = Gdk.ModifierType.MOD1_MASK;
 
     private Scratch.Services.FuzzySearchIndexer indexer;
     private MainWindow window = null;
-    private Scratch.Services.Interface plugins;
+    private Scratch.Plugins.Interface plugins;
     private GLib.MenuItem fuzzy_menuitem;
     private GLib.Cancellable cancellable;
 
@@ -33,12 +33,12 @@ public class Scratch.Plugins.FuzzySearch: Peas.ExtensionBase, Peas.Activatable {
         action_accelerators.set (ACTION_SHOW, @"<Alt>$(Gdk.keyval_name (ACCEL_KEY))");
     }
 
-    public void update_state () {
+    // public void update_state () {
 
-    }
+    // }
 
     public void activate () {
-        plugins = (Scratch.Services.Interface) object;
+        // plugins = (Scratch.Plugins.Interface) object;
 
         plugins.hook_window.connect ((w) => {
             if (window != null) {
@@ -66,6 +66,14 @@ public class Scratch.Plugins.FuzzySearch: Peas.ExtensionBase, Peas.Activatable {
 
             indexer.handle_folder_item_change (src, dest, event);
         });
+    }
+
+    public void deactivate () {
+        folder_settings.changed["opened-folders"].disconnect (handle_opened_projects_change);
+        remove_actions ();
+        if (cancellable != null) {
+            cancellable.cancel ();
+        }
     }
 
     private void add_actions () {
@@ -138,15 +146,6 @@ public class Scratch.Plugins.FuzzySearch: Peas.ExtensionBase, Peas.Activatable {
         popover.popup ();
     }
 
-    public void deactivate () {
-        folder_settings.changed["opened-folders"].disconnect (handle_opened_projects_change);
-        remove_actions ();
-        if (cancellable != null) {
-            cancellable.cancel ();
-        }
-    }
-
-
     private void handle_opened_projects_change () {
         var show_action = Utils.action_from_group (ACTION_SHOW, actions);
         string[] opened_folders = folder_settings.get_strv ("opened-folders");
@@ -154,11 +153,15 @@ public class Scratch.Plugins.FuzzySearch: Peas.ExtensionBase, Peas.Activatable {
     }
 }
 
-[ModuleInit]
-public void peas_register_types (GLib.TypeModule module) {
-    var objmodule = module as Peas.ObjectModule;
-    objmodule.register_extension_type (
-        typeof (Peas.Activatable),
-        typeof (Scratch.Plugins.FuzzySearch)
-    );
+public Scratch.Plugins.PluginBase module_init (Scratch.Plugins.PluginInfo info) {
+    return new Scratch.Plugins.FuzzySearch (info);
 }
+
+// [ModuleInit]
+// public void peas_register_types (GLib.TypeModule module) {
+//     var objmodule = module as Peas.ObjectModule;
+//     objmodule.register_extension_type (
+//         typeof (Peas.Activatable),
+//         typeof (Scratch.Plugins.FuzzySearch)
+//     );
+// }

--- a/plugins/fuzzy-search/fuzzy-search.vala
+++ b/plugins/fuzzy-search/fuzzy-search.vala
@@ -73,8 +73,8 @@ public class Scratch.Plugins.FuzzySearch: Scratch.Plugins.PluginBase {
             cancellable.cancel ();
         }
 
-        this.disconnect (window_hook_handler);
-        this.disconnect (folder_hook_handler);
+        iface.disconnect (window_hook_handler);
+        iface.disconnect (folder_hook_handler);
     }
 
     private void add_actions () {

--- a/plugins/fuzzy-search/fuzzy-search.vala
+++ b/plugins/fuzzy-search/fuzzy-search.vala
@@ -35,8 +35,11 @@ public class Scratch.Plugins.FuzzySearch: Scratch.Plugins.PluginBase {
         base (info, iface);
     }
 
+    ulong window_hook_handler = 0;
+    ulong folder_hook_handler = 0;
     protected override void activate_internal () {
-        plugins.hook_window.connect ((w) => {
+        window_hook_handler = iface.hook_window.connect ((w) => {
+        warning ("fuzzy search - hook window");
             if (window != null) {
                 return;
             }
@@ -55,7 +58,7 @@ public class Scratch.Plugins.FuzzySearch: Scratch.Plugins.PluginBase {
             folder_settings.changed["opened-folders"].connect (handle_opened_projects_change);
         });
 
-        plugins.hook_folder_item_change.connect ((src, dest, event) => {
+        folder_hook_handler = iface.hook_folder_item_change.connect ((src, dest, event) => {
             if (indexer == null) {
                 return;
             }
@@ -70,6 +73,9 @@ public class Scratch.Plugins.FuzzySearch: Scratch.Plugins.PluginBase {
         if (cancellable != null) {
             cancellable.cancel ();
         }
+        
+        this.disconnect (window_hook_handler);
+        this.disconnect (folder_hook_handler);
     }
 
     private void add_actions () {

--- a/plugins/fuzzy-search/fuzzy-search.vala
+++ b/plugins/fuzzy-search/fuzzy-search.vala
@@ -6,7 +6,7 @@
  */
 
 
-public class Scratch.Plugins.FuzzySearch: PluginBase {
+public class Scratch.Plugins.FuzzySearch: Scratch.Plugins.PluginBase {
     // public Object object { owned get; construct; }
     private const uint ACCEL_KEY = Gdk.Key.F;
     private const Gdk.ModifierType ACCEL_MODTYPE = Gdk.ModifierType.MOD1_MASK;
@@ -36,8 +36,11 @@ public class Scratch.Plugins.FuzzySearch: PluginBase {
     // public void update_state () {
 
     // }
-
-    public void activate () {
+    public FuzzySearch (PluginInfo info, Interface iface) {
+        base (info, iface);
+    }
+    
+    public override void activate () {
         // plugins = (Scratch.Plugins.Interface) object;
 
         plugins.hook_window.connect ((w) => {
@@ -68,7 +71,7 @@ public class Scratch.Plugins.FuzzySearch: PluginBase {
         });
     }
 
-    public void deactivate () {
+    public override void deactivate () {
         folder_settings.changed["opened-folders"].disconnect (handle_opened_projects_change);
         remove_actions ();
         if (cancellable != null) {
@@ -153,8 +156,11 @@ public class Scratch.Plugins.FuzzySearch: PluginBase {
     }
 }
 
-public Scratch.Plugins.PluginBase module_init (Scratch.Plugins.PluginInfo info) {
-    return new Scratch.Plugins.FuzzySearch (info);
+public Scratch.Plugins.PluginBase module_init (
+    Scratch.Plugins.PluginInfo info,
+    Scratch.Plugins.Interface iface
+) {
+    return new Scratch.Plugins.FuzzySearch (info, iface);
 }
 
 // [ModuleInit]

--- a/plugins/highlight-word-selection/highlight-word-selection.vala
+++ b/plugins/highlight-word-selection/highlight-word-selection.vala
@@ -28,13 +28,11 @@ public class Scratch.Plugins.HighlightSelectedWords : Scratch.Plugins.PluginBase
     // Pneumonoultramicroscopicsilicovolcanoconiosis longest word in a major dictionary @ 45
     private const uint SELECTION_HIGHLIGHT_MAX_CHARS = 45;
 
-    Scratch.Plugins.Interface plugins;
-
     public HighlightSelectedWords (PluginInfo info, Interface iface) {
         base (info, iface);
     }
 
-    public override void activate () {
+    protected override void activate_internal () {
         // plugins = (Scratch.Plugins.Interface) object;
         plugins.hook_document.connect ((doc) => {
             if (current_source != null) {
@@ -53,7 +51,7 @@ public class Scratch.Plugins.HighlightSelectedWords : Scratch.Plugins.PluginBase
     }
 
 
-    public override void deactivate () {
+    protected override void deactivate_internal () {
         if (current_source != null) {
             current_source.deselected.disconnect (on_deselection);
             current_source.selection_changed.disconnect (on_selection_changed);

--- a/plugins/highlight-word-selection/highlight-word-selection.vala
+++ b/plugins/highlight-word-selection/highlight-word-selection.vala
@@ -1,8 +1,9 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /***
   BEGIN LICENSE
-
-  Copyright (C) 2013 Madelynn May <madelynnmay@madelynnmay.com>
+  Copyright (C) 2019-24 elementary, Inc. <https://elementary.io>
+                2013 Madelynn May <madelynnmay@madelynnmay.com>
+                
   This program is free software: you can redistribute it and/or modify it
   under the terms of the GNU Lesser General Public License version 3, as published
   by the Free Software Foundation.
@@ -28,9 +29,7 @@ public class Scratch.Plugins.HighlightSelectedWords : Scratch.Plugins.PluginBase
     private const uint SELECTION_HIGHLIGHT_MAX_CHARS = 45;
 
     Scratch.Plugins.Interface plugins;
-    // public Object object { owned get; construct; }
 
-    // public void update_state () {}
     public HighlightSelectedWords (PluginInfo info, Interface iface) {
         base (info, iface);
     }
@@ -158,10 +157,3 @@ public Scratch.Plugins.PluginBase module_init (
 ) {
     return new Scratch.Plugins.HighlightSelectedWords (info, iface);
 }
-
-// [ModuleInit]
-// public void peas_register_types (TypeModule module) {
-//     var objmodule = module as Peas.ObjectModule;
-//     objmodule.register_extension_type (typeof (Peas.Activatable),
-//                                      typeof (Scratch.Plugins.HighlightSelectedWords));
-// }

--- a/plugins/highlight-word-selection/highlight-word-selection.vala
+++ b/plugins/highlight-word-selection/highlight-word-selection.vala
@@ -35,7 +35,6 @@ public class Scratch.Plugins.HighlightSelectedWords : Scratch.Plugins.PluginBase
     ulong window_hook_handler = 0;
     ulong doc_hook_handler = 0;
     protected override void activate_internal () {
-        // plugins = (Scratch.Plugins.Interface) object;
         doc_hook_handler = iface.hook_document.connect ((doc) => {
             if (current_source != null) {
                 current_source.deselected.disconnect (on_deselection);

--- a/plugins/highlight-word-selection/highlight-word-selection.vala
+++ b/plugins/highlight-word-selection/highlight-word-selection.vala
@@ -34,7 +34,7 @@ public class Scratch.Plugins.HighlightSelectedWords : Scratch.Plugins.PluginBase
     public HighlightSelectedWords (PluginInfo info, Interface iface) {
         base (info, iface);
     }
-    
+
     public override void activate () {
         // plugins = (Scratch.Plugins.Interface) object;
         plugins.hook_document.connect ((doc) => {
@@ -67,7 +67,7 @@ public class Scratch.Plugins.HighlightSelectedWords : Scratch.Plugins.PluginBase
         if (window_search_context == null ||
             window_search_context.settings.search_text == "" ||
             window_search_context.get_occurrences_count () == 0) {
-            // Perform plugin selection when there is no ongoing and successful search 
+            // Perform plugin selection when there is no ongoing and successful search
             current_search_context = new Gtk.SourceSearchContext (
                 (Gtk.SourceBuffer)current_source.buffer,
                 null

--- a/plugins/highlight-word-selection/highlight-word-selection.vala
+++ b/plugins/highlight-word-selection/highlight-word-selection.vala
@@ -18,7 +18,7 @@
   END LICENSE
 ***/
 
-public class Scratch.Plugins.HighlightSelectedWords : Peas.ExtensionBase, Peas.Activatable {
+public class Scratch.Plugins.HighlightSelectedWords : PluginBase {
     Scratch.Widgets.SourceView current_source;
     Scratch.MainWindow? main_window = null;
     Gtk.SourceSearchContext? current_search_context = null;
@@ -27,13 +27,13 @@ public class Scratch.Plugins.HighlightSelectedWords : Peas.ExtensionBase, Peas.A
     // Pneumonoultramicroscopicsilicovolcanoconiosis longest word in a major dictionary @ 45
     private const uint SELECTION_HIGHLIGHT_MAX_CHARS = 45;
 
-    Scratch.Services.Interface plugins;
-    public Object object { owned get; construct; }
+    Scratch.Plugins.Interface plugins;
+    // public Object object { owned get; construct; }
 
-    public void update_state () {}
+    // public void update_state () {}
 
     public void activate () {
-        plugins = (Scratch.Services.Interface) object;
+        // plugins = (Scratch.Plugins.Interface) object;
         plugins.hook_document.connect ((doc) => {
             if (current_source != null) {
                 current_source.deselected.disconnect (on_deselection);
@@ -48,6 +48,14 @@ public class Scratch.Plugins.HighlightSelectedWords : Peas.ExtensionBase, Peas.A
         plugins.hook_window.connect ((w) => {
             main_window = w;
         });
+    }
+
+
+    public void deactivate () {
+        if (current_source != null) {
+            current_source.deselected.disconnect (on_deselection);
+            current_source.selection_changed.disconnect (on_selection_changed);
+        }
     }
 
     public void on_selection_changed (ref Gtk.TextIter start, ref Gtk.TextIter end) {
@@ -139,18 +147,15 @@ public class Scratch.Plugins.HighlightSelectedWords : Peas.ExtensionBase, Peas.A
             current_search_context = null;
         }
     }
-
-    public void deactivate () {
-        if (current_source != null) {
-            current_source.deselected.disconnect (on_deselection);
-            current_source.selection_changed.disconnect (on_selection_changed);
-        }
-    }
 }
 
-[ModuleInit]
-public void peas_register_types (TypeModule module) {
-    var objmodule = module as Peas.ObjectModule;
-    objmodule.register_extension_type (typeof (Peas.Activatable),
-                                     typeof (Scratch.Plugins.HighlightSelectedWords));
+public Scratch.Plugins.PluginBase module_init (Scratch.Plugins.PluginInfo info) {
+    return new Scratch.Plugins.FuzzySearch (info);
 }
+
+// [ModuleInit]
+// public void peas_register_types (TypeModule module) {
+//     var objmodule = module as Peas.ObjectModule;
+//     objmodule.register_extension_type (typeof (Peas.Activatable),
+//                                      typeof (Scratch.Plugins.HighlightSelectedWords));
+// }

--- a/plugins/highlight-word-selection/highlight-word-selection.vala
+++ b/plugins/highlight-word-selection/highlight-word-selection.vala
@@ -32,9 +32,11 @@ public class Scratch.Plugins.HighlightSelectedWords : Scratch.Plugins.PluginBase
         base (info, iface);
     }
 
+    ulong window_hook_handler = 0;
+    ulong doc_hook_handler = 0;
     protected override void activate_internal () {
         // plugins = (Scratch.Plugins.Interface) object;
-        plugins.hook_document.connect ((doc) => {
+        doc_hook_handler = iface.hook_document.connect ((doc) => {
             if (current_source != null) {
                 current_source.deselected.disconnect (on_deselection);
                 current_source.selection_changed.disconnect (on_selection_changed);
@@ -45,17 +47,19 @@ public class Scratch.Plugins.HighlightSelectedWords : Scratch.Plugins.PluginBase
             current_source.selection_changed.connect (on_selection_changed);
         });
 
-        plugins.hook_window.connect ((w) => {
+        window_hook_handler = iface.hook_window.connect ((w) => {
             main_window = w;
         });
     }
-
 
     protected override void deactivate_internal () {
         if (current_source != null) {
             current_source.deselected.disconnect (on_deselection);
             current_source.selection_changed.disconnect (on_selection_changed);
         }
+
+        this.disconnect (window_hook_handler);
+        this.disconnect (doc_hook_handler);
     }
 
     public void on_selection_changed (ref Gtk.TextIter start, ref Gtk.TextIter end) {

--- a/plugins/highlight-word-selection/highlight-word-selection.vala
+++ b/plugins/highlight-word-selection/highlight-word-selection.vala
@@ -3,7 +3,7 @@
   BEGIN LICENSE
   Copyright (C) 2019-24 elementary, Inc. <https://elementary.io>
                 2013 Madelynn May <madelynnmay@madelynnmay.com>
-                
+
   This program is free software: you can redistribute it and/or modify it
   under the terms of the GNU Lesser General Public License version 3, as published
   by the Free Software Foundation.
@@ -57,8 +57,8 @@ public class Scratch.Plugins.HighlightSelectedWords : Scratch.Plugins.PluginBase
             current_source.selection_changed.disconnect (on_selection_changed);
         }
 
-        this.disconnect (window_hook_handler);
-        this.disconnect (doc_hook_handler);
+        iface.disconnect (window_hook_handler);
+        iface.disconnect (doc_hook_handler);
     }
 
     public void on_selection_changed (ref Gtk.TextIter start, ref Gtk.TextIter end) {

--- a/plugins/highlight-word-selection/highlight-word-selection.vala
+++ b/plugins/highlight-word-selection/highlight-word-selection.vala
@@ -18,7 +18,7 @@
   END LICENSE
 ***/
 
-public class Scratch.Plugins.HighlightSelectedWords : PluginBase {
+public class Scratch.Plugins.HighlightSelectedWords : Scratch.Plugins.PluginBase {
     Scratch.Widgets.SourceView current_source;
     Scratch.MainWindow? main_window = null;
     Gtk.SourceSearchContext? current_search_context = null;
@@ -31,8 +31,11 @@ public class Scratch.Plugins.HighlightSelectedWords : PluginBase {
     // public Object object { owned get; construct; }
 
     // public void update_state () {}
-
-    public void activate () {
+    public HighlightSelectedWords (PluginInfo info, Interface iface) {
+        base (info, iface);
+    }
+    
+    public override void activate () {
         // plugins = (Scratch.Plugins.Interface) object;
         plugins.hook_document.connect ((doc) => {
             if (current_source != null) {
@@ -51,7 +54,7 @@ public class Scratch.Plugins.HighlightSelectedWords : PluginBase {
     }
 
 
-    public void deactivate () {
+    public override void deactivate () {
         if (current_source != null) {
             current_source.deselected.disconnect (on_deselection);
             current_source.selection_changed.disconnect (on_selection_changed);
@@ -149,8 +152,11 @@ public class Scratch.Plugins.HighlightSelectedWords : PluginBase {
     }
 }
 
-public Scratch.Plugins.PluginBase module_init (Scratch.Plugins.PluginInfo info) {
-    return new Scratch.Plugins.FuzzySearch (info);
+public Scratch.Plugins.PluginBase module_init (
+    Scratch.Plugins.PluginInfo info,
+    Scratch.Plugins.Interface iface
+) {
+    return new Scratch.Plugins.HighlightSelectedWords (info, iface);
 }
 
 // [ModuleInit]

--- a/plugins/markdown-actions/markdown-actions.vala
+++ b/plugins/markdown-actions/markdown-actions.vala
@@ -47,7 +47,7 @@ public class Scratch.Plugins.MarkdownActions : Scratch.Plugins.PluginBase {
             current_source.notify["language"].disconnect (configure_shortcuts);
         }
 
-        this.disconnect (doc_hook_handler);
+        iface.disconnect (doc_hook_handler);
     }
 
     private void configure_shortcuts () {

--- a/plugins/markdown-actions/markdown-actions.vala
+++ b/plugins/markdown-actions/markdown-actions.vala
@@ -18,15 +18,18 @@
   END LICENSE
 ***/
 
-public class Code.Plugins.MarkdownActions : PluginBase {
+public class Scratch.Plugins.MarkdownActions : Scratch.Plugins.PluginBase {
     Scratch.Widgets.SourceView current_source;
     Scratch.Plugins.Interface plugins;
 
     // public Object object { owned get; construct; }
 
     // public void update_state () {}
-
-    public void activate () {
+    public MarkdownActions (PluginInfo info, Interface iface) {
+        base (info, iface);
+    }
+    
+    public override void activate () {
         plugins.hook_document.connect ((doc) => {
             if (current_source != null) {
                 current_source.key_press_event.disconnect (shortcut_handler);
@@ -40,7 +43,7 @@ public class Code.Plugins.MarkdownActions : PluginBase {
         });
     }
 
-    public void deactivate () {
+    public override void deactivate () {
         if (current_source != null) {
             current_source.key_press_event.disconnect (shortcut_handler);
             current_source.notify["language"].disconnect (configure_shortcuts);
@@ -239,9 +242,13 @@ public class Code.Plugins.MarkdownActions : PluginBase {
     }
 }
 
-public Scratch.Plugins.PluginBase module_init (Scratch.Plugins.PluginInfo info) {
-    return new Scratch.Plugins.MarkdownActions (info);
+public Scratch.Plugins.PluginBase module_init (
+    Scratch.Plugins.PluginInfo info,
+    Scratch.Plugins.Interface iface
+) {
+    return new Scratch.Plugins.MarkdownActions (info, iface);
 }
+
 
 // [ModuleInit]
 // public void peas_register_types (TypeModule module) {

--- a/plugins/markdown-actions/markdown-actions.vala
+++ b/plugins/markdown-actions/markdown-actions.vala
@@ -21,13 +21,12 @@
 
 public class Scratch.Plugins.MarkdownActions : Scratch.Plugins.PluginBase {
     Scratch.Widgets.SourceView current_source;
-    Scratch.Plugins.Interface plugins;
 
     public MarkdownActions (PluginInfo info, Interface iface) {
         base (info, iface);
     }
 
-    public override void activate () {
+    protected override void activate_internal () {
         plugins.hook_document.connect ((doc) => {
             if (current_source != null) {
                 current_source.key_press_event.disconnect (shortcut_handler);
@@ -41,7 +40,7 @@ public class Scratch.Plugins.MarkdownActions : Scratch.Plugins.PluginBase {
         });
     }
 
-    public override void deactivate () {
+    protected override void deactivate_internal () {
         if (current_source != null) {
             current_source.key_press_event.disconnect (shortcut_handler);
             current_source.notify["language"].disconnect (configure_shortcuts);

--- a/plugins/markdown-actions/markdown-actions.vala
+++ b/plugins/markdown-actions/markdown-actions.vala
@@ -1,8 +1,9 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /***
   BEGIN LICENSE
+  Copyright (C) 2024 elementary, Inc. <https://elementary.io>
+                2020 Igor Montagner <igordsm@gmail.com>
 
-  Copyright (C) 2020 Igor Montagner <igordsm@gmail.com>
   This program is free software: you can redistribute it and/or modify it
   under the terms of the GNU Lesser General Public License version 3, as published
   by the Free Software Foundation.
@@ -22,9 +23,6 @@ public class Scratch.Plugins.MarkdownActions : Scratch.Plugins.PluginBase {
     Scratch.Widgets.SourceView current_source;
     Scratch.Plugins.Interface plugins;
 
-    // public Object object { owned get; construct; }
-
-    // public void update_state () {}
     public MarkdownActions (PluginInfo info, Interface iface) {
         base (info, iface);
     }
@@ -248,11 +246,3 @@ public Scratch.Plugins.PluginBase module_init (
 ) {
     return new Scratch.Plugins.MarkdownActions (info, iface);
 }
-
-
-// [ModuleInit]
-// public void peas_register_types (TypeModule module) {
-//     var objmodule = module as Peas.ObjectModule;
-//     objmodule.register_extension_type (typeof (Peas.Activatable),
-//                                      typeof (Code.Plugins.MarkdownActions));
-// }

--- a/plugins/markdown-actions/markdown-actions.vala
+++ b/plugins/markdown-actions/markdown-actions.vala
@@ -46,7 +46,7 @@ public class Scratch.Plugins.MarkdownActions : Scratch.Plugins.PluginBase {
             current_source.key_press_event.disconnect (shortcut_handler);
             current_source.notify["language"].disconnect (configure_shortcuts);
         }
-        
+
         this.disconnect (doc_hook_handler);
     }
 

--- a/plugins/markdown-actions/markdown-actions.vala
+++ b/plugins/markdown-actions/markdown-actions.vala
@@ -26,8 +26,9 @@ public class Scratch.Plugins.MarkdownActions : Scratch.Plugins.PluginBase {
         base (info, iface);
     }
 
+    ulong doc_hook_handler = 0;
     protected override void activate_internal () {
-        plugins.hook_document.connect ((doc) => {
+        doc_hook_handler = iface.hook_document.connect ((doc) => {
             if (current_source != null) {
                 current_source.key_press_event.disconnect (shortcut_handler);
                 current_source.notify["language"].disconnect (configure_shortcuts);
@@ -45,6 +46,8 @@ public class Scratch.Plugins.MarkdownActions : Scratch.Plugins.PluginBase {
             current_source.key_press_event.disconnect (shortcut_handler);
             current_source.notify["language"].disconnect (configure_shortcuts);
         }
+        
+        this.disconnect (doc_hook_handler);
     }
 
     private void configure_shortcuts () {

--- a/plugins/markdown-actions/markdown-actions.vala
+++ b/plugins/markdown-actions/markdown-actions.vala
@@ -18,16 +18,15 @@
   END LICENSE
 ***/
 
-public class Code.Plugins.MarkdownActions : Peas.ExtensionBase, Peas.Activatable {
+public class Code.Plugins.MarkdownActions : PluginBase {
     Scratch.Widgets.SourceView current_source;
-    Scratch.Services.Interface plugins;
+    Scratch.Plugins.Interface plugins;
 
-    public Object object { owned get; construct; }
+    // public Object object { owned get; construct; }
 
-    public void update_state () {}
+    // public void update_state () {}
 
     public void activate () {
-        plugins = (Scratch.Services.Interface) object;
         plugins.hook_document.connect ((doc) => {
             if (current_source != null) {
                 current_source.key_press_event.disconnect (shortcut_handler);
@@ -39,6 +38,13 @@ public class Code.Plugins.MarkdownActions : Peas.ExtensionBase, Peas.Activatable
 
             current_source.notify["language"].connect (configure_shortcuts);
         });
+    }
+
+    public void deactivate () {
+        if (current_source != null) {
+            current_source.key_press_event.disconnect (shortcut_handler);
+            current_source.notify["language"].disconnect (configure_shortcuts);
+        }
     }
 
     private void configure_shortcuts () {
@@ -231,18 +237,15 @@ public class Code.Plugins.MarkdownActions : Peas.ExtensionBase, Peas.Activatable
         current_buffer.end_user_action ();
         go_back_n_chars (tag.length);
     }
-
-    public void deactivate () {
-        if (current_source != null) {
-            current_source.key_press_event.disconnect (shortcut_handler);
-            current_source.notify["language"].disconnect (configure_shortcuts);
-        }
-    }
 }
 
-[ModuleInit]
-public void peas_register_types (TypeModule module) {
-    var objmodule = module as Peas.ObjectModule;
-    objmodule.register_extension_type (typeof (Peas.Activatable),
-                                     typeof (Code.Plugins.MarkdownActions));
+public Scratch.Plugins.PluginBase module_init (Scratch.Plugins.PluginInfo info) {
+    return new Scratch.Plugins.MarkdownActions (info);
 }
+
+// [ModuleInit]
+// public void peas_register_types (TypeModule module) {
+//     var objmodule = module as Peas.ObjectModule;
+//     objmodule.register_extension_type (typeof (Peas.Activatable),
+//                                      typeof (Code.Plugins.MarkdownActions));
+// }

--- a/plugins/markdown-actions/markdown-actions.vala
+++ b/plugins/markdown-actions/markdown-actions.vala
@@ -28,7 +28,7 @@ public class Scratch.Plugins.MarkdownActions : Scratch.Plugins.PluginBase {
     public MarkdownActions (PluginInfo info, Interface iface) {
         base (info, iface);
     }
-    
+
     public override void activate () {
         plugins.hook_document.connect ((doc) => {
             if (current_source != null) {

--- a/plugins/pastebin/pastebin.plugin
+++ b/plugins/pastebin/pastebin.plugin
@@ -1,5 +1,5 @@
 [Plugin]
-Module=libpastebin
+Module=pastebin
 Loader=C
 IAge=2
 Name=Pastebin

--- a/plugins/pastebin/pastebin.vala
+++ b/plugins/pastebin/pastebin.vala
@@ -1,8 +1,9 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /***
   BEGIN LICENSE
-
-  Copyright (C) 2011-2012 Giulio Collura <random.cpp@gmail.com>
+  Copyright (C) 2024 elementary, Inc. <https://elementary.io>
+                2011-2012 Giulio Collura <random.cpp@gmail.com>
+                
   This program is free software: you can redistribute it and/or modify it
   under the terms of the GNU Lesser General Public License version 3, as published
   by the Free Software Foundation.
@@ -37,15 +38,11 @@ public class Scratch.Plugins.Pastebin : Scratch.Plugins.PluginBase {
         {ACTION_SHOW, show_paste_bin_upload_dialog }
     };
 
-    // public void update_state () {
-    // }
     public Pastebin (PluginInfo info, Interface iface) {
         base (info, iface);
     }
 
     public override void activate () {
-        // plugins = (Scratch.Services.Interface) object;
-
         plugins.hook_document.connect ((doc) => {
             this.doc = doc;
         });
@@ -105,11 +102,3 @@ public Scratch.Plugins.PluginBase module_init (
 ) {
     return new Scratch.Plugins.Pastebin (info, iface);
 }
-
-
-// [ModuleInit]
-// public void peas_register_types (GLib.TypeModule module) {
-//     var objmodule = module as Peas.ObjectModule;
-//     objmodule.register_extension_type (typeof (Peas.Activatable),
-//                                      typeof (Scratch.Plugins.Pastebin));
-// }

--- a/plugins/pastebin/pastebin.vala
+++ b/plugins/pastebin/pastebin.vala
@@ -41,16 +41,20 @@ public class Scratch.Plugins.Pastebin : Scratch.Plugins.PluginBase {
         base (info, iface);
     }
 
+    ulong doc_hook_handler = 0;
+    ulong menu_hook_handler = 0;
     protected override void activate_internal () {
-        plugins.hook_document.connect ((doc) => {
+        doc_hook_handler = iface.hook_document.connect ((doc) => {
             this.doc = doc;
         });
 
-        plugins.hook_share_menu.connect (on_hook_share_menu);
+        menu_hook_handler = iface.hook_share_menu.connect (on_hook_share_menu);
     }
 
     protected override void deactivate_internal () {
         remove_actions ();
+        this.disconnect (menu_hook_handler);
+        this.disconnect (doc_hook_handler);
     }
 
     void on_hook_share_menu (GLib.MenuModel menu) {
@@ -67,7 +71,7 @@ public class Scratch.Plugins.Pastebin : Scratch.Plugins.PluginBase {
             actions.add_action_entries (ACTION_ENTRIES, this);
         }
 
-        plugins.manager.window.insert_action_group (ACTION_GROUP, actions);
+        iface.manager.window.insert_action_group (ACTION_GROUP, actions);
         share_menu = (GLib.Menu) menu;
         menuitem = new GLib.MenuItem (_("Upload to Pastebin"), ACTION_PREFIX + ACTION_SHOW);
         share_menu.append_item (menuitem);
@@ -86,11 +90,11 @@ public class Scratch.Plugins.Pastebin : Scratch.Plugins.PluginBase {
             }
         }
 
-        plugins.manager.window.insert_action_group (ACTION_GROUP, null);
+        iface.manager.window.insert_action_group (ACTION_GROUP, null);
     }
 
     void show_paste_bin_upload_dialog () {
-        MainWindow window = plugins.manager.window;
+        MainWindow window = iface.manager.window;
         new Dialogs.PasteBinDialog (window, doc);
     }
 }

--- a/plugins/pastebin/pastebin.vala
+++ b/plugins/pastebin/pastebin.vala
@@ -3,7 +3,7 @@
   BEGIN LICENSE
   Copyright (C) 2024 elementary, Inc. <https://elementary.io>
                 2011-2012 Giulio Collura <random.cpp@gmail.com>
-                
+
   This program is free software: you can redistribute it and/or modify it
   under the terms of the GNU Lesser General Public License version 3, as published
   by the Free Software Foundation.
@@ -24,7 +24,6 @@
 public class Scratch.Plugins.Pastebin : Scratch.Plugins.PluginBase {
     GLib.MenuItem? menuitem = null;
     GLib.Menu? share_menu = null;
-    // public Object object { owned get; construct; }
 
     Scratch.Services.Document? doc = null;
 

--- a/plugins/pastebin/pastebin.vala
+++ b/plugins/pastebin/pastebin.vala
@@ -52,8 +52,8 @@ public class Scratch.Plugins.Pastebin : Scratch.Plugins.PluginBase {
 
     protected override void deactivate_internal () {
         remove_actions ();
-        this.disconnect (menu_hook_handler);
-        this.disconnect (doc_hook_handler);
+        iface.disconnect (menu_hook_handler);
+        iface.disconnect (doc_hook_handler);
     }
 
     void on_hook_share_menu (GLib.MenuModel menu) {

--- a/plugins/pastebin/pastebin.vala
+++ b/plugins/pastebin/pastebin.vala
@@ -42,7 +42,7 @@ public class Scratch.Plugins.Pastebin : Scratch.Plugins.PluginBase {
     public Pastebin (PluginInfo info, Interface iface) {
         base (info, iface);
     }
-    
+
     public override void activate () {
         // plugins = (Scratch.Services.Interface) object;
 

--- a/plugins/pastebin/pastebin.vala
+++ b/plugins/pastebin/pastebin.vala
@@ -18,7 +18,7 @@
   END LICENSE
 ***/
 
-namespace Scratch.Services {
+namespace Scratch.Plugins {
     public class PasteBin : GLib.Object {
         public const string NEVER = "N";
         public const string TEN_MINUTES = "10M";
@@ -68,10 +68,10 @@ namespace Scratch.Services {
     }
 }
 
-public class Scratch.Plugins.Pastebin : Peas.ExtensionBase, Peas.Activatable {
+public class Scratch.Plugins.Pastebin : PluginBase {
     GLib.MenuItem? menuitem = null;
     GLib.Menu? share_menu = null;
-    public Object object { owned get; construct; }
+    // public Object object { owned get; construct; }
 
     Scratch.Services.Document? doc = null;
     Scratch.Services.Interface plugins;
@@ -85,17 +85,21 @@ public class Scratch.Plugins.Pastebin : Peas.ExtensionBase, Peas.Activatable {
         {ACTION_SHOW, show_paste_bin_upload_dialog }
     };
 
-    public void update_state () {
-    }
+    // public void update_state () {
+    // }
 
     public void activate () {
-        plugins = (Scratch.Services.Interface) object;
+        // plugins = (Scratch.Services.Interface) object;
 
         plugins.hook_document.connect ((doc) => {
             this.doc = doc;
         });
 
         plugins.hook_share_menu.connect (on_hook_share_menu);
+    }
+
+    public void deactivate () {
+        remove_actions ();
     }
 
     void on_hook_share_menu (GLib.MenuModel menu) {
@@ -138,15 +142,15 @@ public class Scratch.Plugins.Pastebin : Peas.ExtensionBase, Peas.Activatable {
         MainWindow window = plugins.manager.window;
         new Dialogs.PasteBinDialog (window, doc);
     }
-
-    public void deactivate () {
-        remove_actions ();
-    }
 }
 
-[ModuleInit]
-public void peas_register_types (GLib.TypeModule module) {
-    var objmodule = module as Peas.ObjectModule;
-    objmodule.register_extension_type (typeof (Peas.Activatable),
-                                     typeof (Scratch.Plugins.Pastebin));
+public Scratch.Plugins.PluginBase module_init (Scratch.Plugins.PluginInfo info) {
+    return new Scratch.Plugins.Pastebin (info);
 }
+
+// [ModuleInit]
+// public void peas_register_types (GLib.TypeModule module) {
+//     var objmodule = module as Peas.ObjectModule;
+//     objmodule.register_extension_type (typeof (Peas.Activatable),
+//                                      typeof (Scratch.Plugins.Pastebin));
+// }

--- a/plugins/pastebin/pastebin.vala
+++ b/plugins/pastebin/pastebin.vala
@@ -18,63 +18,15 @@
   END LICENSE
 ***/
 
-namespace Scratch.Plugins {
-    public class PasteBin : GLib.Object {
-        public const string NEVER = "N";
-        public const string TEN_MINUTES = "10M";
-        public const string HOUR = "1H";
-        public const string DAY = "1D";
-        public const string MONTH = "1M";
-
-        public const string PRIVATE = "1";
-        public const string PUBLIC = "0";
 
 
-        public static bool submit (out string link, string paste_code, string paste_name,
-                                     string paste_private, string paste_expire_date,
-                                     string paste_format) {
-
-            if (paste_code.length == 0) { link = "No text to paste"; return false; }
-
-            string api_url = "https://pastebin.com/api/api_post.php";
-
-            var session = new Soup.Session ();
-            var message = new Soup.Message ("POST", api_url);
-
-            string request = Soup.Form.encode (
-                "api_option", "paste",
-                "api_dev_key", "67480801fa55fc0977f7561cf650a339",
-                "api_paste_code", paste_code,
-                "api_paste_name", paste_name,
-                "api_paste_private", paste_private,
-                "api_paste_expire_date", paste_expire_date,
-                "api_paste_format", paste_format);
-
-            message.set_request ("application/x-www-form-urlencoded", Soup.MemoryUse.COPY, request.data);
-            message.set_flags (Soup.MessageFlags.NO_REDIRECT);
-
-            session.send_message (message);
-
-            var output = (string) message.response_body.data;
-            link = output;
-
-            if (Uri.parse_scheme (output) == null || message.status_code != 200) {
-                // A URI was not returned
-                return false;
-            }
-
-            return true;
-        }
-    }
-}
-
-public class Scratch.Plugins.Pastebin : PluginBase {
+public class Scratch.Plugins.Pastebin : Scratch.Plugins.PluginBase {
     GLib.MenuItem? menuitem = null;
     GLib.Menu? share_menu = null;
     // public Object object { owned get; construct; }
 
     Scratch.Services.Document? doc = null;
-    Scratch.Services.Interface plugins;
+    Scratch.Plugins.Interface plugins;
 
     const string ACTION_GROUP = "pastebin";
     const string ACTION_PREFIX = ACTION_GROUP + ".";
@@ -87,8 +39,11 @@ public class Scratch.Plugins.Pastebin : PluginBase {
 
     // public void update_state () {
     // }
-
-    public void activate () {
+    public Pastebin (PluginInfo info, Interface iface) {
+        base (info, iface);
+    }
+    
+    public override void activate () {
         // plugins = (Scratch.Services.Interface) object;
 
         plugins.hook_document.connect ((doc) => {
@@ -98,7 +53,7 @@ public class Scratch.Plugins.Pastebin : PluginBase {
         plugins.hook_share_menu.connect (on_hook_share_menu);
     }
 
-    public void deactivate () {
+    public override void deactivate () {
         remove_actions ();
     }
 
@@ -144,9 +99,13 @@ public class Scratch.Plugins.Pastebin : PluginBase {
     }
 }
 
-public Scratch.Plugins.PluginBase module_init (Scratch.Plugins.PluginInfo info) {
-    return new Scratch.Plugins.Pastebin (info);
+public Scratch.Plugins.PluginBase module_init (
+    Scratch.Plugins.PluginInfo info,
+    Scratch.Plugins.Interface iface
+) {
+    return new Scratch.Plugins.Pastebin (info, iface);
 }
+
 
 // [ModuleInit]
 // public void peas_register_types (GLib.TypeModule module) {

--- a/plugins/pastebin/pastebin.vala
+++ b/plugins/pastebin/pastebin.vala
@@ -27,7 +27,6 @@ public class Scratch.Plugins.Pastebin : Scratch.Plugins.PluginBase {
     // public Object object { owned get; construct; }
 
     Scratch.Services.Document? doc = null;
-    Scratch.Plugins.Interface plugins;
 
     const string ACTION_GROUP = "pastebin";
     const string ACTION_PREFIX = ACTION_GROUP + ".";
@@ -42,7 +41,7 @@ public class Scratch.Plugins.Pastebin : Scratch.Plugins.PluginBase {
         base (info, iface);
     }
 
-    public override void activate () {
+    protected override void activate_internal () {
         plugins.hook_document.connect ((doc) => {
             this.doc = doc;
         });
@@ -50,7 +49,7 @@ public class Scratch.Plugins.Pastebin : Scratch.Plugins.PluginBase {
         plugins.hook_share_menu.connect (on_hook_share_menu);
     }
 
-    public override void deactivate () {
+    protected override void deactivate_internal () {
         remove_actions ();
     }
 

--- a/plugins/preserve-indent/preserve-indent.vala
+++ b/plugins/preserve-indent/preserve-indent.vala
@@ -51,7 +51,7 @@ public class Scratch.Plugins.PreserveIndent : Scratch.Plugins.PluginBase {
 
     protected override void deactivate_internal () {
         this.documents.clear ();
-        this.disconnect (doc_hook_handler);
+        iface.disconnect (doc_hook_handler);
     }
 
     // determine how many characters precede a given iterator position

--- a/plugins/preserve-indent/preserve-indent.vala
+++ b/plugins/preserve-indent/preserve-indent.vala
@@ -20,7 +20,6 @@
 ***/
 
 public class Scratch.Plugins.PreserveIndent : Scratch.Plugins.PluginBase {
-    private Scratch.Plugins.Interface plugins;
     private Gee.TreeSet<weak Services.Document> documents;
     private Services.Document active_document;
     private int last_clipboard_indent_level = 0;
@@ -30,7 +29,7 @@ public class Scratch.Plugins.PreserveIndent : Scratch.Plugins.PluginBase {
         base (info, iface);
     }
 
-    public override void activate () {
+    protected override void activate_internal () {
         this.documents = new Gee.TreeSet<weak Services.Document> ();
 
         plugins.hook_document.connect ((d) => {
@@ -49,7 +48,7 @@ public class Scratch.Plugins.PreserveIndent : Scratch.Plugins.PluginBase {
         });
     }
 
-    public override void deactivate () {
+    protected override void deactivate_internal () {
         this.documents.clear ();
     }
 

--- a/plugins/preserve-indent/preserve-indent.vala
+++ b/plugins/preserve-indent/preserve-indent.vala
@@ -18,7 +18,7 @@
   END LICENSE
 ***/
 
-public class Scratch.Plugins.PreserveIndent : Peas.ExtensionBase, Peas.Activatable {
+public class Scratch.Plugins.PreserveIndent : PluginBase {
 
     private Scratch.Services.Interface plugins;
     private Gee.TreeSet<weak Services.Document> documents;
@@ -26,11 +26,11 @@ public class Scratch.Plugins.PreserveIndent : Peas.ExtensionBase, Peas.Activatab
     private int last_clipboard_indent_level = 0;
     private bool waiting_for_clipboard_text = false;
 
-    public Object object { owned get; construct; }
+    // public Object object { owned get; construct; }
 
     public void activate () {
         this.documents = new Gee.TreeSet<weak Services.Document> ();
-        plugins = (Scratch.Services.Interface) object;
+        // plugins = (Scratch.Services.Interface) object;
 
         plugins.hook_document.connect ((d) => {
             this.active_document = d;
@@ -241,9 +241,13 @@ public class Scratch.Plugins.PreserveIndent : Peas.ExtensionBase, Peas.Activatab
     }
 }
 
-[ModuleInit]
-public void peas_register_types (GLib.TypeModule module) {
-    var objmodule = module as Peas.ObjectModule;
-    objmodule.register_extension_type (typeof (Peas.Activatable),
-                                     typeof (Scratch.Plugins.PreserveIndent));
+public Scratch.Plugins.PluginBase module_init (Scratch.Plugins.PluginInfo info) {
+    return new Scratch.Plugins.PreserveIndent (info);
 }
+
+// [ModuleInit]
+// public void peas_register_types (GLib.TypeModule module) {
+//     var objmodule = module as Peas.ObjectModule;
+//     objmodule.register_extension_type (typeof (Peas.Activatable),
+//                                      typeof (Scratch.Plugins.PreserveIndent));
+// }

--- a/plugins/preserve-indent/preserve-indent.vala
+++ b/plugins/preserve-indent/preserve-indent.vala
@@ -3,7 +3,7 @@
   BEGIN LICENSE
   Copyright (C) 2024 elementary, Inc. <https://elementary.io>
                 2015 James Morgan <james.harmonic@gmail.com>
-                
+
   This program is free software: you can redistribute it and/or modify it
   under the terms of the GNU Lesser General Public License version 3, as published
   by the Free Software Foundation.

--- a/plugins/preserve-indent/preserve-indent.vala
+++ b/plugins/preserve-indent/preserve-indent.vala
@@ -18,17 +18,19 @@
   END LICENSE
 ***/
 
-public class Scratch.Plugins.PreserveIndent : PluginBase {
-
-    private Scratch.Services.Interface plugins;
+public class Scratch.Plugins.PreserveIndent : Scratch.Plugins.PluginBase {
+    private Scratch.Plugins.Interface plugins;
     private Gee.TreeSet<weak Services.Document> documents;
     private Services.Document active_document;
     private int last_clipboard_indent_level = 0;
     private bool waiting_for_clipboard_text = false;
 
     // public Object object { owned get; construct; }
-
-    public void activate () {
+    public PreserveIndent (PluginInfo info, Interface iface) {
+        base (info, iface);
+    }
+    
+    public override void activate () {
         this.documents = new Gee.TreeSet<weak Services.Document> ();
         // plugins = (Scratch.Services.Interface) object;
 
@@ -48,11 +50,8 @@ public class Scratch.Plugins.PreserveIndent : PluginBase {
         });
     }
 
-    public void deactivate () {
+    public override void deactivate () {
         this.documents.clear ();
-    }
-
-    public void update_state () {
     }
 
     // determine how many characters precede a given iterator position
@@ -241,9 +240,13 @@ public class Scratch.Plugins.PreserveIndent : PluginBase {
     }
 }
 
-public Scratch.Plugins.PluginBase module_init (Scratch.Plugins.PluginInfo info) {
-    return new Scratch.Plugins.PreserveIndent (info);
+public Scratch.Plugins.PluginBase module_init (
+    Scratch.Plugins.PluginInfo info,
+    Scratch.Plugins.Interface iface
+) {
+    return new Scratch.Plugins.PreserveIndent (info, iface);
 }
+
 
 // [ModuleInit]
 // public void peas_register_types (GLib.TypeModule module) {

--- a/plugins/preserve-indent/preserve-indent.vala
+++ b/plugins/preserve-indent/preserve-indent.vala
@@ -29,7 +29,7 @@ public class Scratch.Plugins.PreserveIndent : Scratch.Plugins.PluginBase {
     public PreserveIndent (PluginInfo info, Interface iface) {
         base (info, iface);
     }
-    
+
     public override void activate () {
         this.documents = new Gee.TreeSet<weak Services.Document> ();
         // plugins = (Scratch.Services.Interface) object;

--- a/plugins/preserve-indent/preserve-indent.vala
+++ b/plugins/preserve-indent/preserve-indent.vala
@@ -29,10 +29,11 @@ public class Scratch.Plugins.PreserveIndent : Scratch.Plugins.PluginBase {
         base (info, iface);
     }
 
+    ulong doc_hook_handler = 0;
     protected override void activate_internal () {
         this.documents = new Gee.TreeSet<weak Services.Document> ();
 
-        plugins.hook_document.connect ((d) => {
+        doc_hook_handler = iface.hook_document.connect ((d) => {
             this.active_document = d;
 
             if (documents.add (d)) {
@@ -50,6 +51,7 @@ public class Scratch.Plugins.PreserveIndent : Scratch.Plugins.PluginBase {
 
     protected override void deactivate_internal () {
         this.documents.clear ();
+        this.disconnect (doc_hook_handler);
     }
 
     // determine how many characters precede a given iterator position

--- a/plugins/preserve-indent/preserve-indent.vala
+++ b/plugins/preserve-indent/preserve-indent.vala
@@ -1,8 +1,9 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /***
   BEGIN LICENSE
-
-  Copyright (C) 2015 James Morgan <james.harmonic@gmail.com>
+  Copyright (C) 2024 elementary, Inc. <https://elementary.io>
+                2015 James Morgan <james.harmonic@gmail.com>
+                
   This program is free software: you can redistribute it and/or modify it
   under the terms of the GNU Lesser General Public License version 3, as published
   by the Free Software Foundation.
@@ -25,14 +26,12 @@ public class Scratch.Plugins.PreserveIndent : Scratch.Plugins.PluginBase {
     private int last_clipboard_indent_level = 0;
     private bool waiting_for_clipboard_text = false;
 
-    // public Object object { owned get; construct; }
     public PreserveIndent (PluginInfo info, Interface iface) {
         base (info, iface);
     }
 
     public override void activate () {
         this.documents = new Gee.TreeSet<weak Services.Document> ();
-        // plugins = (Scratch.Services.Interface) object;
 
         plugins.hook_document.connect ((d) => {
             this.active_document = d;
@@ -246,11 +245,3 @@ public Scratch.Plugins.PluginBase module_init (
 ) {
     return new Scratch.Plugins.PreserveIndent (info, iface);
 }
-
-
-// [ModuleInit]
-// public void peas_register_types (GLib.TypeModule module) {
-//     var objmodule = module as Peas.ObjectModule;
-//     objmodule.register_extension_type (typeof (Peas.Activatable),
-//                                      typeof (Scratch.Plugins.PreserveIndent));
-// }

--- a/plugins/spell/spell.vala
+++ b/plugins/spell/spell.vala
@@ -15,7 +15,6 @@
  */
 
 public class Scratch.Plugins.Spell: Scratch.Plugins.PluginBase {
-    Scratch.Plugins.Interface plugins;
     private GLib.Settings settings;
     MainWindow window = null;
     private string lang_dict;
@@ -30,7 +29,7 @@ public class Scratch.Plugins.Spell: Scratch.Plugins.PluginBase {
         base (info, iface);
     }
 
-    public override void activate () {
+    protected override void activate_internal () {
         settings = new GLib.Settings (Constants.PROJECT_NAME + ".plugins.spell");
 
         // Restore the last dictionary used.
@@ -121,7 +120,7 @@ public class Scratch.Plugins.Spell: Scratch.Plugins.PluginBase {
 
     }
 
-    public override void deactivate () {
+    protected override void deactivate_internal () {
         save_settings ();
         window.destroy.disconnect (save_settings);
     }

--- a/plugins/spell/spell.vala
+++ b/plugins/spell/spell.vala
@@ -1,6 +1,7 @@
-/*
- * Copyright (C) 2011-2012 Mario Guerriero <mefrio.g@gmail.com> This program
- * is free software: you can redistribute it and/or modify it under the
+/* Copyright (C) 2024 elementary, Inc. <https://elementary.io>
+ *               2011-2012 Mario Guerriero <mefrio.g@gmail.com> 
+ * 
+ * This program is free software: you can redistribute it and/or modify it under the
  * terms of the GNU Lesser General Public License version 3, as published by
  * the Free Software Foundation.
  *
@@ -28,10 +29,6 @@ public class Scratch.Plugins.Spell: Scratch.Plugins.PluginBase {
     public Spell (PluginInfo info, Interface iface) {
         base (info, iface);
     }
-    // public Object object {owned get; construct;}
-
-    // public void update_state () {
-    // }
 
     public override void activate () {
         settings = new GLib.Settings (Constants.PROJECT_NAME + ".plugins.spell");
@@ -41,7 +38,6 @@ public class Scratch.Plugins.Spell: Scratch.Plugins.PluginBase {
 
         settings.changed.connect (settings_changed);
 
-        // plugins = (Scratch.Services.Interface) object;
         plugins.hook_document.connect ((d) => {
             var view = d.source_view;
 
@@ -159,13 +155,3 @@ public Scratch.Plugins.PluginBase module_init (
 ) {
     return new Scratch.Plugins.Spell (info, iface);
 }
-
-
-// [ModuleInit]
-// public void peas_register_types (GLib.TypeModule module) {
-//     var objmodule = module as Peas.ObjectModule;
-//     objmodule.register_extension_type (
-//         typeof (Peas.Activatable),
-//         typeof (Scratch.Plugins.Spell)
-//     );
-// }

--- a/plugins/spell/spell.vala
+++ b/plugins/spell/spell.vala
@@ -13,14 +13,10 @@
  * with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 
-public class Scratch.Plugins.Spell: PluginBase {
-
+public class Scratch.Plugins.Spell: Scratch.Plugins.PluginBase {
     Scratch.Plugins.Interface plugins;
-
     private GLib.Settings settings;
-
     MainWindow window = null;
-
     private string lang_dict;
 
 #if SPELLLEGACY
@@ -29,12 +25,15 @@ public class Scratch.Plugins.Spell: PluginBase {
     GtkSpell.Checker spell = null;
 #endif
 
+    public Spell (PluginInfo info, Interface iface) {
+        base (info, iface);
+    }
     // public Object object {owned get; construct;}
 
     // public void update_state () {
     // }
 
-    public void activate () {
+    public override void activate () {
         settings = new GLib.Settings (Constants.PROJECT_NAME + ".plugins.spell");
 
         // Restore the last dictionary used.
@@ -93,7 +92,7 @@ public class Scratch.Plugins.Spell: PluginBase {
 #endif
                 // Deactivate Spell checker when it is no longer needed
                 plugins.manager.extension_removed.connect ((info) => {
-                    if (info.get_module_name () == "spell")
+                    if (info.module_name == "spell")
                         spell.detach ();
                 });
 
@@ -126,7 +125,7 @@ public class Scratch.Plugins.Spell: PluginBase {
 
     }
 
-    public void deactivate () {
+    public override void deactivate () {
         save_settings ();
         window.destroy.disconnect (save_settings);
     }
@@ -154,9 +153,13 @@ public class Scratch.Plugins.Spell: PluginBase {
 
 }
 
-public Scratch.Plugins.PluginBase module_init (Scratch.Plugins.PluginInfo info) {
-    return new Scratch.Plugins.Spell (info);
+public Scratch.Plugins.PluginBase module_init (
+    Scratch.Plugins.PluginInfo info,
+    Scratch.Plugins.Interface iface
+) {
+    return new Scratch.Plugins.Spell (info, iface);
 }
+
 
 // [ModuleInit]
 // public void peas_register_types (GLib.TypeModule module) {

--- a/plugins/spell/spell.vala
+++ b/plugins/spell/spell.vala
@@ -123,8 +123,8 @@ public class Scratch.Plugins.Spell: Scratch.Plugins.PluginBase {
     protected override void deactivate_internal () {
         save_settings ();
         window.destroy.disconnect (save_settings);
-        this.disconnect (window_hook_handler);
-        this.disconnect (doc_hook_handler);
+        iface.disconnect (window_hook_handler);
+        iface.disconnect (doc_hook_handler);
     }
 
     private void language_changed_spell (Scratch.Widgets.SourceView view) {

--- a/plugins/spell/spell.vala
+++ b/plugins/spell/spell.vala
@@ -13,9 +13,9 @@
  * with this program.  If not, see <http://www.gnu.org/licenses/>
  */
 
-public class Scratch.Plugins.Spell: Peas.ExtensionBase, Peas.Activatable {
+public class Scratch.Plugins.Spell: PluginBase {
 
-    Scratch.Services.Interface plugins;
+    Scratch.Plugins.Interface plugins;
 
     private GLib.Settings settings;
 
@@ -29,10 +29,10 @@ public class Scratch.Plugins.Spell: Peas.ExtensionBase, Peas.Activatable {
     GtkSpell.Checker spell = null;
 #endif
 
-    public Object object {owned get; construct;}
+    // public Object object {owned get; construct;}
 
-    public void update_state () {
-    }
+    // public void update_state () {
+    // }
 
     public void activate () {
         settings = new GLib.Settings (Constants.PROJECT_NAME + ".plugins.spell");
@@ -42,7 +42,7 @@ public class Scratch.Plugins.Spell: Peas.ExtensionBase, Peas.Activatable {
 
         settings.changed.connect (settings_changed);
 
-        plugins = (Scratch.Services.Interface) object;
+        // plugins = (Scratch.Services.Interface) object;
         plugins.hook_document.connect ((d) => {
             var view = d.source_view;
 
@@ -126,7 +126,10 @@ public class Scratch.Plugins.Spell: Peas.ExtensionBase, Peas.Activatable {
 
     }
 
-
+    public void deactivate () {
+        save_settings ();
+        window.destroy.disconnect (save_settings);
+    }
 
     private void language_changed_spell (Scratch.Widgets.SourceView view) {
         if (view.language != null)
@@ -149,18 +152,17 @@ public class Scratch.Plugins.Spell: Peas.ExtensionBase, Peas.Activatable {
         settings.set_string ("language", lang_dict);
     }
 
-    public void deactivate () {
-        save_settings ();
-        window.destroy.disconnect (save_settings);
-    }
-
 }
 
-[ModuleInit]
-public void peas_register_types (GLib.TypeModule module) {
-    var objmodule = module as Peas.ObjectModule;
-    objmodule.register_extension_type (
-        typeof (Peas.Activatable),
-        typeof (Scratch.Plugins.Spell)
-    );
+public Scratch.Plugins.PluginBase module_init (Scratch.Plugins.PluginInfo info) {
+    return new Scratch.Plugins.Spell (info);
 }
+
+// [ModuleInit]
+// public void peas_register_types (GLib.TypeModule module) {
+//     var objmodule = module as Peas.ObjectModule;
+//     objmodule.register_extension_type (
+//         typeof (Peas.Activatable),
+//         typeof (Scratch.Plugins.Spell)
+//     );
+// }

--- a/plugins/vim-emulation/vim-emulation.vala
+++ b/plugins/vim-emulation/vim-emulation.vala
@@ -1,8 +1,9 @@
 // -*- Mode: vala; indent-tabs-mode: nil; tab-width: 4 -*-
 /***
   BEGIN LICENSE
+  Copyright (C) 2024 elementary, Inc. <https://elementary.io>
+                2013 Mario Guerriero <mario@elementaryos.org>
 
-  Copyright (C) 2013 Mario Guerriero <mario@elementaryos.org>
   This program is free software: you can redistribute it and/or modify it
   under the terms of the GNU Lesser General Public License version 3, as published
   by the Free Software Foundation.
@@ -34,7 +35,6 @@ public class Scratch.Plugins.VimEmulation : Scratch.Plugins.PluginBase {
     Scratch.Widgets.SourceView? view = null;
 
     Scratch.Plugins.Interface plugins;
-    // public Object object { owned get; construct; }
 
     public VimEmulation (PluginInfo info, Interface iface) {
         base (info, iface);
@@ -44,12 +44,7 @@ public class Scratch.Plugins.VimEmulation : Scratch.Plugins.PluginBase {
         views = new Gee.TreeSet<Scratch.Widgets.SourceView> ();
     }
 
-    // public void update_state () {
-
-    // }
-
     public override void activate () {
-        // plugins = (Scratch.Plugins.Interface) object;
         plugins.hook_document.connect ((doc) => {
             this.view = doc.source_view;
             this.view.key_press_event.disconnect (handle_key_press);
@@ -305,11 +300,3 @@ public Scratch.Plugins.PluginBase module_init (
 ) {
     return new Scratch.Plugins.VimEmulation (info, iface);
 }
-
-
-// [ModuleInit]
-// public void peas_register_types (GLib.TypeModule module) {
-//     var objmodule = module as Peas.ObjectModule;
-//     objmodule.register_extension_type (typeof (Peas.Activatable),
-//                                      typeof (Scratch.Plugins.VimEmulation));
-// }

--- a/plugins/vim-emulation/vim-emulation.vala
+++ b/plugins/vim-emulation/vim-emulation.vala
@@ -57,7 +57,7 @@ public class Scratch.Plugins.VimEmulation : Scratch.Plugins.PluginBase {
             v.key_press_event.disconnect (handle_key_press);
         }
 
-        this.disconnect (doc_hook_handler);
+        iface.disconnect (doc_hook_handler);
     }
 
     private bool handle_key_press (Gdk.EventKey event) {

--- a/plugins/vim-emulation/vim-emulation.vala
+++ b/plugins/vim-emulation/vim-emulation.vala
@@ -56,7 +56,7 @@ public class Scratch.Plugins.VimEmulation : Scratch.Plugins.PluginBase {
         foreach (var v in views) {
             v.key_press_event.disconnect (handle_key_press);
         }
-        
+
         this.disconnect (doc_hook_handler);
     }
 

--- a/plugins/vim-emulation/vim-emulation.vala
+++ b/plugins/vim-emulation/vim-emulation.vala
@@ -18,7 +18,7 @@
   END LICENSE
 ***/
 
-public class Scratch.Plugins.VimEmulation : Peas.ExtensionBase, Peas.Activatable {
+public class Scratch.Plugins.VimEmulation : PluginBase {
     public enum Mode {
         COMMAND,
         INSERT,
@@ -33,19 +33,19 @@ public class Scratch.Plugins.VimEmulation : Peas.ExtensionBase, Peas.Activatable
     Gee.TreeSet<Scratch.Widgets.SourceView> views;
     Scratch.Widgets.SourceView? view = null;
 
-    Scratch.Services.Interface plugins;
-    public Object object { owned get; construct; }
+    Scratch.Plugins.Interface plugins;
+    // public Object object { owned get; construct; }
 
     construct {
         views = new Gee.TreeSet<Scratch.Widgets.SourceView> ();
     }
 
-    public void update_state () {
+    // public void update_state () {
 
-    }
+    // }
 
     public void activate () {
-        plugins = (Scratch.Services.Interface) object;
+        plugins = (Scratch.Plugins.Interface) object;
         plugins.hook_document.connect ((doc) => {
             this.view = doc.source_view;
             this.view.key_press_event.disconnect (handle_key_press);
@@ -295,9 +295,13 @@ public class Scratch.Plugins.VimEmulation : Peas.ExtensionBase, Peas.Activatable
     }
 }
 
-[ModuleInit]
-public void peas_register_types (GLib.TypeModule module) {
-    var objmodule = module as Peas.ObjectModule;
-    objmodule.register_extension_type (typeof (Peas.Activatable),
-                                     typeof (Scratch.Plugins.VimEmulation));
+public Scratch.Plugins.PluginBase module_init (Scratch.Plugins.PluginInfo info) {
+    return new Scratch.Plugins.VimEmulation (info);
 }
+
+// [ModuleInit]
+// public void peas_register_types (GLib.TypeModule module) {
+//     var objmodule = module as Peas.ObjectModule;
+//     objmodule.register_extension_type (typeof (Peas.Activatable),
+//                                      typeof (Scratch.Plugins.VimEmulation));
+// }

--- a/plugins/vim-emulation/vim-emulation.vala
+++ b/plugins/vim-emulation/vim-emulation.vala
@@ -18,7 +18,7 @@
   END LICENSE
 ***/
 
-public class Scratch.Plugins.VimEmulation : PluginBase {
+public class Scratch.Plugins.VimEmulation : Scratch.Plugins.PluginBase {
     public enum Mode {
         COMMAND,
         INSERT,
@@ -36,6 +36,10 @@ public class Scratch.Plugins.VimEmulation : PluginBase {
     Scratch.Plugins.Interface plugins;
     // public Object object { owned get; construct; }
 
+    public VimEmulation (PluginInfo info, Interface iface) {
+        base (info, iface);
+    }
+    
     construct {
         views = new Gee.TreeSet<Scratch.Widgets.SourceView> ();
     }
@@ -44,8 +48,8 @@ public class Scratch.Plugins.VimEmulation : PluginBase {
 
     // }
 
-    public void activate () {
-        plugins = (Scratch.Plugins.Interface) object;
+    public override void activate () {
+        // plugins = (Scratch.Plugins.Interface) object;
         plugins.hook_document.connect ((doc) => {
             this.view = doc.source_view;
             this.view.key_press_event.disconnect (handle_key_press);
@@ -54,7 +58,7 @@ public class Scratch.Plugins.VimEmulation : PluginBase {
         });
     }
 
-    public void deactivate () {
+    public override void deactivate () {
         foreach (var v in views) {
             v.key_press_event.disconnect (handle_key_press);
         }
@@ -295,9 +299,13 @@ public class Scratch.Plugins.VimEmulation : PluginBase {
     }
 }
 
-public Scratch.Plugins.PluginBase module_init (Scratch.Plugins.PluginInfo info) {
-    return new Scratch.Plugins.VimEmulation (info);
+public Scratch.Plugins.PluginBase module_init (
+    Scratch.Plugins.PluginInfo info,
+    Scratch.Plugins.Interface iface
+) {
+    return new Scratch.Plugins.VimEmulation (info, iface);
 }
+
 
 // [ModuleInit]
 // public void peas_register_types (GLib.TypeModule module) {

--- a/plugins/vim-emulation/vim-emulation.vala
+++ b/plugins/vim-emulation/vim-emulation.vala
@@ -39,7 +39,7 @@ public class Scratch.Plugins.VimEmulation : Scratch.Plugins.PluginBase {
     public VimEmulation (PluginInfo info, Interface iface) {
         base (info, iface);
     }
-    
+
     construct {
         views = new Gee.TreeSet<Scratch.Widgets.SourceView> ();
     }

--- a/plugins/vim-emulation/vim-emulation.vala
+++ b/plugins/vim-emulation/vim-emulation.vala
@@ -34,8 +34,6 @@ public class Scratch.Plugins.VimEmulation : Scratch.Plugins.PluginBase {
     Gee.TreeSet<Scratch.Widgets.SourceView> views;
     Scratch.Widgets.SourceView? view = null;
 
-    Scratch.Plugins.Interface plugins;
-
     public VimEmulation (PluginInfo info, Interface iface) {
         base (info, iface);
     }
@@ -44,7 +42,7 @@ public class Scratch.Plugins.VimEmulation : Scratch.Plugins.PluginBase {
         views = new Gee.TreeSet<Scratch.Widgets.SourceView> ();
     }
 
-    public override void activate () {
+    protected override void activate_internal () {
         plugins.hook_document.connect ((doc) => {
             this.view = doc.source_view;
             this.view.key_press_event.disconnect (handle_key_press);
@@ -53,7 +51,7 @@ public class Scratch.Plugins.VimEmulation : Scratch.Plugins.PluginBase {
         });
     }
 
-    public override void deactivate () {
+    protected override void deactivate_internal () {
         foreach (var v in views) {
             v.key_press_event.disconnect (handle_key_press);
         }

--- a/plugins/vim-emulation/vim-emulation.vala
+++ b/plugins/vim-emulation/vim-emulation.vala
@@ -42,8 +42,9 @@ public class Scratch.Plugins.VimEmulation : Scratch.Plugins.PluginBase {
         views = new Gee.TreeSet<Scratch.Widgets.SourceView> ();
     }
 
+    ulong doc_hook_handler = 0;
     protected override void activate_internal () {
-        plugins.hook_document.connect ((doc) => {
+        doc_hook_handler = iface.hook_document.connect ((doc) => {
             this.view = doc.source_view;
             this.view.key_press_event.disconnect (handle_key_press);
             this.view.key_press_event.connect (handle_key_press);
@@ -55,6 +56,8 @@ public class Scratch.Plugins.VimEmulation : Scratch.Plugins.PluginBase {
         foreach (var v in views) {
             v.key_press_event.disconnect (handle_key_press);
         }
+        
+        this.disconnect (doc_hook_handler);
     }
 
     private bool handle_key_press (Gdk.EventKey event) {

--- a/plugins/word-completion/plugin.vala
+++ b/plugins/word-completion/plugin.vala
@@ -18,7 +18,7 @@
  *
  */
 
-public class Scratch.Plugins.Completion : Peas.ExtensionBase, Peas.Activatable {
+public class Scratch.Plugins.Completion : PluginBase {
     public Object object { owned get; construct; }
 
     private List<Gtk.SourceView> text_view_list = new List<Gtk.SourceView> ();
@@ -27,7 +27,7 @@ public class Scratch.Plugins.Completion : Peas.ExtensionBase, Peas.Activatable {
     public Scratch.Services.Document current_document {get; private set;}
 
     private MainWindow main_window;
-    private Scratch.Services.Interface plugins;
+    private Scratch.Plugins.Interface plugins;
     private bool completion_in_progress = false;
 
     private const uint [] ACTIVATE_KEYS = {
@@ -44,7 +44,7 @@ public class Scratch.Plugins.Completion : Peas.ExtensionBase, Peas.Activatable {
     private uint timeout_id = 0;
 
     public void activate () {
-        plugins = (Scratch.Services.Interface) object;
+        // plugins = (Scratch.Services.Interface) object;
         parser = new Euclide.Completion.Parser ();
         plugins.hook_window.connect ((w) => {
             this.main_window = w;
@@ -53,7 +53,7 @@ public class Scratch.Plugins.Completion : Peas.ExtensionBase, Peas.Activatable {
         plugins.hook_document.connect (on_new_source_view);
     }
 
-    public void deactivate () {
+    public override void deactivate () {
         text_view_list.@foreach (cleanup);
     }
 
@@ -182,9 +182,13 @@ public class Scratch.Plugins.Completion : Peas.ExtensionBase, Peas.Activatable {
     }
 }
 
-[ModuleInit]
-public void peas_register_types (GLib.TypeModule module) {
-    var objmodule = module as Peas.ObjectModule;
-    objmodule.register_extension_type (typeof (Peas.Activatable),
-                                       typeof (Scratch.Plugins.Completion));
+public Scratch.Plugins.PluginBase module_init (Scratch.Plugins.PluginInfo info) {
+    return new Scratch.Plugins.Completion (info);
 }
+
+// [ModuleInit]
+// public void peas_register_types (GLib.TypeModule module) {
+//     var objmodule = module as Peas.ObjectModule;
+//     objmodule.register_extension_type (typeof (Peas.Activatable),
+//                                        typeof (Scratch.Plugins.Completion));
+// }

--- a/plugins/word-completion/plugin.vala
+++ b/plugins/word-completion/plugin.vala
@@ -42,11 +42,11 @@ public class Scratch.Plugins.Completion : Scratch.Plugins.PluginBase {
     private const uint REFRESH_SHORTCUT = Gdk.Key.bar; //"|" in combination with <Ctrl> will cause refresh
 
     private uint timeout_id = 0;
-    
+
     public Completion (PluginInfo info, Interface iface) {
         base (info, iface);
     }
-    
+
     public override void activate () {
         // plugins = (Scratch.Services.Interface) object;
         parser = new Euclide.Completion.Parser ();

--- a/plugins/word-completion/plugin.vala
+++ b/plugins/word-completion/plugin.vala
@@ -20,15 +20,12 @@
  */
 
 public class Scratch.Plugins.Completion : Scratch.Plugins.PluginBase {
-    public Object object { owned get; construct; }
-
     private List<Gtk.SourceView> text_view_list = new List<Gtk.SourceView> ();
     public Euclide.Completion.Parser parser {get; private set;}
     public Gtk.SourceView? current_view {get; private set;}
     public Scratch.Services.Document current_document {get; private set;}
 
     private MainWindow main_window;
-    private Scratch.Plugins.Interface plugins;
     private bool completion_in_progress = false;
 
     private const uint [] ACTIVATE_KEYS = {
@@ -48,8 +45,7 @@ public class Scratch.Plugins.Completion : Scratch.Plugins.PluginBase {
         base (info, iface);
     }
 
-    public override void activate () {
-        // plugins = (Scratch.Services.Interface) object;
+    protected override void activate_internal () {
         parser = new Euclide.Completion.Parser ();
         plugins.hook_window.connect ((w) => {
             this.main_window = w;
@@ -58,7 +54,7 @@ public class Scratch.Plugins.Completion : Scratch.Plugins.PluginBase {
         plugins.hook_document.connect (on_new_source_view);
     }
 
-    public override void deactivate () {
+    protected override void deactivate_internal () {
         text_view_list.@foreach (cleanup);
     }
 

--- a/plugins/word-completion/plugin.vala
+++ b/plugins/word-completion/plugin.vala
@@ -58,8 +58,8 @@ public class Scratch.Plugins.Completion : Scratch.Plugins.PluginBase {
 
     protected override void deactivate_internal () {
         text_view_list.@foreach (cleanup);
-        this.disconnect (window_hook_handler);
-        this.disconnect (doc_hook_handler);
+        iface.disconnect (window_hook_handler);
+        iface.disconnect (doc_hook_handler);
     }
 
     public void on_new_source_view (Scratch.Services.Document doc) {

--- a/plugins/word-completion/plugin.vala
+++ b/plugins/word-completion/plugin.vala
@@ -45,17 +45,24 @@ public class Scratch.Plugins.Completion : Scratch.Plugins.PluginBase {
         base (info, iface);
     }
 
+    ulong window_hook_handler = 0;
+    ulong doc_hook_handler = 0;
     protected override void activate_internal () {
+        if (window_hook_handler > 0) {
+            return;
+        }
         parser = new Euclide.Completion.Parser ();
-        plugins.hook_window.connect ((w) => {
+        window_hook_handler = iface.hook_window.connect ((w) => {
             this.main_window = w;
         });
 
-        plugins.hook_document.connect (on_new_source_view);
+        doc_hook_handler = iface.hook_document.connect (on_new_source_view);
     }
 
     protected override void deactivate_internal () {
         text_view_list.@foreach (cleanup);
+        this.disconnect (window_hook_handler);
+        this.disconnect (doc_hook_handler);
     }
 
     public void on_new_source_view (Scratch.Services.Document doc) {

--- a/plugins/word-completion/plugin.vala
+++ b/plugins/word-completion/plugin.vala
@@ -1,5 +1,6 @@
 /*
- * Copyright (c) 2011 Lucas Baudin <xapantu@gmail.com>
+ * Copyright (C) 2024 elementary, Inc. <https://elementary.io>
+ *               2011 Lucas Baudin <xapantu@gmail.com>
  *
  * This is a free software; you can redistribute it and/or
  * modify it under the terms of the GNU General Public License as
@@ -188,11 +189,3 @@ public Scratch.Plugins.PluginBase module_init (
 ) {
     return new Scratch.Plugins.Completion (info, iface);
 }
-
-
-// [ModuleInit]
-// public void peas_register_types (GLib.TypeModule module) {
-//     var objmodule = module as Peas.ObjectModule;
-//     objmodule.register_extension_type (typeof (Peas.Activatable),
-//                                        typeof (Scratch.Plugins.Completion));
-// }

--- a/plugins/word-completion/plugin.vala
+++ b/plugins/word-completion/plugin.vala
@@ -18,7 +18,7 @@
  *
  */
 
-public class Scratch.Plugins.Completion : PluginBase {
+public class Scratch.Plugins.Completion : Scratch.Plugins.PluginBase {
     public Object object { owned get; construct; }
 
     private List<Gtk.SourceView> text_view_list = new List<Gtk.SourceView> ();
@@ -42,8 +42,12 @@ public class Scratch.Plugins.Completion : PluginBase {
     private const uint REFRESH_SHORTCUT = Gdk.Key.bar; //"|" in combination with <Ctrl> will cause refresh
 
     private uint timeout_id = 0;
-
-    public void activate () {
+    
+    public Completion (PluginInfo info, Interface iface) {
+        base (info, iface);
+    }
+    
+    public override void activate () {
         // plugins = (Scratch.Services.Interface) object;
         parser = new Euclide.Completion.Parser ();
         plugins.hook_window.connect ((w) => {
@@ -55,10 +59,6 @@ public class Scratch.Plugins.Completion : PluginBase {
 
     public override void deactivate () {
         text_view_list.@foreach (cleanup);
-    }
-
-    public void update_state () {
-
     }
 
     public void on_new_source_view (Scratch.Services.Document doc) {
@@ -182,9 +182,13 @@ public class Scratch.Plugins.Completion : PluginBase {
     }
 }
 
-public Scratch.Plugins.PluginBase module_init (Scratch.Plugins.PluginInfo info) {
-    return new Scratch.Plugins.Completion (info);
+public Scratch.Plugins.PluginBase module_init (
+    Scratch.Plugins.PluginInfo info,
+    Scratch.Plugins.Interface iface
+) {
+    return new Scratch.Plugins.Completion (info, iface);
 }
+
 
 // [ModuleInit]
 // public void peas_register_types (GLib.TypeModule module) {

--- a/plugins/word-completion/plugin.vala
+++ b/plugins/word-completion/plugin.vala
@@ -48,9 +48,6 @@ public class Scratch.Plugins.Completion : Scratch.Plugins.PluginBase {
     ulong window_hook_handler = 0;
     ulong doc_hook_handler = 0;
     protected override void activate_internal () {
-        if (window_hook_handler > 0) {
-            return;
-        }
         parser = new Euclide.Completion.Parser ();
         window_hook_handler = iface.hook_window.connect ((w) => {
             this.main_window = w;

--- a/src/Dialogs/PreferencesDialog.vala
+++ b/src/Dialogs/PreferencesDialog.vala
@@ -160,6 +160,11 @@ public class Scratch.Dialogs.Preferences : Granite.Dialog {
         close_button.clicked.connect (() => {
             destroy ();
         });
+        
+        // Always start with Behaviour page
+        realize.connect (() => {
+            stack.visible_child_name = "behavior";
+        });
     }
 
     private class SettingSwitch : Gtk.Grid {

--- a/src/Dialogs/PreferencesDialog.vala
+++ b/src/Dialogs/PreferencesDialog.vala
@@ -160,7 +160,7 @@ public class Scratch.Dialogs.Preferences : Granite.Dialog {
         close_button.clicked.connect (() => {
             destroy ();
         });
-        
+
         // Always start with Behaviour page
         realize.connect (() => {
             stack.visible_child_name = "behavior";

--- a/src/Dialogs/PreferencesDialog.vala
+++ b/src/Dialogs/PreferencesDialog.vala
@@ -146,7 +146,7 @@ public class Scratch.Dialogs.Preferences : Granite.Dialog {
 
         plugins.hook_preferences_dialog (this);
 
-        if (Peas.Engine.get_default ().get_plugin_list ().length () > 0) {
+        if (plugins.get_n_plugins () > 0) {
             var pbox = plugins.get_view ();
             pbox.vexpand = true;
 

--- a/src/Dialogs/PreferencesDialog.vala
+++ b/src/Dialogs/PreferencesDialog.vala
@@ -8,9 +8,9 @@
  */
 
 public class Scratch.Dialogs.Preferences : Granite.Dialog {
-    public Services.PluginsManager plugins { get; construct; }
+    public Scratch.Services.PluginsManager plugins { get; construct; }
 
-    public Preferences (Gtk.Window? parent, Services.PluginsManager plugins) {
+    public Preferences (Gtk.Window? parent, Scratch.Services.PluginsManager plugins) {
         Object (
             title: _("Preferences"),
             transient_for: parent,

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -573,6 +573,7 @@ namespace Scratch {
                 };
 
                 plugins.extension_added.connect (() => {
+                    warning ("hook func");
                     hook_func ();
                 });
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -281,6 +281,7 @@ namespace Scratch {
 
             clipboard = Gtk.Clipboard.get_for_display (get_display (), Gdk.SELECTION_CLIPBOARD);
 
+            warning ("creating new plugin manager");
             plugins = new Scratch.Services.PluginsManager (this);
 
             key_controller = new Gtk.EventControllerKey (this) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -281,7 +281,6 @@ namespace Scratch {
 
             clipboard = Gtk.Clipboard.get_for_display (get_display (), Gdk.SELECTION_CLIPBOARD);
 
-            warning ("creating new plugin manager");
             plugins = new Scratch.Services.PluginsManager (this);
 
             key_controller = new Gtk.EventControllerKey (this) {

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -573,7 +573,6 @@ namespace Scratch {
                 };
 
                 plugins.extension_added.connect (() => {
-                    warning ("hook func");
                     hook_func ();
                 });
 

--- a/src/Services/PluginManager.vala
+++ b/src/Services/PluginManager.vala
@@ -21,15 +21,28 @@
 // namespace Scratch.Plugins {
 public abstract class Scratch.Plugins.PluginBase : GLib.Object {
     public PluginInfo plugin_info { get; construct; }
-    public Interface plugin_iface { get; construct; }
-    public abstract void activate ();
-    public abstract void deactivate ();
-    public virtual void update_state () {}
+    public Interface plugins { get; construct; }
+    public bool is_active { get; set; }
+    public void activate () {
+    warning ("plugin base activate");
+        is_active = true;
+        activate_internal ();
+    }
+    
 
+    public void deactivate () {
+        is_active = false;
+        deactivate_internal ();
+    }
+    
+    protected abstract void activate_internal ();
+    protected virtual void deactivate_internal () {} // Not implemented by some plugins
+    public virtual void update_state () {} // Not currently used
+    
     protected PluginBase (PluginInfo info, Interface iface) {
         Object (
             plugin_info: info,
-            plugin_iface: iface
+            plugins: iface
         );
     }
 }
@@ -39,7 +52,6 @@ public struct Scratch.Plugins.PluginInfo {
     string module_name;
     string description;
     string icon_name;
-    bool is_active;
 }
 
 public class Scratch.Plugins.Interface : GLib.Object {
@@ -320,7 +332,7 @@ public class Scratch.Services.PluginsManager : GLib.Object {
         var content = new Gtk.Box (HORIZONTAL, 6);
         var checkbox = new Gtk.CheckButton () {
             valign = Gtk.Align.CENTER,
-            active = info.is_active,
+            active = plugin.is_active,
             margin_start = 6
         };
 

--- a/src/Services/PluginManager.vala
+++ b/src/Services/PluginManager.vala
@@ -18,11 +18,24 @@
   END LICENSE
 ***/
 
-namespace Scratch.Services {
-    public class Interface : GLib.Object {
+// namespace Scratch.Plugins {
+    public abstract class Scratch.Plugins.PluginBase : GLib.Object {
+        public PluginInfo plugin_info { get; construct; }
+        public Interface plugin_iface { get; construct; }
+        public abstract void activate ();
+        public abstract void deactivate ();
+        // public abstract PluginBase module_init (PluginInfo plugin_info);
+        public virtual void update_state () {}
+    }
 
-        public PluginsManager manager;
+    public struct Scratch.Plugins.PluginInfo {
+        string name;
+        string description;
+        string icon_name;
+    }
 
+    public class Scratch.Plugins.Interface : GLib.Object {
+        public Scratch.Services.PluginsManager manager;
         // Signals
         public signal void hook_window (Scratch.MainWindow window);
         public signal void hook_share_menu (GLib.MenuModel menu);
@@ -33,31 +46,31 @@ namespace Scratch.Services {
 
         public Scratch.TemplateManager template_manager { private set; get; }
 
-        public Interface (PluginsManager manager) {
+        public Interface (Scratch.Services.PluginsManager manager) {
             this.manager = manager;
 
             template_manager = new Scratch.TemplateManager ();
         }
 
-        public Document open_file (File file) {
-            var doc = new Document (manager.window.actions, file);
+        public Scratch.Services.Document open_file (File file) {
+            var doc = new Scratch.Services.Document (manager.window.actions, file);
             manager.window.open_document (doc);
             return doc;
         }
 
-        public void close_document (Document doc) {
+        public void close_document (Scratch.Services.Document doc) {
             manager.window.close_document (doc);
         }
     }
 
 
-    public class PluginsManager : GLib.Object {
-        Peas.Engine engine;
-        Peas.ExtensionSet exts;
+    public class Scratch.Services.PluginsManager : GLib.Object {
+        // Peas.Engine engine;
+        // Peas.ExtensionSet exts;
 
-        string settings_field;
+        // string settings_field;
 
-        public Interface plugin_iface { private set; public get; }
+        public Scratch.Plugins.Interface plugin_iface { private set; public get; }
 
         public weak MainWindow window;
 
@@ -70,71 +83,241 @@ namespace Scratch.Services {
         public signal void hook_folder_item_change (File file, File? other_file, FileMonitorEvent event_type);
 
         public signal void extension_added (Peas.PluginInfo info);
-        public signal void extension_removed (Peas.PluginInfo info);
+        // public signal void extension_removed (Peas.PluginInfo info);
+
+        /* FROM FILES PLUGIN SYSTEM */
+
+        delegate Scratch.Plugins.PluginBase ModuleInitFunc (Scratch.Plugins.PluginInfo info);
+        Gee.HashMap<string,Scratch.Plugins.PluginBase> plugin_hash;
+        Gee.List<string> names;
+        // bool in_available = false;
+        bool update_queued = false;
+        // bool is_admin = false;
+        public Gee.List<Gtk.Widget> menuitem_references { get; private set; }
 
         public PluginsManager (MainWindow window) {
             this.window = window;
 
-            settings_field = "plugins-enabled";
+            // settings_field = "plugins-enabled";
 
-            plugin_iface = new Interface (this);
+            plugin_iface = new Scratch.Plugins.Interface (this);
 
-            /* Let's init the engine */
-            engine = Peas.Engine.get_default ();
-            engine.enable_loader ("python");
-            engine.add_search_path (Constants.PLUGINDIR, null);
-            Scratch.settings.bind ("plugins-enabled", engine, "loaded-plugins", SettingsBindFlags.DEFAULT);
+            /* From Files PluginManager construct */
+            plugin_hash = new Gee.HashMap<string, Scratch.Plugins.PluginBase> ();
+            names = new Gee.ArrayList<string> ();
+            menuitem_references = new Gee.LinkedList<Gtk.Widget> ();
 
-            /* Our extension set */
-            exts = new Peas.ExtensionSet (engine, typeof (Peas.Activatable), "object", plugin_iface, null);
+            // Code has only one plugin directory.
 
-            exts.extension_added.connect ((info, ext) => {
-                ((Peas.Activatable)ext).activate ();
-                extension_added (info);
-            });
+            // if (!is_admin) {
+            // plugin_dirs += Path.build_filename (plugin_dir, "core");
+            // plugin_dirs += plugin_dir;
 
-            exts.extension_removed.connect ((info, ext) => {
-                ((Peas.Activatable)ext).deactivate ();
-                extension_removed (info);
-            });
+            // load_plugins ();
+            load_modules_from_dir (Constants.PLUGINDIR);
 
-            exts.foreach (on_extension_foreach);
+            // No need to monitor plugin directory - we do not allow third party plugins
 
-            // Connect managers signals to interface's signals
-            this.hook_window.connect ((w) => {
-                plugin_iface.hook_window (w);
-            });
+            // /* Monitor plugin dirs */
+            // foreach (string path in plugin_dirs) {
+            //     set_directory_monitor (path);
+            // }
+            // }
 
-            this.hook_share_menu.connect ((m) => {
-                plugin_iface.hook_share_menu (m);
-            });
+            // /* Let's init the engine */
+            // engine = Peas.Engine.get_default ();
+            // engine.enable_loader ("python");
+            // engine.add_search_path (Constants.PLUGINDIR, null);
+            // Scratch.settings.bind ("plugins-enabled", engine, "loaded-plugins", SettingsBindFlags.DEFAULT);
 
-            this.hook_toolbar.connect ((t) => {
-                plugin_iface.hook_toolbar (t);
-            });
+            // /* Our extension set */
+            // exts = new Peas.ExtensionSet (engine, typeof (Peas.Activatable), "object", plugin_iface, null);
 
-            this.hook_document.connect ((d) => {
-                plugin_iface.hook_document (d);
-            });
+            // exts.extension_added.connect ((info, ext) => {
+            //     ((Peas.Activatable)ext).activate ();
+            //     extension_added (info);
+            // });
 
-            this.hook_preferences_dialog.connect ((d) => {
-                plugin_iface.hook_preferences_dialog (d);
-            });
+            // exts.extension_removed.connect ((info, ext) => {
+            //     ((Peas.Activatable)ext).deactivate ();
+            //     extension_removed (info);
+            // });
 
-            this.hook_folder_item_change.connect ((source, dest, event) => {
-                plugin_iface.hook_folder_item_change (source, dest, event);
-            });
+            // exts.foreach (on_extension_foreach);
+
+            // // Connect managers signals to interface's signals
+            // this.hook_window.connect ((w) => {
+            //     plugin_iface.hook_window (w);
+            // });
+
+            // this.hook_share_menu.connect ((m) => {
+            //     plugin_iface.hook_share_menu (m);
+            // });
+
+            // this.hook_toolbar.connect ((t) => {
+            //     plugin_iface.hook_toolbar (t);
+            // });
+
+            // this.hook_document.connect ((d) => {
+            //     plugin_iface.hook_document (d);
+            // });
+
+            // this.hook_preferences_dialog.connect ((d) => {
+            //     plugin_iface.hook_preferences_dialog (d);
+            // });
+
+            // this.hook_folder_item_change.connect ((source, dest, event) => {
+            //     plugin_iface.hook_folder_item_change (source, dest, event);
+            // });
         }
 
-        void on_extension_foreach (Peas.ExtensionSet set, Peas.PluginInfo info, Peas.Extension extension) {
-            ((Peas.Activatable)extension).activate ();
-        }
+        // void on_extension_foreach (Peas.ExtensionSet set, Peas.PluginInfo info, Peas.Extension extension) {
+        //     ((Peas.Activatable)extension).activate ();
+        // }
 
         public Gtk.Widget get_view () {
-            var view = new PeasGtk.PluginManager (engine);
-            var bottom_box = view.get_children ().nth_data (1);
-            bottom_box.no_show_all = true;
-            return view;
+            // var view = new PeasGtk.PluginManager (engine);
+            // var bottom_box = view.get_children ().nth_data (1);
+            // bottom_box.no_show_all = true;
+            return new Gtk.Frame (null);
+        }
+
+
+
+    // [Version (deprecated = true, deprecated_since = "0.2", replacement = "Files.PluginManager.menuitem_references")]
+    // public GLib.List<Gtk.Widget>? menus; /* this doesn't manage GObject references properly */
+
+
+    // private void load_plugins () {
+    //     in_available = true;
+    //     load_modules_from_dir (plugin_dirs[1]);
+    //     in_available = false;
+    // }
+
+    // private void set_directory_monitor (string path) {
+    //     var dir = GLib.File.new_for_path (path);
+
+    //     try {
+    //         var monitor = dir.monitor_directory (FileMonitorFlags.NONE, null);
+    //         monitor.changed.connect (on_plugin_directory_change);
+    //         monitor.ref (); /* keep alive */
+    //     } catch (IOError e) {
+    //         critical ("Could not setup monitor for '%s': %s", dir.get_path (), e.message);
+    //     }
+    // }
+
+    // private async void on_plugin_directory_change (GLib.File file, GLib.File? other_file, FileMonitorEvent event) {
+    //     if (update_queued) {
+    //         return;
+    //     }
+
+    //     update_queued = true;
+
+    //     Idle.add_full (Priority.LOW, on_plugin_directory_change.callback);
+    //     yield;
+
+    //     load_plugins ();
+    //     update_queued = false;
+    // }
+
+        private void load_modules_from_dir (string path) {
+            string attributes = FileAttribute.STANDARD_NAME + "," +
+                                FileAttribute.STANDARD_TYPE;
+
+            FileInfo info;
+            FileEnumerator enumerator;
+
+            try {
+                var dir = GLib.File.new_for_path (path);
+
+                enumerator = dir.enumerate_children
+                                            (attributes,
+                                             FileQueryInfoFlags.NONE);
+
+                info = enumerator.next_file ();
+
+                while (info != null) {
+                    string file_name = info.get_name ();
+                    var plugin_file = dir.get_child_for_display_name (file_name);
+
+                    if (file_name.has_suffix (".plug")) {
+                        load_plugin_keyfile (plugin_file.get_path (), path);
+                    }
+
+                    info = enumerator.next_file ();
+                }
+            } catch (Error error) {
+                critical ("Error listing contents of folder '%s': %s", path, error.message);
+            }
+        }
+
+        private bool load_module (string file_path, Scratch.Plugins.PluginInfo plugin_info) {
+            if (plugin_hash.has_key (file_path)) {
+                debug ("plugin for %s already loaded. Not adding again", file_path);
+                return false;
+            }
+
+            debug ("Loading plugin for %s", file_path);
+
+            Module module = Module.open (file_path, ModuleFlags.LOCAL);
+            if (module == null) {
+                warning ("Failed to load module from path '%s': %s",
+                         file_path,
+                         Module.error ());
+                return false;
+            }
+
+            void* function;
+
+            if (!module.symbol ("module_init", out function)) {
+                warning ("Failed to find entry point function '%s' in '%s': %s",
+                         "module_init",
+                         file_path,
+                         Module.error ());
+                return false;
+            }
+
+            unowned ModuleInitFunc module_init = (ModuleInitFunc) function;
+            assert (module_init != null);
+
+            //TODO Reconsider for Code plugins
+            /* We don't want our modules to ever unload */
+            module.make_resident ();
+            Scratch.Plugins.PluginBase plug = module_init (plugin_info);
+            
+            debug ("Loaded module source: '%s'", module.name ());
+
+            if (plug != null) {
+                plugin_hash.set (file_path, plug);
+                return true;
+            }
+
+            // if (in_available) {
+            //     names.add (name);
+            // }
+            return false;
+        }
+
+        // Load the .plugin file from each plugin folder
+        private void load_plugin_keyfile (string path, string parent) {
+            var keyfile = new KeyFile ();
+            var plugin_info = Scratch.Plugins.PluginInfo ();
+            try {
+                keyfile.load_from_file (path, KeyFileFlags.NONE);
+                plugin_info.name = keyfile.get_string ("Plugin", "Name");
+                plugin_info.description = keyfile.get_string ("Plugin", "Description");
+                plugin_info.icon_name = keyfile.get_string ("Plugin", "Icon");
+                // Should we expose the author(s)?
+                var plug_path = Path.build_filename (parent, keyfile.get_string ("Plugin", "File"));
+                load_module (plug_path, plugin_info);
+            } catch (Error e) {
+                warning ("Couldn't open the keyfile '%s': %s", path, e.message);
+
+            }
+        }
+
+        public Gee.List<string> get_available_plugins () {
+            return names;
         }
     }
-}
+// }

--- a/src/Services/PluginManager.vala
+++ b/src/Services/PluginManager.vala
@@ -106,7 +106,6 @@ public class Scratch.Services.PluginsManager : GLib.Object {
 
     Gee.HashMap<string,Scratch.Plugins.PluginBase> plugin_hash; // all plugins
     public Gee.HashSet<string> active_plugin_set; //active plugin names
-    public Gee.List<Gtk.Widget> menuitem_references { get; private set; }
 
     public PluginsManager (MainWindow window) {
         this.window = window;
@@ -115,7 +114,6 @@ public class Scratch.Services.PluginsManager : GLib.Object {
         /* From Files PluginManager construct */
         plugin_hash = new Gee.HashMap<string, Scratch.Plugins.PluginBase> ();
         active_plugin_set = new Gee.HashSet<string> ();
-        menuitem_references = new Gee.LinkedList<Gtk.Widget> ();
         // Code has only one plugin directory.
         load_modules_from_dir (Constants.PLUGINDIR);
 

--- a/src/Services/PluginManager.vala
+++ b/src/Services/PluginManager.vala
@@ -143,9 +143,9 @@ public class Scratch.Services.PluginsManager : GLib.Object {
         });
 
         // Activate plugins according to setting
-        foreach (var plugin_name in settings.get_strv (ACTIVE_PLUGINS_KEY)) {
-            if (plugin_hash.has_key (plugin_name)) {
-                var plugin = plugin_hash.@get (plugin_name);
+        foreach (var module_name in settings.get_strv (ACTIVE_PLUGINS_KEY)) {
+            if (plugin_hash.has_key (module_name)) {
+                var plugin = plugin_hash.@get (module_name);
                 activate_plugin (plugin);
             }
         }
@@ -155,7 +155,7 @@ public class Scratch.Services.PluginsManager : GLib.Object {
         var info = plugin.plugin_info;
         if (!plugin.is_active) {
             plugin.activate ();
-            active_plugin_set.add (info.name);
+            active_plugin_set.add (info.module_name);
             extension_added (); // Signals Window to run initial hook function
         }
     }
@@ -164,7 +164,7 @@ public class Scratch.Services.PluginsManager : GLib.Object {
         var info = plugin.plugin_info;
         if (plugin.is_active) {
             plugin.deactivate ();
-            active_plugin_set.remove (info.name);
+            active_plugin_set.remove (info.module_name);
             extension_removed (info);
         }
     }
@@ -172,12 +172,12 @@ public class Scratch.Services.PluginsManager : GLib.Object {
     private void update_active_plugin_settings () {
         // For some reason using active_plugin_set.to_array () does not work (crashes)
         // So construct the string array ourselves
-        string[] plugins = {};
-        foreach (string s in active_plugin_set) {
-            plugins += s;
+        string[] module_names = {};
+        foreach (string module in active_plugin_set) {
+            module_names += module;
         }
 
-        settings.set_strv (ACTIVE_PLUGINS_KEY, plugins);
+        settings.set_strv (ACTIVE_PLUGINS_KEY, module_names);
     }
 
     private void load_modules_from_dir (string path) {
@@ -212,7 +212,7 @@ public class Scratch.Services.PluginsManager : GLib.Object {
     }
 
     private bool load_module (File dir, Scratch.Plugins.PluginInfo info) {
-        if (plugin_hash.has_key (info.name)) {
+        if (plugin_hash.has_key (info.module_name)) {
             warning ("plugin for %s already loaded. Not adding again", info.name);
             return false;
         }
@@ -257,7 +257,7 @@ public class Scratch.Services.PluginsManager : GLib.Object {
         debug ("Loaded module source: '%s'", module.name ());
 
         if (plug != null) {
-            plugin_hash.set (info.name, plug);
+            plugin_hash.set (info.module_name, plug);
             plug.is_active = false;
             // Plugins only become active via initial settings or preferences dialog
             return true;

--- a/src/Services/PluginManager.vala
+++ b/src/Services/PluginManager.vala
@@ -76,19 +76,8 @@ public class Scratch.Plugins.Interface : GLib.Object {
 
     public Interface (Scratch.Services.PluginsManager manager) {
         this.manager = manager;
-
         template_manager = new Scratch.TemplateManager ();
     }
-
-    // public Scratch.Services.Document open_file (File file) {
-    //     var doc = new Scratch.Services.Document (manager.window.actions, file);
-    //     manager.window.open_document (doc);
-    //     return doc;
-    // }
-
-    // public void close_document (Scratch.Services.Document doc) {
-    //     manager.window.close_document (doc);
-    // }
 }
 
 delegate Scratch.Plugins.PluginBase ModuleInitFunc (
@@ -380,7 +369,6 @@ public class Scratch.Services.PluginsManager : GLib.Object {
     }
 
     public uint get_n_plugins () {
-        warning ("get n plugins  %u", plugin_hash.size);
         return plugin_hash.size;
     }
 }

--- a/src/Services/PluginManager.vala
+++ b/src/Services/PluginManager.vala
@@ -19,305 +19,318 @@
 ***/
 
 // namespace Scratch.Plugins {
-    public abstract class Scratch.Plugins.PluginBase : GLib.Object {
-        public PluginInfo plugin_info { get; construct; }
-        public Interface plugin_iface { get; construct; }
-        public abstract void activate ();
-        public abstract void deactivate ();
-        // public abstract PluginBase module_init (PluginInfo plugin_info);
-        public virtual void update_state () {}
+public abstract class Scratch.Plugins.PluginBase : GLib.Object {
+    public PluginInfo plugin_info { get; construct; }
+    public Interface plugin_iface { get; construct; }
+    public abstract void activate ();
+    public abstract void deactivate ();
+    // public abstract PluginBase module_init (PluginInfo plugin_info);
+    public virtual void update_state () {}
+
+    protected PluginBase (PluginInfo info, Interface iface) {
+        Object (
+            plugin_info: info,
+            plugin_iface: iface
+        );
+    }
+}
+
+public struct Scratch.Plugins.PluginInfo {
+    string name;
+    string module_name;
+    string description;
+    string icon_name;
+}
+
+public class Scratch.Plugins.Interface : GLib.Object {
+    public Scratch.Services.PluginsManager manager;
+    // Signals
+    public signal void hook_window (Scratch.MainWindow window);
+    public signal void hook_share_menu (GLib.MenuModel menu);
+    public signal void hook_toolbar (Scratch.HeaderBar toolbar);
+    public signal void hook_document (Scratch.Services.Document doc);
+    public signal void hook_preferences_dialog (Scratch.Dialogs.Preferences dialog);
+    public signal void hook_folder_item_change (File file, File? other_file, FileMonitorEvent event_type);
+
+    public Scratch.TemplateManager template_manager { private set; get; }
+
+    public Interface (Scratch.Services.PluginsManager manager) {
+        this.manager = manager;
+
+        template_manager = new Scratch.TemplateManager ();
     }
 
-    public struct Scratch.Plugins.PluginInfo {
-        string name;
-        string description;
-        string icon_name;
+    public Scratch.Services.Document open_file (File file) {
+        var doc = new Scratch.Services.Document (manager.window.actions, file);
+        manager.window.open_document (doc);
+        return doc;
     }
 
-    public class Scratch.Plugins.Interface : GLib.Object {
-        public Scratch.Services.PluginsManager manager;
-        // Signals
-        public signal void hook_window (Scratch.MainWindow window);
-        public signal void hook_share_menu (GLib.MenuModel menu);
-        public signal void hook_toolbar (Scratch.HeaderBar toolbar);
-        public signal void hook_document (Scratch.Services.Document doc);
-        public signal void hook_preferences_dialog (Scratch.Dialogs.Preferences dialog);
-        public signal void hook_folder_item_change (File file, File? other_file, FileMonitorEvent event_type);
-
-        public Scratch.TemplateManager template_manager { private set; get; }
-
-        public Interface (Scratch.Services.PluginsManager manager) {
-            this.manager = manager;
-
-            template_manager = new Scratch.TemplateManager ();
-        }
-
-        public Scratch.Services.Document open_file (File file) {
-            var doc = new Scratch.Services.Document (manager.window.actions, file);
-            manager.window.open_document (doc);
-            return doc;
-        }
-
-        public void close_document (Scratch.Services.Document doc) {
-            manager.window.close_document (doc);
-        }
+    public void close_document (Scratch.Services.Document doc) {
+        manager.window.close_document (doc);
     }
+}
+
+delegate Scratch.Plugins.PluginBase ModuleInitFunc (
+    Scratch.Plugins.PluginInfo info, 
+    Scratch.Plugins.Interface iface
+);
+    
+public class Scratch.Services.PluginsManager : GLib.Object {
+    // Peas.Engine engine;
+    // Peas.ExtensionSet exts;
+
+    // string settings_field;
+
+    public Scratch.Plugins.Interface plugin_iface { private set; public get; }
+
+    public weak MainWindow window;
+
+    // Signals
+    public signal void hook_window (Scratch.MainWindow window);
+    public signal void hook_share_menu (GLib.MenuModel menu);
+    public signal void hook_toolbar (Scratch.HeaderBar toolbar);
+    public signal void hook_document (Scratch.Services.Document doc);
+    public signal void hook_preferences_dialog (Scratch.Dialogs.Preferences dialog);
+    public signal void hook_folder_item_change (File file, File? other_file, FileMonitorEvent event_type);
+
+    public signal void extension_added (Scratch.Plugins.PluginInfo info);
+    public signal void extension_removed (Scratch.Plugins.PluginInfo info);
+
+    /* FROM FILES PLUGIN SYSTEM */
 
 
-    public class Scratch.Services.PluginsManager : GLib.Object {
-        // Peas.Engine engine;
-        // Peas.ExtensionSet exts;
+    Gee.HashMap<string,Scratch.Plugins.PluginBase> plugin_hash;
+    Gee.List<string> names;
+    // bool in_available = false;
+    bool update_queued = false;
+    // bool is_admin = false;
+    public Gee.List<Gtk.Widget> menuitem_references { get; private set; }
 
-        // string settings_field;
+    public PluginsManager (MainWindow window) {
+        this.window = window;
 
-        public Scratch.Plugins.Interface plugin_iface { private set; public get; }
+        // settings_field = "plugins-enabled";
 
-        public weak MainWindow window;
+        plugin_iface = new Scratch.Plugins.Interface (this);
 
-        // Signals
-        public signal void hook_window (Scratch.MainWindow window);
-        public signal void hook_share_menu (GLib.MenuModel menu);
-        public signal void hook_toolbar (Scratch.HeaderBar toolbar);
-        public signal void hook_document (Scratch.Services.Document doc);
-        public signal void hook_preferences_dialog (Scratch.Dialogs.Preferences dialog);
-        public signal void hook_folder_item_change (File file, File? other_file, FileMonitorEvent event_type);
+        /* From Files PluginManager construct */
+        plugin_hash = new Gee.HashMap<string, Scratch.Plugins.PluginBase> ();
+        names = new Gee.ArrayList<string> ();
+        menuitem_references = new Gee.LinkedList<Gtk.Widget> ();
 
-        public signal void extension_added (Peas.PluginInfo info);
-        // public signal void extension_removed (Peas.PluginInfo info);
+        // Code has only one plugin directory.
 
-        /* FROM FILES PLUGIN SYSTEM */
+        // if (!is_admin) {
+        // plugin_dirs += Path.build_filename (plugin_dir, "core");
+        // plugin_dirs += plugin_dir;
 
-        delegate Scratch.Plugins.PluginBase ModuleInitFunc (Scratch.Plugins.PluginInfo info);
-        Gee.HashMap<string,Scratch.Plugins.PluginBase> plugin_hash;
-        Gee.List<string> names;
-        // bool in_available = false;
-        bool update_queued = false;
-        // bool is_admin = false;
-        public Gee.List<Gtk.Widget> menuitem_references { get; private set; }
+        // load_plugins ();
+        load_modules_from_dir (Constants.PLUGINDIR);
 
-        public PluginsManager (MainWindow window) {
-            this.window = window;
+        // No need to monitor plugin directory - we do not allow third party plugins
 
-            // settings_field = "plugins-enabled";
-
-            plugin_iface = new Scratch.Plugins.Interface (this);
-
-            /* From Files PluginManager construct */
-            plugin_hash = new Gee.HashMap<string, Scratch.Plugins.PluginBase> ();
-            names = new Gee.ArrayList<string> ();
-            menuitem_references = new Gee.LinkedList<Gtk.Widget> ();
-
-            // Code has only one plugin directory.
-
-            // if (!is_admin) {
-            // plugin_dirs += Path.build_filename (plugin_dir, "core");
-            // plugin_dirs += plugin_dir;
-
-            // load_plugins ();
-            load_modules_from_dir (Constants.PLUGINDIR);
-
-            // No need to monitor plugin directory - we do not allow third party plugins
-
-            // /* Monitor plugin dirs */
-            // foreach (string path in plugin_dirs) {
-            //     set_directory_monitor (path);
-            // }
-            // }
-
-            // /* Let's init the engine */
-            // engine = Peas.Engine.get_default ();
-            // engine.enable_loader ("python");
-            // engine.add_search_path (Constants.PLUGINDIR, null);
-            // Scratch.settings.bind ("plugins-enabled", engine, "loaded-plugins", SettingsBindFlags.DEFAULT);
-
-            // /* Our extension set */
-            // exts = new Peas.ExtensionSet (engine, typeof (Peas.Activatable), "object", plugin_iface, null);
-
-            // exts.extension_added.connect ((info, ext) => {
-            //     ((Peas.Activatable)ext).activate ();
-            //     extension_added (info);
-            // });
-
-            // exts.extension_removed.connect ((info, ext) => {
-            //     ((Peas.Activatable)ext).deactivate ();
-            //     extension_removed (info);
-            // });
-
-            // exts.foreach (on_extension_foreach);
-
-            // // Connect managers signals to interface's signals
-            // this.hook_window.connect ((w) => {
-            //     plugin_iface.hook_window (w);
-            // });
-
-            // this.hook_share_menu.connect ((m) => {
-            //     plugin_iface.hook_share_menu (m);
-            // });
-
-            // this.hook_toolbar.connect ((t) => {
-            //     plugin_iface.hook_toolbar (t);
-            // });
-
-            // this.hook_document.connect ((d) => {
-            //     plugin_iface.hook_document (d);
-            // });
-
-            // this.hook_preferences_dialog.connect ((d) => {
-            //     plugin_iface.hook_preferences_dialog (d);
-            // });
-
-            // this.hook_folder_item_change.connect ((source, dest, event) => {
-            //     plugin_iface.hook_folder_item_change (source, dest, event);
-            // });
-        }
-
-        // void on_extension_foreach (Peas.ExtensionSet set, Peas.PluginInfo info, Peas.Extension extension) {
-        //     ((Peas.Activatable)extension).activate ();
+        // /* Monitor plugin dirs */
+        // foreach (string path in plugin_dirs) {
+        //     set_directory_monitor (path);
+        // }
         // }
 
-        public Gtk.Widget get_view () {
-            // var view = new PeasGtk.PluginManager (engine);
-            // var bottom_box = view.get_children ().nth_data (1);
-            // bottom_box.no_show_all = true;
-            return new Gtk.Frame (null);
-        }
+        // /* Let's init the engine */
+        // engine = Peas.Engine.get_default ();
+        // engine.enable_loader ("python");
+        // engine.add_search_path (Constants.PLUGINDIR, null);
+        // Scratch.settings.bind ("plugins-enabled", engine, "loaded-plugins", SettingsBindFlags.DEFAULT);
 
+        // /* Our extension set */
+        // exts = new Peas.ExtensionSet (engine, typeof (Peas.Activatable), "object", plugin_iface, null);
 
+        // exts.extension_added.connect ((info, ext) => {
+        //     ((Peas.Activatable)ext).activate ();
+        //     extension_added (info);
+        // });
 
-    // [Version (deprecated = true, deprecated_since = "0.2", replacement = "Files.PluginManager.menuitem_references")]
-    // public GLib.List<Gtk.Widget>? menus; /* this doesn't manage GObject references properly */
+        // exts.extension_removed.connect ((info, ext) => {
+        //     ((Peas.Activatable)ext).deactivate ();
+        //     extension_removed (info);
+        // });
 
+        // exts.foreach (on_extension_foreach);
 
-    // private void load_plugins () {
-    //     in_available = true;
-    //     load_modules_from_dir (plugin_dirs[1]);
-    //     in_available = false;
+        // // Connect managers signals to interface's signals
+        // this.hook_window.connect ((w) => {
+        //     plugin_iface.hook_window (w);
+        // });
+
+        // this.hook_share_menu.connect ((m) => {
+        //     plugin_iface.hook_share_menu (m);
+        // });
+
+        // this.hook_toolbar.connect ((t) => {
+        //     plugin_iface.hook_toolbar (t);
+        // });
+
+        // this.hook_document.connect ((d) => {
+        //     plugin_iface.hook_document (d);
+        // });
+
+        // this.hook_preferences_dialog.connect ((d) => {
+        //     plugin_iface.hook_preferences_dialog (d);
+        // });
+
+        // this.hook_folder_item_change.connect ((source, dest, event) => {
+        //     plugin_iface.hook_folder_item_change (source, dest, event);
+        // });
+    }
+
+    // void on_extension_foreach (Peas.ExtensionSet set, Peas.PluginInfo info, Peas.Extension extension) {
+    //     ((Peas.Activatable)extension).activate ();
     // }
 
-    // private void set_directory_monitor (string path) {
-    //     var dir = GLib.File.new_for_path (path);
+    public Gtk.Widget get_view () {
+        // var view = new PeasGtk.PluginManager (engine);
+        // var bottom_box = view.get_children ().nth_data (1);
+        // bottom_box.no_show_all = true;
+        return new Gtk.Frame (null);
+    }
 
-    //     try {
-    //         var monitor = dir.monitor_directory (FileMonitorFlags.NONE, null);
-    //         monitor.changed.connect (on_plugin_directory_change);
-    //         monitor.ref (); /* keep alive */
-    //     } catch (IOError e) {
-    //         critical ("Could not setup monitor for '%s': %s", dir.get_path (), e.message);
-    //     }
-    // }
 
-    // private async void on_plugin_directory_change (GLib.File file, GLib.File? other_file, FileMonitorEvent event) {
-    //     if (update_queued) {
-    //         return;
-    //     }
 
-    //     update_queued = true;
+// [Version (deprecated = true, deprecated_since = "0.2", replacement = "Files.PluginManager.menuitem_references")]
+// public GLib.List<Gtk.Widget>? menus; /* this doesn't manage GObject references properly */
 
-    //     Idle.add_full (Priority.LOW, on_plugin_directory_change.callback);
-    //     yield;
 
-    //     load_plugins ();
-    //     update_queued = false;
-    // }
+// private void load_plugins () {
+//     in_available = true;
+//     load_modules_from_dir (plugin_dirs[1]);
+//     in_available = false;
+// }
 
-        private void load_modules_from_dir (string path) {
-            string attributes = FileAttribute.STANDARD_NAME + "," +
-                                FileAttribute.STANDARD_TYPE;
+// private void set_directory_monitor (string path) {
+//     var dir = GLib.File.new_for_path (path);
 
-            FileInfo info;
-            FileEnumerator enumerator;
+//     try {
+//         var monitor = dir.monitor_directory (FileMonitorFlags.NONE, null);
+//         monitor.changed.connect (on_plugin_directory_change);
+//         monitor.ref (); /* keep alive */
+//     } catch (IOError e) {
+//         critical ("Could not setup monitor for '%s': %s", dir.get_path (), e.message);
+//     }
+// }
 
-            try {
-                var dir = GLib.File.new_for_path (path);
+// private async void on_plugin_directory_change (GLib.File file, GLib.File? other_file, FileMonitorEvent event) {
+//     if (update_queued) {
+//         return;
+//     }
 
-                enumerator = dir.enumerate_children
-                                            (attributes,
-                                             FileQueryInfoFlags.NONE);
+//     update_queued = true;
+
+//     Idle.add_full (Priority.LOW, on_plugin_directory_change.callback);
+//     yield;
+
+//     load_plugins ();
+//     update_queued = false;
+// }
+
+    private void load_modules_from_dir (string path) {
+        string attributes = FileAttribute.STANDARD_NAME + "," +
+                            FileAttribute.STANDARD_TYPE;
+
+        FileInfo info;
+        FileEnumerator enumerator;
+
+        try {
+            var dir = GLib.File.new_for_path (path);
+
+            enumerator = dir.enumerate_children
+                                        (attributes,
+                                         FileQueryInfoFlags.NONE);
+
+            info = enumerator.next_file ();
+
+            while (info != null) {
+                string file_name = info.get_name ();
+                var plugin_file = dir.get_child_for_display_name (file_name);
+
+                if (file_name.has_suffix (".plug")) {
+                    load_plugin_keyfile (plugin_file.get_path (), path);
+                }
 
                 info = enumerator.next_file ();
-
-                while (info != null) {
-                    string file_name = info.get_name ();
-                    var plugin_file = dir.get_child_for_display_name (file_name);
-
-                    if (file_name.has_suffix (".plug")) {
-                        load_plugin_keyfile (plugin_file.get_path (), path);
-                    }
-
-                    info = enumerator.next_file ();
-                }
-            } catch (Error error) {
-                critical ("Error listing contents of folder '%s': %s", path, error.message);
             }
+        } catch (Error error) {
+            critical ("Error listing contents of folder '%s': %s", path, error.message);
         }
+    }
 
-        private bool load_module (string file_path, Scratch.Plugins.PluginInfo plugin_info) {
-            if (plugin_hash.has_key (file_path)) {
-                debug ("plugin for %s already loaded. Not adding again", file_path);
-                return false;
-            }
-
-            debug ("Loading plugin for %s", file_path);
-
-            Module module = Module.open (file_path, ModuleFlags.LOCAL);
-            if (module == null) {
-                warning ("Failed to load module from path '%s': %s",
-                         file_path,
-                         Module.error ());
-                return false;
-            }
-
-            void* function;
-
-            if (!module.symbol ("module_init", out function)) {
-                warning ("Failed to find entry point function '%s' in '%s': %s",
-                         "module_init",
-                         file_path,
-                         Module.error ());
-                return false;
-            }
-
-            unowned ModuleInitFunc module_init = (ModuleInitFunc) function;
-            assert (module_init != null);
-
-            //TODO Reconsider for Code plugins
-            /* We don't want our modules to ever unload */
-            module.make_resident ();
-            Scratch.Plugins.PluginBase plug = module_init (plugin_info);
-            
-            debug ("Loaded module source: '%s'", module.name ());
-
-            if (plug != null) {
-                plugin_hash.set (file_path, plug);
-                return true;
-            }
-
-            // if (in_available) {
-            //     names.add (name);
-            // }
+    private bool load_module (string file_path, Scratch.Plugins.PluginInfo plugin_info) {
+        if (plugin_hash.has_key (file_path)) {
+            debug ("plugin for %s already loaded. Not adding again", file_path);
             return false;
         }
 
-        // Load the .plugin file from each plugin folder
-        private void load_plugin_keyfile (string path, string parent) {
-            var keyfile = new KeyFile ();
-            var plugin_info = Scratch.Plugins.PluginInfo ();
-            try {
-                keyfile.load_from_file (path, KeyFileFlags.NONE);
-                plugin_info.name = keyfile.get_string ("Plugin", "Name");
-                plugin_info.description = keyfile.get_string ("Plugin", "Description");
-                plugin_info.icon_name = keyfile.get_string ("Plugin", "Icon");
-                // Should we expose the author(s)?
-                var plug_path = Path.build_filename (parent, keyfile.get_string ("Plugin", "File"));
-                load_module (plug_path, plugin_info);
-            } catch (Error e) {
-                warning ("Couldn't open the keyfile '%s': %s", path, e.message);
+        debug ("Loading plugin for %s", file_path);
 
-            }
+        Module module = Module.open (file_path, ModuleFlags.LOCAL);
+        if (module == null) {
+            warning ("Failed to load module from path '%s': %s",
+                     file_path,
+                     Module.error ());
+            return false;
         }
 
-        public Gee.List<string> get_available_plugins () {
-            return names;
+        void* function;
+
+        if (!module.symbol ("module_init", out function)) {
+            warning ("Failed to find entry point function '%s' in '%s': %s",
+                     "module_init",
+                     file_path,
+                     Module.error ());
+            return false;
+        }
+
+        unowned ModuleInitFunc module_init = (ModuleInitFunc) function;
+        assert (module_init != null);
+
+        //TODO Reconsider for Code plugins
+        /* We don't want our modules to ever unload */
+        module.make_resident ();
+        Scratch.Plugins.PluginBase plug = module_init (plugin_info, plugin_iface);
+        
+        debug ("Loaded module source: '%s'", module.name ());
+
+        if (plug != null) {
+            plugin_hash.set (file_path, plug);
+            return true;
+        }
+
+        // if (in_available) {
+        //     names.add (name);
+        // }
+        return false;
+    }
+
+    // Load the .plugin file from each plugin folder
+    private void load_plugin_keyfile (string path, string parent) {
+        var keyfile = new KeyFile ();
+        var plugin_info = Scratch.Plugins.PluginInfo ();
+        try {
+            keyfile.load_from_file (path, KeyFileFlags.NONE);
+            plugin_info.name = keyfile.get_string ("Plugin", "Name");
+            plugin_info.module_name = keyfile.get_string ("Plugin", "Module");
+            plugin_info.description = keyfile.get_string ("Plugin", "Description");
+            plugin_info.icon_name = keyfile.get_string ("Plugin", "Icon");
+            // Should we expose the author(s)?
+            var plug_path = Path.build_filename (parent, keyfile.get_string ("Plugin", "File"));
+            load_module (plug_path, plugin_info);
+        } catch (Error e) {
+            warning ("Couldn't open the keyfile '%s': %s", path, e.message);
+
         }
     }
+
+    public Gee.List<string> get_available_plugins () {
+        return names;
+    }
+}
 // }

--- a/src/Services/PluginManager.vala
+++ b/src/Services/PluginManager.vala
@@ -51,7 +51,7 @@ public abstract class Scratch.Plugins.PluginBase : GLib.Object {
     }
 
     protected abstract void activate_internal ();
-    protected virtual void deactivate_internal () {} // Not implemented by some plugins
+    protected abstract void deactivate_internal ();
     public virtual void update_state () {} // Not currently used
 }
 

--- a/src/Services/PluginManager.vala
+++ b/src/Services/PluginManager.vala
@@ -28,17 +28,17 @@ public abstract class Scratch.Plugins.PluginBase : GLib.Object {
         is_active = true;
         activate_internal ();
     }
-    
+
 
     public void deactivate () {
         is_active = false;
         deactivate_internal ();
     }
-    
+
     protected abstract void activate_internal ();
     protected virtual void deactivate_internal () {} // Not implemented by some plugins
     public virtual void update_state () {} // Not currently used
-    
+
     protected PluginBase (PluginInfo info, Interface iface) {
         Object (
             plugin_info: info,
@@ -158,9 +158,8 @@ public class Scratch.Services.PluginsManager : GLib.Object {
 
     private void activate_plugin (Scratch.Plugins.PluginBase plugin) {
         var info = plugin.plugin_info;
-        if (!info.is_active) {
+        if (!plugin.is_active) {
             plugin.activate ();
-            info.is_active = true;
             active_plugin_set.add (info.name);
             extension_added (); // Signals Window to run initial hook function
             update_active_plugin_settings ();
@@ -169,9 +168,8 @@ public class Scratch.Services.PluginsManager : GLib.Object {
 
     private void deactivate_plugin (Scratch.Plugins.PluginBase plugin) {
         var info = plugin.plugin_info;
-        if (info.is_active) {
+        if (plugin.is_active) {
             plugin.deactivate ();
-            info.is_active = false;
             active_plugin_set.remove (info.name);
             extension_removed (info);
             update_active_plugin_settings ();
@@ -262,7 +260,7 @@ public class Scratch.Services.PluginsManager : GLib.Object {
 
         if (plug != null) {
             plugin_hash.set (info.name, plug);
-            info.is_active = false;
+            plug.is_active = false;
             // Plugins only become active via initial settings or preferences dialog
             return true;
         } else {

--- a/src/Services/PluginManager.vala
+++ b/src/Services/PluginManager.vala
@@ -32,12 +32,20 @@ public abstract class Scratch.Plugins.PluginBase : GLib.Object {
     }
 
     public void activate () {
+        if (is_active) {
+            return;
+        }
+
         is_active = true;
         activate_internal ();
     }
 
 
     public void deactivate () {
+        if (!is_active) {
+            return;
+        }
+
         is_active = false;
         deactivate_internal ();
     }

--- a/src/Services/PluginManager.vala
+++ b/src/Services/PluginManager.vala
@@ -21,10 +21,17 @@
 // namespace Scratch.Plugins {
 public abstract class Scratch.Plugins.PluginBase : GLib.Object {
     public PluginInfo plugin_info { get; construct; }
-    public Interface plugins { get; construct; }
+    public Interface iface { get; construct; }
     public bool is_active { get; set; }
+
+    protected PluginBase (PluginInfo info, Interface iface) {
+        Object (
+            plugin_info: info,
+            iface: iface
+        );
+    }
+
     public void activate () {
-    warning ("plugin base activate");
         is_active = true;
         activate_internal ();
     }
@@ -38,13 +45,6 @@ public abstract class Scratch.Plugins.PluginBase : GLib.Object {
     protected abstract void activate_internal ();
     protected virtual void deactivate_internal () {} // Not implemented by some plugins
     public virtual void update_state () {} // Not currently used
-
-    protected PluginBase (PluginInfo info, Interface iface) {
-        Object (
-            plugin_info: info,
-            plugins: iface
-        );
-    }
 }
 
 public struct Scratch.Plugins.PluginInfo {
@@ -72,15 +72,15 @@ public class Scratch.Plugins.Interface : GLib.Object {
         template_manager = new Scratch.TemplateManager ();
     }
 
-    public Scratch.Services.Document open_file (File file) {
-        var doc = new Scratch.Services.Document (manager.window.actions, file);
-        manager.window.open_document (doc);
-        return doc;
-    }
+    // public Scratch.Services.Document open_file (File file) {
+    //     var doc = new Scratch.Services.Document (manager.window.actions, file);
+    //     manager.window.open_document (doc);
+    //     return doc;
+    // }
 
-    public void close_document (Scratch.Services.Document doc) {
-        manager.window.close_document (doc);
-    }
+    // public void close_document (Scratch.Services.Document doc) {
+    //     manager.window.close_document (doc);
+    // }
 }
 
 delegate Scratch.Plugins.PluginBase ModuleInitFunc (
@@ -158,6 +158,7 @@ public class Scratch.Services.PluginsManager : GLib.Object {
 
     private void activate_plugin (Scratch.Plugins.PluginBase plugin) {
         var info = plugin.plugin_info;
+        warning ("activate plugin %s, active %s", info.name, plugin.is_active.to_string ());
         if (!plugin.is_active) {
             plugin.activate ();
             active_plugin_set.add (info.name);

--- a/src/Services/PluginManager.vala
+++ b/src/Services/PluginManager.vala
@@ -275,7 +275,7 @@ public class Scratch.Services.PluginsManager : GLib.Object {
                 plugin_info.icon_name = "extension";
             }
             // Should we expose the author(s)?
-            load_module (plugin_file.get_parent (), plugin_info);
+            load_module (keyfile_file.get_parent (), plugin_info);
         } catch (Error e) {
             warning ("Couldn't open the keyfile '%s': %s", keyfile_file.get_path (), e.message);
 

--- a/src/codecore.deps
+++ b/src/codecore.deps
@@ -2,7 +2,7 @@ codecore
 gtksourceview-4
 gee-0.8
 gobject-2.0
+gmodule-2.0
 gio-2.0
 gtk+-3.0
 granite
-libpeas-1.0


### PR DESCRIPTION
Fix #1498

 - Use `gmodule-2.0` directly
 - Implement only the necessary parts of `libpeas` in `PluginManager` (based on the equivalent class in `io.elementary.files`)
 - Update code style a bit, add some headers
 - Move some code into PastbinDialog.vala where it is actually used
 
NOTE:  All the plugins are loaded and made resident in the same way as Files. They are activated and deactivated (but not unloaded) as required.  When deactivated the interface signals are disconnected.

Need to check all plugins still work as expected.