### PR TITLE
Jeremypw/vala symbols/improve tooltip

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -579,7 +579,6 @@ namespace Scratch {
             });
 
             document_view.realize.connect (() => {
-                document_view.update_outline_visible ();
                 update_find_actions ();
             });
 
@@ -694,6 +693,7 @@ namespace Scratch {
             }
 
             document_view.request_placeholder_if_empty ();
+            document_view.update_outline_visible ();
             restore_override = null;
             if (focused_file != null) {
                 folder_manager_view.expand_to_path (focused_file.get_path ());

--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -1226,27 +1226,30 @@ namespace Scratch.Services {
 
         public void show_outline (bool show) {
             if (show && outline == null) {
-               switch (mime_type) {
-                   case "text/x-vala":
+                switch (mime_type) {
+                    case "text/x-vala":
                        outline = new ValaSymbolOutline (this);
                        break;
-                   case "text/x-csrc":
-                   case "text/x-chdr":
-                   case "text/x-c++src":
-                   case "text/x-c++hdr":
+                    case "text/x-csrc":
+                    case "text/x-chdr":
+                    case "text/x-c++src":
+                    case "text/x-c++hdr":
                        outline = new CtagsSymbolOutline (this);
                        break;
-               }
+                }
 
-               if (outline != null) {
-                   outline_widget_pane.pack2 (outline.get_widget (), false, false);
-                   Idle.add (() => {
-                       set_outline_width (doc_view.outline_width);
-                       outline_widget_pane.notify["position"].connect (sync_outline_width);
-                       outline.parse_symbols ();
-                       return Source.REMOVE;
-                   });
-               }
+                if (outline != null) {
+                    outline_widget_pane.pack2 (outline.get_widget (), false, false);
+                    Idle.add (() => {
+                        set_outline_width (doc_view.outline_width);
+                        outline_widget_pane.notify["position"].connect (sync_outline_width);
+                        if (!tab.loading) {
+                            outline.parse_symbols ();
+                        } // else parsing will occur when tab finishes loading
+
+                        return Source.REMOVE;
+                    });
+                }
             } else if (!show && outline != null) {
                outline_widget_pane.notify["position"].disconnect (sync_outline_width);
                outline_widget_pane.get_child2 ().destroy ();

--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -1341,6 +1341,9 @@ namespace Scratch.Services {
         /* Block user editing while tab is loading */
         private void on_tab_loading_change () {
             source_view.sensitive = !tab.loading;
+            if (!tab.loading && outline != null) {
+                outline.parse_symbols ();
+            }
         }
     }
 }

--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -815,6 +815,26 @@ namespace Scratch.Services {
             return this.source_view.get_selected_text (replace_newline);
         }
 
+        public string get_slice (int start_line, int start_col, int end_line, int end_col) {
+            var text = source_view;
+            Gtk.TextIter iter;
+            text.buffer.get_iter_at_line (out iter, start_line - 1);
+            if (!iter.forward_chars (start_col - 1)) {
+                return "";
+            }
+
+            var start = iter;
+            text.buffer.get_iter_at_line (out iter, end_line - 1);
+
+            if (!iter.forward_to_line_end ()) {
+                return "";
+            }
+
+            var end = iter;
+            var slice = text.buffer.get_text (start, end, false);
+            return text.buffer.get_text (start, end, false);
+        }
+
         // Get language name
         public string get_language_name () {
             var source_buffer = (Gtk.SourceBuffer) source_view.buffer;

--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -306,7 +306,7 @@ namespace Scratch.Services {
 
         public void init_tab (Hdy.TabPage tab) {
             this.tab = tab;
-            notify["tab.loading"].connect (on_tab_loading_change);
+            tab.notify["loading"].connect (on_tab_loading_change);
 
             tab.title = title;
             tab.icon = icon;

--- a/src/SymbolPane/Vala/ValaSymbolItem.vala
+++ b/src/SymbolPane/Vala/ValaSymbolItem.vala
@@ -36,6 +36,68 @@ public class Scratch.Services.ValaSymbolItem : Code.Widgets.SourceList.Expandabl
         } else {
             name = symbol.name;
         }
+
+        if (symbol is Vala.Struct) {
+            icon = new ThemedIcon ("lang-struct");
+            symbol_type = SymbolType.STRUCT;
+        } else if (symbol is Vala.Class) {
+            if (((Vala.Class) symbol).is_abstract) {
+                icon = new ThemedIcon ("lang-class-abstract");
+            } else {
+                icon = new ThemedIcon ("lang-class");
+            }
+
+            symbol_type = SymbolType.CLASS;
+        } else if (symbol is Vala.Constant) {
+            icon = new ThemedIcon ("lang-constant");
+            symbol_type = SymbolType.CONSTANT;
+        } else if (symbol is Vala.Enum) {
+            icon = new ThemedIcon ("lang-enum");
+            symbol_type = SymbolType.ENUM;
+        } else if (symbol is Vala.Field) {
+            icon = new ThemedIcon ("lang-property");
+            symbol_type = SymbolType.PROPERTY;
+        } else if (symbol is Vala.Interface) {
+            icon = new ThemedIcon ("lang-interface");
+            symbol_type = SymbolType.INTERFACE;
+        } else if (symbol is Vala.Property) {
+            if (((Vala.Property) symbol).is_abstract) {
+                icon = new ThemedIcon ("lang-property-abstract");
+            } else if (((Vala.Property) symbol).is_virtual) {
+                icon = new ThemedIcon ("lang-property-virtual");
+            } else {
+                icon = new ThemedIcon ("lang-property");
+            }
+
+            symbol_type = SymbolType.PROPERTY;
+        } else if (symbol is Vala.Signal) {
+            icon = new ThemedIcon ("lang-signal");
+            symbol_type = SymbolType.SIGNAL;
+        } else if (symbol is Vala.CreationMethod) {
+            icon = new ThemedIcon ("lang-constructor");
+            symbol_type = SymbolType.CONSTRUCTOR;
+        } else if (symbol is Vala.Method) {
+            if (((Vala.Method) symbol).is_abstract) {
+                icon = new ThemedIcon ("lang-method-abstract");
+            } else if (((Vala.Method) symbol).is_virtual) {
+                icon = new ThemedIcon ("lang-method-virtual");
+            } else if (((Vala.Method) symbol).binding == Vala.MemberBinding.STATIC) {
+                icon = new ThemedIcon ("lang-method-static");
+            } else {
+                icon = new ThemedIcon ("lang-method");
+            }
+
+            symbol_type = SymbolType.METHOD;
+        } else if (symbol is Vala.Namespace) {
+            icon = new ThemedIcon ("lang-namespace");
+            symbol_type = SymbolType.NAMESPACE;
+        } else if (symbol is Vala.ErrorDomain) {
+            icon = new ThemedIcon ("lang-errordomain");
+        } else if (symbol is Vala.Delegate) {
+            icon = new ThemedIcon ("lang-delegate");
+        } else {
+            warning (symbol.type_name);
+        }
     }
 
     ~ValaSymbolItem () {

--- a/src/SymbolPane/Vala/ValaSymbolItem.vala
+++ b/src/SymbolPane/Vala/ValaSymbolItem.vala
@@ -19,9 +19,10 @@
 public class Scratch.Services.ValaSymbolItem : Code.Widgets.SourceList.ExpandableItem, Code.Widgets.SourceListSortable, Scratch.Services.SymbolItem {
     public Vala.Symbol symbol { get; construct; }
     public SymbolType symbol_type { get; set; default = SymbolType.OTHER; }
-    public ValaSymbolItem (Vala.Symbol symbol) {
+    public ValaSymbolItem (Vala.Symbol symbol, string _tooltip) {
         Object (
-            symbol: symbol
+            symbol: symbol,
+            tooltip: _tooltip
         );
     }
 

--- a/src/SymbolPane/Vala/ValaSymbolItem.vala
+++ b/src/SymbolPane/Vala/ValaSymbolItem.vala
@@ -17,16 +17,24 @@
  */
 
 public class Scratch.Services.ValaSymbolItem : Code.Widgets.SourceList.ExpandableItem, Code.Widgets.SourceListSortable, Scratch.Services.SymbolItem {
-    public Vala.Symbol symbol { get; set; }
+    public Vala.Symbol symbol { get; construct; }
     public SymbolType symbol_type { get; set; default = SymbolType.OTHER; }
     public ValaSymbolItem (Vala.Symbol symbol) {
-        this.symbol = symbol;
-        this.name = symbol.name;
+        Object (
+            symbol: symbol
+        );
+    }
+
+    construct {
         if (symbol is Vala.CreationMethod) {
-            if (symbol.name == ".new")
-                this.name = ((Vala.CreationMethod)symbol).class_name;
-            else
-                this.name = "%s.%s".printf (((Vala.CreationMethod)symbol).class_name, symbol.name);
+            var klass = ((Vala.CreationMethod)symbol).class_name;
+            if (symbol.name == ".new") {
+                name = klass;
+            } else {
+                name = "%s.%s".printf (klass, symbol.name);
+            }
+        } else {
+            name = symbol.name;
         }
     }
 

--- a/src/SymbolPane/Vala/ValaSymbolOutline.vala
+++ b/src/SymbolPane/Vala/ValaSymbolOutline.vala
@@ -166,6 +166,7 @@ public class Scratch.Services.ValaSymbolOutline : Scratch.Services.SymbolOutline
         symbols.remove_all (fields);
 
         var new_root = new Code.Widgets.SourceList.ExpandableItem (_("Symbols"));
+        new_root.tooltip = _("Vala symbols found in %s").printf (doc.file.get_basename ());
         foreach (var symbol in symbols) {
             if (cancellable.is_cancelled ())
                 break;
@@ -180,7 +181,12 @@ public class Scratch.Services.ValaSymbolOutline : Scratch.Services.SymbolOutline
         return new_root;
     }
 
-    private ValaSymbolItem construct_child (Vala.Symbol symbol, Code.Widgets.SourceList.ExpandableItem given_parent, GLib.Cancellable cancellable) {
+    private ValaSymbolItem construct_child (
+        Vala.Symbol symbol,
+        Code.Widgets.SourceList.ExpandableItem given_parent,
+        GLib.Cancellable cancellable
+    ) {
+
         Code.Widgets.SourceList.ExpandableItem parent;
         if (symbol.scope.parent_scope.owner.name == null)
             parent = given_parent;
@@ -191,8 +197,20 @@ public class Scratch.Services.ValaSymbolOutline : Scratch.Services.SymbolOutline
             parent = construct_child (symbol.scope.parent_scope.owner, given_parent, cancellable);
         }
 
-        var tree_child = new ValaSymbolItem (symbol);
+        var tooltip = "%s%s".printf (
+            doc.get_slice (
+                symbol.source_reference.begin.line,
+                symbol.source_reference.begin.column,
+                symbol.source_reference.end.line,
+                symbol.source_reference.end.column
+            ),
+            symbol.comment != null ? "\n" + symbol.comment.content : ""
+        );
 
+        var tree_child = new ValaSymbolItem (
+            symbol,
+            tooltip
+        );
         parent.add (tree_child);
         return tree_child;
     }

--- a/src/SymbolPane/Vala/ValaSymbolOutline.vala
+++ b/src/SymbolPane/Vala/ValaSymbolOutline.vala
@@ -192,67 +192,6 @@ public class Scratch.Services.ValaSymbolOutline : Scratch.Services.SymbolOutline
         }
 
         var tree_child = new ValaSymbolItem (symbol);
-        if (symbol is Vala.Struct) {
-            tree_child.icon = new ThemedIcon ("lang-struct");
-            tree_child.symbol_type = SymbolType.STRUCT;
-        } else if (symbol is Vala.Class) {
-            if (((Vala.Class) symbol).is_abstract) {
-                tree_child.icon = new ThemedIcon ("lang-class-abstract");
-            } else {
-                tree_child.icon = new ThemedIcon ("lang-class");
-            }
-
-            tree_child.symbol_type = SymbolType.CLASS;
-        } else if (symbol is Vala.Constant) {
-            tree_child.icon = new ThemedIcon ("lang-constant");
-            tree_child.symbol_type = SymbolType.CONSTANT;
-        } else if (symbol is Vala.Enum) {
-            tree_child.icon = new ThemedIcon ("lang-enum");
-            tree_child.symbol_type = SymbolType.ENUM;
-        } else if (symbol is Vala.Field) {
-            tree_child.icon = new ThemedIcon ("lang-property");
-            tree_child.symbol_type = SymbolType.PROPERTY;
-        } else if (symbol is Vala.Interface) {
-            tree_child.icon = new ThemedIcon ("lang-interface");
-            tree_child.symbol_type = SymbolType.INTERFACE;
-        } else if (symbol is Vala.Property) {
-            if (((Vala.Property) symbol).is_abstract) {
-                tree_child.icon = new ThemedIcon ("lang-property-abstract");
-            } else if (((Vala.Property) symbol).is_virtual) {
-                tree_child.icon = new ThemedIcon ("lang-property-virtual");
-            } else {
-                tree_child.icon = new ThemedIcon ("lang-property");
-            }
-
-            tree_child.symbol_type = SymbolType.PROPERTY;
-        } else if (symbol is Vala.Signal) {
-            tree_child.icon = new ThemedIcon ("lang-signal");
-            tree_child.symbol_type = SymbolType.SIGNAL;
-        } else if (symbol is Vala.CreationMethod) {
-            tree_child.icon = new ThemedIcon ("lang-constructor");
-            tree_child.symbol_type = SymbolType.CONSTRUCTOR;
-        } else if (symbol is Vala.Method) {
-            if (((Vala.Method) symbol).is_abstract) {
-                tree_child.icon = new ThemedIcon ("lang-method-abstract");
-            } else if (((Vala.Method) symbol).is_virtual) {
-                tree_child.icon = new ThemedIcon ("lang-method-virtual");
-            } else if (((Vala.Method) symbol).binding == Vala.MemberBinding.STATIC) {
-                tree_child.icon = new ThemedIcon ("lang-method-static");
-            } else {
-                tree_child.icon = new ThemedIcon ("lang-method");
-            }
-
-            tree_child.symbol_type = SymbolType.METHOD;
-        } else if (symbol is Vala.Namespace) {
-            tree_child.icon = new ThemedIcon ("lang-namespace");
-            tree_child.symbol_type = SymbolType.NAMESPACE;
-        } else if (symbol is Vala.ErrorDomain) {
-            tree_child.icon = new ThemedIcon ("lang-errordomain");
-        } else if (symbol is Vala.Delegate) {
-            tree_child.icon = new ThemedIcon ("lang-delegate");
-        } else {
-            warning (symbol.type_name);
-        }
 
         parent.add (tree_child);
         return tree_child;


### PR DESCRIPTION
Fixes #1410 

 - Extract the source definition from the document and use as tooltip
 - Fix some consequential timing issues on restoring documents with the outline open
 - Update some code style of ValaSymbolItem and move some code from ValaSymbolItem into the construct clause

It proved simpler and better to copy the definition from the document rather than trying to reconstruct from the parsed symbols.  The tooltip includes text to the end of the first line pointed to by the symbol.source_reference as this may contain extra useful information such as parameters and/or comments.

