### PR TITLE
Symbol Pane - indicate when loading

### DIFF
--- a/src/SymbolPane/C/CtagsSymbolOutline.vala
+++ b/src/SymbolPane/C/CtagsSymbolOutline.vala
@@ -55,6 +55,7 @@ public class Scratch.Services.CtagsSymbolOutline : Scratch.Services.SymbolOutlin
     }
 
     public override void parse_symbols () {
+        before_parse ();
         if (current_subprocess != null)
             current_subprocess.force_exit ();
 
@@ -64,9 +65,12 @@ public class Scratch.Services.CtagsSymbolOutline : Scratch.Services.SymbolOutlin
                 "ctags", "-f", "-", "--format=2", "--excmd=n", "--fields=nstK", "--extra=", "--sort=no", doc.file.get_path ()
             );
 
-            parse_output.begin (current_subprocess);
+            parse_output.begin (current_subprocess, (obj, res) => {
+                after_parse ();
+            });
         } catch (GLib.Error e) {
             critical (e.message);
+            after_parse ();
         }
     }
 

--- a/src/SymbolPane/Vala/ValaSymbolOutline.vala
+++ b/src/SymbolPane/Vala/ValaSymbolOutline.vala
@@ -74,7 +74,7 @@ public class Scratch.Services.ValaSymbolOutline : Scratch.Services.SymbolOutline
 
     private uint parse_timeout_id = 0;
     public override void parse_symbols () {
-        tool_box_sensitive = true;
+        before_parse ();
         var context = new Vala.CodeContext ();
 #if VALA_0_50
         context.set_target_profile (Vala.Profile.GOBJECT, false);
@@ -95,7 +95,6 @@ public class Scratch.Services.ValaSymbolOutline : Scratch.Services.SymbolOutline
             resolver.resolve (context);
             Vala.CodeContext.pop ();
 
-            bool took_too_long = false;
             parse_timeout_id = Timeout.add_full (Priority.LOW, PARSE_TIME_MAX_MSEC, () => {
                 parse_timeout_id = 0;
                 took_too_long = true;
@@ -126,8 +125,6 @@ public class Scratch.Services.ValaSymbolOutline : Scratch.Services.SymbolOutline
                         };
 
                         store.root.add (warning_item);
-                        tool_box_sensitive = false;
-
                     } else {
                         store.root.add (new_root);
                     }
@@ -135,19 +132,22 @@ public class Scratch.Services.ValaSymbolOutline : Scratch.Services.SymbolOutline
                     store.root.expand_all ();
                     add_tooltips (store.root);
                     store.vadjustment.set_value (adjustment_value);
-                    return false;
+                    return Source.REMOVE;
                 });
             } else {
                 destroy_all_children (new_root);
             }
 
+            after_parse ();
             return null;
         });
     }
 
     protected override void add_tooltips (Code.Widgets.SourceList.ExpandableItem root) {
         foreach (var parent in root.children) {
-            add_tooltip ((Code.Widgets.SourceList.ExpandableItem) parent);
+            if (parent is Code.Widgets.SourceList.ExpandableItem) {
+                add_tooltip ((Code.Widgets.SourceList.ExpandableItem) parent);
+            }
         }
     }
 


### PR DESCRIPTION
Fixes #26 

Shows a spinner in place of the filter button when parsing, after a short delay.

In the majority of cases the parsing completes before spinner shows but for large files (or slow computers) if does show.

Works for both Vala and C files.
