### PR TITLE
Allow network access from Flatpak

### DIFF
--- a/io.elementary.code.yml
+++ b/io.elementary.code.yml
@@ -8,6 +8,7 @@ finish-args:
   - '--filesystem=host'
 
   - '--share=ipc'
+  - '--share=network'
   - '--socket=fallback-x11'
   - '--socket=wayland'
 


### PR DESCRIPTION
A number of functions which require network access do not work in the Flatpak.

This PR allows e.g. git functions like checkout, push, pull to be used from the Code terminal within the Flatpak.