### PR TITLE
OverwriteUncommittedConfirmationDialog: Correct icon name and buttons order

### DIFF
--- a/src/Dialogs/OverwriteUncommittedConfirmationDialog.vala
+++ b/src/Dialogs/OverwriteUncommittedConfirmationDialog.vala
@@ -35,15 +35,14 @@ public class Scratch.Dialogs.OverwriteUncommittedConfirmationDialog : Granite.Me
 
     construct {
         modal = true;
-        image_icon = new ThemedIcon ("dialog-stop");
+        image_icon = new ThemedIcon ("dialog-warning");
 
         primary_text = _("There are uncommitted changes in the current branch");
         ///TRANSLATORS '%s' is a placeholder for the name of the branch to be checked out
-        secondary_text = _("Uncommitted changes will be permanently lost if <b>'%s'</b> is checked out now.\n\n<i>It is recommended that uncommitted changes are stashed, committed, or reverted before proceeding </i>").printf (branch_name);
+        secondary_text = _("Uncommitted changes will be permanently lost if <b>'%s'</b> is checked out now.\n\n<i>It is recommended that uncommitted changes are stashed, committed, or reverted before proceeding.</i>").printf (branch_name);
 
+        var cancel_button = add_button (_("Do not Checkout"), Gtk.ResponseType.REJECT);
         var proceed_button = (Gtk.Button) add_button (_("Checkout and Overwrite"), Gtk.ResponseType.ACCEPT);
         proceed_button.get_style_context ().add_class (Gtk.STYLE_CLASS_DESTRUCTIVE_ACTION);
-        var cancel_button = add_button (_("Do not Checkout"), Gtk.ResponseType.REJECT);
-        cancel_button.get_style_context ().add_class (Gtk.STYLE_CLASS_SUGGESTED_ACTION);
     }
 }


### PR DESCRIPTION
- Replace dialog-stop icon name that actually does not exist
- Replace a trailing space with a period
- Follow the button order that we use in other dialogs

### After
![Screenshot From 2025-03-02 19-08-50](https://github.com/user-attachments/assets/97210511-1038-4e41-bfe0-fb63a904e807)

### Before
![Screenshot From 2025-03-02 19-09-11](https://github.com/user-attachments/assets/0b4efe62-323c-4a4e-b0d4-c6ee5f0c4de2)
