### PR TITLE
Rework word completion: Do not reparse whole document unnecessarily

### DIFF
--- a/plugins/word-completion/prefix-tree.vala
+++ b/plugins/word-completion/prefix-tree.vala
@@ -11,6 +11,7 @@ namespace Scratch.Plugins {
 
     public class PrefixTree : Object {
         private PrefixNode root;
+        public bool completed { get; set; default = false; }
 
         construct {
             clear ();


### PR DESCRIPTION
This should only be merged *after* the code that implements dynamic updating of the word list (by detecting insertions and deletions rather than key presses) else the word list may get out of date more often (e.g. if doc changed externally).

The document is fully parsed once on loading, editing the document does not usually require a full reparse (unless forced).