### PR TITLE
Reapply use switch instead of CheckBox after accidental reversion

### DIFF
--- a/src/Services/PluginManager.vala
+++ b/src/Services/PluginManager.vala
@@ -159,9 +159,9 @@ public class Scratch.Services.PluginsManager : GLib.Object {
     private Gtk.Widget get_widget_for_plugin_info (Object obj) {
         var info = (Peas.PluginInfo)obj;
 
-        var checkbox = new Gtk.CheckButton () {
+        var load_switch = new Gtk.Switch () {
             valign = CENTER,
-            active = info.is_loaded ()
+            state = info.is_loaded ()
         };
 
         var image = new Gtk.Image.from_icon_name (info.get_icon_name (), LARGE_TOOLBAR) {
@@ -196,11 +196,11 @@ public class Scratch.Services.PluginsManager : GLib.Object {
         };
         content.add (image);
         content.add (description_box);
-        content.add (checkbox);
+        content.add (load_switch);
         content.set_data<string> ("name", info.get_name ());
 
-        checkbox.toggled.connect (() => {
-            if (checkbox.active) {
+            load_switch.notify["active"].connect (() => {
+                if (load_switch.active) {
                 engine.load_plugin (info);
             } else {
                 engine.unload_plugin (info);


### PR DESCRIPTION
When fixing the libpeas migration this change was accidentally reverted.  Reapplying.