### PR TITLE
Fix crash from Document `get_slice ()` on start up under some conditions

### DIFF
--- a/src/SymbolPane/SymbolOutline.vala
+++ b/src/SymbolPane/SymbolOutline.vala
@@ -87,6 +87,7 @@ public class Scratch.Services.SymbolOutline : Gtk.Box {
     }
 
     public virtual void parse_symbols () {}
+    public virtual void add_tooltips (Code.Widgets.SourceList.ExpandableItem root) {}
 
     Gtk.MenuButton filter_button;
 


### PR DESCRIPTION
It seems that Document function `get_slice ()` is not thread-safe (?) and sometimes causes a crash during startup. An occasional crash during use was also noticed that may be due to reparsing the document.

This function is used for constructing the symbol pane items' tooltips. 

Calling this function on each item *after* the tree is constructed rather than during the construction of each item seems to fix the crash but some testing is needed to assure this as the exact reason has not been determined.


Needs to be tested and merged before next release can take place.