### PR TITLE
Rework word completion: Split out PrefixNode class

### DIFF
--- a/plugins/word-completion/meson.build
+++ b/plugins/word-completion/meson.build
@@ -2,6 +2,7 @@ module_name = 'word-completion'
 
 module_files = [
     'prefix-tree.vala',
+    'prefix-tree-node.vala',
     'completion-provider.vala',
     'engine.vala',
     'plugin.vala'

--- a/plugins/word-completion/prefix-tree-node.vala
+++ b/plugins/word-completion/prefix-tree-node.vala
@@ -21,7 +21,13 @@
 
 public class Scratch.Plugins.PrefixNode : Object{
     public GLib.List<PrefixNode> children;
-    public unichar value { get; set; }
+    public unichar value { get; construct; }
+
+    public PrefixNode (unichar c = '\0') {
+        Object (
+            value: c
+        );
+    }
 
     construct {
         children = new List<PrefixNode> ();

--- a/plugins/word-completion/prefix-tree-node.vala
+++ b/plugins/word-completion/prefix-tree-node.vala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2024 elementary, Inc. <https://elementary.io>
+ *           2011 Lucas Baudin <xapantu@gmail.com>
+ *  *
+ * This is a free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License as
+ * published by the Free Software Foundation; either version 2 of the
+ * License, or (at your option) any later version.
+ *
+ * This is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public
+ * License along with this program; see the file COPYING.  If not,
+ * write to the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA.
+ *
+ */
+
+public class Scratch.Plugins.PrefixNode : Object{
+    public GLib.List<PrefixNode> children;
+    public unichar value { get; set; }
+
+    construct {
+        children = new List<PrefixNode> ();
+    }
+}

--- a/plugins/word-completion/prefix-tree-node.vala
+++ b/plugins/word-completion/prefix-tree-node.vala
@@ -19,7 +19,7 @@
  *
  */
 
-public class Scratch.Plugins.PrefixNode : Object{
+public class Scratch.Plugins.PrefixNode : Object {
     public GLib.List<PrefixNode> children;
     public unichar value { get; construct; }
 

--- a/plugins/word-completion/prefix-tree.vala
+++ b/plugins/word-completion/prefix-tree.vala
@@ -1,14 +1,5 @@
 
 namespace Scratch.Plugins {
-    private class PrefixNode : Object {
-        public GLib.List<PrefixNode> children;
-        public unichar value { get; set; }
-
-        construct {
-            children = new List<PrefixNode> ();
-        }
-    }
-
     public class PrefixTree : Object {
         private PrefixNode root;
 

--- a/plugins/word-completion/prefix-tree.vala
+++ b/plugins/word-completion/prefix-tree.vala
@@ -8,9 +8,7 @@ namespace Scratch.Plugins {
         }
 
         public void clear () {
-            root = new PrefixNode () {
-                value = '\0'
-            };
+            root = new PrefixNode ();
         }
 
         public void insert (string word) {
@@ -38,9 +36,7 @@ namespace Scratch.Plugins {
                 }
             }
 
-            var new_child = new PrefixNode () {
-                value = curr
-            };
+            var new_child = new PrefixNode (curr);
             node.children.insert_sorted (new_child, (c1, c2) => {
                 if (c1.value > c2.value) {
                     return 1;


### PR DESCRIPTION
Towards #1491 

Little value by itself but in order to implement dynamic updating of the tree when text is deleted it is necessary to make this class more complex (e.g. keeps track of number of occurrences of each word) and a lot of code in PrefixTree can be moved here.