### PR TITLE
Prepare for release 8.0.0

### DIFF
--- a/data/code.metainfo.xml.in
+++ b/data/code.metainfo.xml.in
@@ -68,7 +68,7 @@
   <update_contact>contact_AT_elementary.io</update_contact>
 
   <releases>
-    <release version="8.0.0" date="2025-05-26" urgency="medium">
+    <release version="8.0.0" date="2025-06-13" urgency="medium">
       <description>
         <p>Improvements:</p>
         <ul>
@@ -79,6 +79,7 @@
           <li>The branch names in the "Branch" submenus are now sorted alphabetically</li>
           <li>The extension list now has switches instead of checkboxes in order to provide a larger target</li>
           <li>The terminal pane now implements smart copy-paste and follows the "natural-copy-paste" setting of Terminal</li>
+          <li>The Vala symbol pane now gives more information in the tooltips</li>
         </ul>
         <p>Minor updates:</p>
         <ul>
@@ -110,6 +111,7 @@
         <issue url="https://github.com/elementary/code/issues/1471">Active project dropdown sometimes out of sync on restart</issue>
         <issue url="https://github.com/elementary/code/issues/1473">Markdown numbered list auto-completion deletes text</issue>
         <issue url="https://github.com/elementary/code/issues/1469">Certain word selections are not highlighted by plugin</issue>
+        <issue url="https://github.com/elementary/code/issues/1410">Add more information to Symbol plugin tooltips</issue>
         <issue url="https://github.com/elementary/code/issues/1408">Move "Open in Terminal Pane" item to the "Open In" menu</issue>
         <issue url="https://github.com/elementary/code/issues/1332">Sidebar is slow to expand folders containing moderately many (2000) files first time</issue>
         <issue url="https://github.com/elementary/code/issues/1317">Symbol Pane: Does not scroll back to already selected method</issue>


### PR DESCRIPTION
 - [x] Add to release section to metadata for v8.0.0
 - [x] Update screenshot paths
 - [x] Merge essential fixes
 - - [x] #1566    Required for plugins to work with libpeas2
 - - [x] #1571    Required for global search to work reliably with asynchronous folder loading
 - - [x] #1588 Fix natural copy - pass on 'Ctrl C' when nothing to copy
 - - [x] Investigate possible crash from symbol pane found in dogfood testing branch - found not to apply to original repo
 - - [x] Reapply accidentally reverted #1567
 - [x] Merge any desired outstanding PRs if possible
 - - [x] #1565    Also stops symbol pane blocking UI when parsing
 - - [x] #1567    Bitesize
 - - [x] #1576 Bitesize
 - - [x] #1578 Nice to have - fixes long outstanding request
 - [x] Finalize