### PR TITLE
MainWindow: Fix missing gettext

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -1072,8 +1072,8 @@ namespace Scratch {
                                 open_folder (workdir);
                                 clone_dialog.destroy ();
                                 var message_dialog = new Granite.MessageDialog.with_image_from_icon_name (
-                                    "Repository %s successfully cloned".printf (uri),
-                                    "Local repository working directory is %s".printf (workdir.get_uri ()),
+                                    _("Repository %s successfully cloned").printf (uri),
+                                    _("Local repository working directory is %s").printf (workdir.get_uri ()),
                                     "dialog-information",
                                     Gtk.ButtonsType.CLOSE
                                 ) {
@@ -1084,7 +1084,7 @@ namespace Scratch {
                             } else {
                                 clone_dialog.hide ();
                                 var message_dialog = new Granite.MessageDialog.with_image_from_icon_name (
-                                    "Unable to clone %s".printf (uri),
+                                    _("Unable to clone %s").printf (uri),
                                     error,
                                     "dialog-error",
                                     Gtk.ButtonsType.CLOSE


### PR DESCRIPTION
Fixes the dialog after git clone succeeded not being available for translation:

![image](https://github.com/user-attachments/assets/5af462e2-83f8-451b-bc41-1e5d7a49e5c1)
