### PR TITLE
Use 'development-target' tag of docker image to build Gettext catalog updates

### DIFF
--- a/.github/workflows/merge.yml
+++ b/.github/workflows/merge.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     container:
-      image: ghcr.io/elementary/docker:next-unstable
+      image: ghcr.io/elementary/docker:development-target
 
     steps:
     - name: Install git


### PR DESCRIPTION
We are using an old container image to build gettext updates, it's now failing to build because the image contains a old version of GLib, so using 'development-target' image fixes the Gettext Catalogs build.