### PR TITLE
Move "New Branch" action to "New" submenu

### DIFF
--- a/src/FolderManager/FolderItem.vala
+++ b/src/FolderManager/FolderItem.vala
@@ -140,7 +140,7 @@ namespace Scratch.FolderManager {
             }
 
             var direct_actions_section = new GLib.Menu ();
-            direct_actions_section.append_item (create_submenu_for_new ());
+            direct_actions_section.append_item (create_new_menuitem ());
             direct_actions_section.append_item (rename_menu_item);
             direct_actions_section.append_item (delete_item);
 
@@ -179,7 +179,7 @@ namespace Scratch.FolderManager {
             return open_in_menu_item;
         }
 
-        protected GLib.MenuItem create_submenu_for_new () {
+        protected virtual GLib.Menu create_submenu_for_new () {
             var new_folder_item = new GLib.MenuItem (
                 _("Folder"),
                 GLib.Action.print_detailed_name (
@@ -200,9 +200,12 @@ namespace Scratch.FolderManager {
             new_menu.append_item (new_folder_item);
             new_menu.append_item (new_file_item);
 
-            var new_item = new GLib.MenuItem.submenu (_("New"), new_menu);
-            new_item.set_submenu (new_menu);
+            return new_menu;
 
+        }
+
+        protected GLib.MenuItem create_new_menuitem () {
+            var new_item = new GLib.MenuItem.submenu (_("New"), create_submenu_for_new ());
             return new_item;
         }
 

--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -158,7 +158,7 @@ namespace Scratch.FolderManager {
             external_actions_section.append_item (create_submenu_for_open_in (file_type));
 
             var folder_actions_section = new GLib.Menu ();
-            folder_actions_section.append_item (create_submenu_for_new ());
+            folder_actions_section.append_item (create_new_menuitem ());
             if (monitored_repo != null) {
                 folder_actions_section.append_item (create_submenu_for_branch ());
             }
@@ -301,6 +301,35 @@ namespace Scratch.FolderManager {
             return menu;
         }
 
+        protected override GLib.Menu create_submenu_for_new () {
+            var new_menu = base.create_submenu_for_new ();
+            if (monitored_repo != null) {
+                var new_branch_item = new GLib.MenuItem (
+                    _("New Branch…"),
+                    GLib.Action.print_detailed_name (
+                        MainWindow.ACTION_PREFIX + MainWindow.ACTION_NEW_BRANCH,
+                        file.path
+                    )
+                );
+
+                new_branch_item.set_attribute_value (
+                    "accel",
+                    Utils.get_accel_for_action (
+                        GLib.Action.print_detailed_name (
+                            MainWindow.ACTION_PREFIX + MainWindow.ACTION_NEW_BRANCH,
+                            ""
+                        )
+                    )
+                );
+
+                var new_branch_section = new GLib.Menu ();
+                new_branch_section.append_item (new_branch_item);
+                new_menu.append_section (null, new_branch_section);
+            }
+
+            return new_menu;
+        }
+
         protected GLib.MenuItem create_submenu_for_branch () {
             // Ensures that action for relevant project is being used
             view.actions.add_action (change_branch_action);
@@ -316,33 +345,7 @@ namespace Scratch.FolderManager {
                 );
             }
 
-
-            var new_branch_item = new GLib.MenuItem (
-                _("New Branch…"),
-                GLib.Action.print_detailed_name (
-                    MainWindow.ACTION_PREFIX + MainWindow.ACTION_NEW_BRANCH,
-                    file.path
-                )
-            );
-
-            new_branch_item.set_attribute_value (
-                "accel",
-                Utils.get_accel_for_action (
-                    GLib.Action.print_detailed_name (
-                        MainWindow.ACTION_PREFIX + MainWindow.ACTION_NEW_BRANCH,
-                        ""
-                    )
-                )
-            );
-
-            GLib.Menu bottom_section = new GLib.Menu ();
-            bottom_section.append_item (new_branch_item);
-
-            var menu = new GLib.Menu ();
-            menu.append_section (null, branch_selection_menu);
-            menu.append_section (null, bottom_section);
-
-            var menu_item = new GLib.MenuItem.submenu (_("Branch"), menu);
+            var menu_item = new GLib.MenuItem.submenu (_("Branch"), branch_selection_menu);
             return menu_item;
         }
 


### PR DESCRIPTION
This was motivated by having a project with a large number of local branches resulting in the the New Branch item scrolling off the bottom of the menu and also by #1516 which added another section to the branch menu.

Needs design input.