### PR TITLE
Restart shell in terminal pane if it exits

### DIFF
--- a/src/Widgets/Terminal.vala
+++ b/src/Widgets/Terminal.vala
@@ -130,8 +130,7 @@ public class Code.Terminal : Gtk.Box {
         Posix.kill (child_pid, Posix.Signal.TERM);
         terminal.reset (true, true);
         spawn_shell (dir);
-        var settings = new Settings (Constants.PROJECT_NAME + ".saved-state");
-        settings.set_string ("last-opened-path", dir);
+        Scratch.saved_state.set_string ("last-opened-path", dir);
     }
 
     private string get_shell_location () {


### PR DESCRIPTION
Fixes #457 

There was already code to hide the terminal if it's child exited but it had regressed and was not working.

This PR makes the terminal hide again if the shell exits.

It also restarts the shell at the last saved location and clears the screen ready for it to be used again. To enable this, the shell location is saved to settings every time it changes through app action instead of just at closing the app. (NOTE: Change of location through the shell `cd` command is not detected so not saved)
