### PR TITLE
Confirm overwriting uncommitted changes on branch change

### DIFF
--- a/po/POTFILES
+++ b/po/POTFILES
@@ -5,6 +5,7 @@ src/Dialogs/GlobalSearchDialog.vala
 src/Dialogs/NewBranchDialog.vala
 src/Dialogs/PreferencesDialog.vala
 src/Dialogs/RestoreConfirmationDialog.vala
+src/Dialogs/OverwriteUncommittedConfirmationDialog.vala
 src/FolderManager/File.vala
 src/FolderManager/FileItem.vala
 src/FolderManager/FileView.vala

--- a/src/Dialogs/OverwriteUncommittedConfirmationDialog.vala
+++ b/src/Dialogs/OverwriteUncommittedConfirmationDialog.vala
@@ -1,0 +1,43 @@
+/*
+* Copyright 2025 elementary, Inc. (https://elementary.io)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU Lesser General Public
+* License version 3 as published by the Free Software Foundation.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU Lesser General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*/
+
+public class Scratch.Dialogs.OverwriteUncommittedConfirmationDialog : Granite.MessageDialog {
+
+    public string branch_name { get; construct; }
+    public OverwriteUncommittedConfirmationDialog (Gtk.Window parent, string new_branch_name) {
+        Object (
+            buttons: Gtk.ButtonsType.NONE,
+            transient_for: parent,
+            branch_name: new_branch_name
+        );
+    }
+
+    construct {
+        modal = true;
+        image_icon = new ThemedIcon ("dialog-stop");
+
+        primary_text = _("There are uncommitted changes in the current branch");
+        ///TRANSLATORS '%s' is a placeholder for the name of the branch to be checked out
+        secondary_text = _("Uncommitted changes will be permanently lost if <b>'%s'</b> is checked out now.\n\n<i>It is recommended that uncommitted changes are stashed, committed, or reverted before proceeding </i>").printf (branch_name);
+
+        var proceed_button = (Gtk.Button) add_button (_("Checkout and Overwrite"), Gtk.ResponseType.ACCEPT);
+        proceed_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
+        var cancel_button = add_button (_("Do not Checkout"), Gtk.ResponseType.REJECT);
+        cancel_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
+    }
+}

--- a/src/Dialogs/OverwriteUncommittedConfirmationDialog.vala
+++ b/src/Dialogs/OverwriteUncommittedConfirmationDialog.vala
@@ -19,12 +19,18 @@
 public class Scratch.Dialogs.OverwriteUncommittedConfirmationDialog : Granite.MessageDialog {
 
     public string branch_name { get; construct; }
-    public OverwriteUncommittedConfirmationDialog (Gtk.Window parent, string new_branch_name) {
+    public OverwriteUncommittedConfirmationDialog (
+        Gtk.Window parent,
+        string new_branch_name,
+        string details
+    ) {
         Object (
             buttons: Gtk.ButtonsType.NONE,
             transient_for: parent,
             branch_name: new_branch_name
         );
+
+        show_error_details (details);
     }
 
     construct {

--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -349,7 +349,7 @@ namespace Scratch.FolderManager {
         private void handle_change_branch_action (GLib.Variant? parameter) {
             var branch_name = parameter.get_string ();
             try {
-                monitored_repo.change_branch (branch_name);
+                monitored_repo.change_local_branch (branch_name);
             } catch (GLib.Error e) {
                 warning ("Failed to change branch to %s. %s", branch_name, e.message);
             }

--- a/src/meson.build
+++ b/src/meson.build
@@ -20,6 +20,7 @@ code_files = files(
     'Utils.vala',
     'Dialogs/PreferencesDialog.vala',
     'Dialogs/RestoreConfirmationDialog.vala',
+    'Dialogs/OverwriteUncommittedConfirmationDialog.vala',
     'Dialogs/GlobalSearchDialog.vala',
     'Dialogs/NewBranchDialog.vala',
     'FolderManager/File.vala',


### PR DESCRIPTION
Fixes #1521 

Split out from #1516 

 - Before checking out a branch determine whether there are any uncommitted changes in the current branch
 - Obtain the diff in text form
 - Show a confirmation dialog with the diff text as error details


![Screenshot from 2025-01-29 12-21-22](https://github.com/user-attachments/assets/da0359f2-a88a-4c8f-be1e-764d23f7f4e5)

