### PR TITLE
Fix closing an empty temporary document

### DIFF
--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -158,6 +158,8 @@ namespace Scratch.Services {
             }
         }
 
+        public bool closing { get; private set; default = false; }
+
         public Gtk.Stack main_stack;
         public Scratch.Widgets.SourceView source_view;
         private Scratch.Services.SymbolOutline? outline = null;
@@ -181,7 +183,6 @@ namespace Scratch.Services {
         private ulong onchange_handler_id = 0; // It is used to not mark files as changed on load
         private bool loaded = false;
         private bool mounted = true; // Mount state of the file
-        private bool closing = false;
         private Mount mount;
         private Icon locked_icon;
 
@@ -470,6 +471,9 @@ namespace Scratch.Services {
 
         public async bool do_close (bool app_closing = false) {
             debug ("Closing \"%s\"", get_basename ());
+            if (closing) {
+                return true;
+            }
 
             if (!loaded) {
                 load_cancellable.cancel ();
@@ -488,7 +492,6 @@ namespace Scratch.Services {
 
                 // Ask whether to save changes
                 var parent_window = source_view.get_toplevel () as Gtk.Window;
-
                 var dialog = new Granite.MessageDialog (
                     _("Save changes to “%s” before closing?").printf (this.get_basename ()),
                     _("If you don't save, changes will be permanently lost."),
@@ -1155,6 +1158,9 @@ namespace Scratch.Services {
                 file.delete ();
                 return true;
             } catch (Error e) {
+                if (e is IOError.NOT_FOUND) {
+                    return true;
+                }
                 warning ("Cannot delete temporary file “%s”: %s", file.get_uri (), e.message);
             }
 

--- a/src/Widgets/DocumentView.vala
+++ b/src/Widgets/DocumentView.vala
@@ -122,6 +122,10 @@ public class Scratch.Widgets.DocumentView : Gtk.Box {
         // TabView tab events
         tab_view.close_page.connect ((tab) => {
             var doc = tab.child as Services.Document;
+            if (doc == null || doc.closing) {
+                return true; // doc.do_close () already called once
+            }
+
             if (doc == null) {
                 tab_view.close_page_finish (tab, true);
             } else {


### PR DESCRIPTION
Fixes #1536 

For empty temporary documents, async code intended to be called once for a closing document was being called twice. For obscure reasons this lead to the `n_pages` property of `Hdy.TabView` becoming different from the actual number of pages and hence the issue.

An existing private flag was made public and used to prevent the responsible code being called twice.
