### PR TITLE
Fix crash from highlight selection plugin when deleting selection

### DIFF
--- a/plugins/highlight-word-selection/highlight-word-selection.vala
+++ b/plugins/highlight-word-selection/highlight-word-selection.vala
@@ -48,10 +48,6 @@ public class Scratch.Plugins.HighlightSelectedWords : Peas.ExtensionBase, Scratc
 
     // A deselection is now treated as a selection change
     private void on_selection_changed () requires (main_window != null) {
-        Idle.add (update_highlight_source_func);
-    }
-
-    private bool update_highlight_source_func () {
         if (current_search_context != null) {
             // Cancel existing search
             current_search_context.set_highlight (false);
@@ -127,8 +123,6 @@ public class Scratch.Plugins.HighlightSelectedWords : Peas.ExtensionBase, Scratc
                 current_search_context.set_highlight (selected_text.length > 0);
             }
         }
-
-        return Source.REMOVE;
     }
 
     public void deactivate () {

--- a/plugins/highlight-word-selection/highlight-word-selection.vala
+++ b/plugins/highlight-word-selection/highlight-word-selection.vala
@@ -34,12 +34,10 @@ public class Scratch.Plugins.HighlightSelectedWords : Peas.ExtensionBase, Scratc
         plugins = (Scratch.Services.Interface) object;
         plugins.hook_document.connect ((doc) => {
             if (current_source != null) {
-                current_source.deselected.disconnect (on_deselection);
                 current_source.selection_changed.disconnect (on_selection_changed);
             }
 
             current_source = doc.source_view;
-            current_source.deselected.connect (on_deselection);
             current_source.selection_changed.connect (on_selection_changed);
         });
 
@@ -48,16 +46,22 @@ public class Scratch.Plugins.HighlightSelectedWords : Peas.ExtensionBase, Scratc
         });
     }
 
-    public void on_selection_changed (ref Gtk.TextIter start, ref Gtk.TextIter end) requires (main_window != null) {
-        if (!main_window.has_successful_search ()) {
-            // Perform plugin selection when there is no ongoing and successful search 
-            current_search_context = new Gtk.SourceSearchContext (
-                (Gtk.SourceBuffer)current_source.buffer,
-                null
-            );
-            current_search_context.settings.search_text = "";
-            current_search_context.set_highlight (false);
+    // A deselection is now treated as a selection change
+    private void on_selection_changed () requires (main_window != null) {
+        Idle.add (update_highlight_source_func);
+    }
 
+    private bool update_highlight_source_func () {
+        if (current_search_context != null) {
+            // Cancel existing search
+            current_search_context.set_highlight (false);
+            current_search_context = null;
+        }
+
+        // Only highlight (extended) selection if non-zero length and search highlighting not happening
+        Gtk.TextIter start, end;
+        if (current_source.buffer.get_selection_bounds (out start, out end) &&
+            !main_window.has_successful_search ()) {
             var original_start = start.copy ();
 
             // Ignore leading space
@@ -114,29 +118,21 @@ public class Scratch.Plugins.HighlightSelectedWords : Peas.ExtensionBase, Scratc
             // Ensure no leading or trailing space
             var selected_text = start.get_text (end).strip ();
 
-            if (selected_text.char_count () > SELECTION_HIGHLIGHT_MAX_CHARS) {
-                return;
+            if (selected_text.char_count () <= SELECTION_HIGHLIGHT_MAX_CHARS) {
+                current_search_context = new Gtk.SourceSearchContext (
+                    (Gtk.SourceBuffer)current_source.buffer,
+                    null
+                );
+                current_search_context.settings.search_text = selected_text;
+                current_search_context.set_highlight (selected_text.length > 0);
             }
-
-            current_search_context.settings.search_text = selected_text;
-            current_search_context.set_highlight (true);
-        } else if (current_search_context != null) {
-            // Cancel existing search
-            current_search_context.set_highlight (false);
-            current_search_context = null;
         }
-    }
 
-    public void on_deselection () {
-        if (current_search_context != null) {
-            current_search_context.set_highlight (false);
-            current_search_context = null;
-        }
+        return Source.REMOVE;
     }
 
     public void deactivate () {
         if (current_source != null) {
-            current_source.deselected.disconnect (on_deselection);
             current_source.selection_changed.disconnect (on_selection_changed);
         }
     }

--- a/plugins/highlight-word-selection/highlight-word-selection.vala
+++ b/plugins/highlight-word-selection/highlight-word-selection.vala
@@ -114,13 +114,14 @@ public class Scratch.Plugins.HighlightSelectedWords : Peas.ExtensionBase, Scratc
             // Ensure no leading or trailing space
             var selected_text = start.get_text (end).strip ();
 
+            // We know the selected text is non-zero length, check not too long
             if (selected_text.char_count () <= SELECTION_HIGHLIGHT_MAX_CHARS) {
                 current_search_context = new Gtk.SourceSearchContext (
                     (Gtk.SourceBuffer)current_source.buffer,
                     null
                 );
                 current_search_context.settings.search_text = selected_text;
-                current_search_context.set_highlight (selected_text.length > 0);
+                current_search_context.set_highlight (true);
             }
         }
     }

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -44,9 +44,9 @@ namespace Scratch.Widgets {
         private const double SCROLL_THRESHOLD = 1.0;
 
         public signal void style_changed (Gtk.SourceStyleScheme style);
-        // "selection_changed" signal now only emitted when the selected text changes (position ignored).  Listened to by searchbar and highlight word selection plugin
+        // "selection_changed" signal now only emitted when the selected text changes (position ignored).  
+        // Listened to by searchbar and highlight word selection plugin
         public signal void selection_changed (Gtk.TextIter start_iter, Gtk.TextIter end_iter);
-        public signal void deselected ();
 
         //lang can be null, in the case of *No highlight style* aka Normal text
         public Gtk.SourceLanguage? language {
@@ -680,12 +680,7 @@ namespace Scratch.Widgets {
             }
 
             // Fire deselected immediately
-            if (start.equal (end)) {
-                deselected ();
-            // Don't fire signal till we think select movement is done
-            } else {
                 selection_changed_timer = Timeout.add (THROTTLE_MS, selection_changed_event);
-            }
         }
 
         private void on_mark_deleted (Gtk.TextMark mark) {
@@ -698,15 +693,12 @@ namespace Scratch.Widgets {
 
         private bool selection_changed_event () {
             Gtk.TextIter start, end;
-            bool selected = buffer.get_selection_bounds (out start, out end);
-            if (selected) {
-                var prev_selected_text = selected_text;
-                selected_text = buffer.get_text (start, end, true);
-                if (selected_text != prev_selected_text) {
-                    selection_changed (start, end);
-                }
-            } else {
-                deselected ();
+            buffer.get_selection_bounds (out start, out end);
+            // No selection now treated as a potential selection change
+            var prev_selected_text = selected_text;
+            selected_text = buffer.get_text (start, end, true);
+            if (selected_text != prev_selected_text) {
+                selection_changed (start, end);
             }
 
             selection_changed_timer = 0;

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -44,7 +44,7 @@ namespace Scratch.Widgets {
         private const double SCROLL_THRESHOLD = 1.0;
 
         public signal void style_changed (Gtk.SourceStyleScheme style);
-        // "selection_changed" signal now only emitted when the selected text changes (position ignored).  
+        // "selection_changed" signal now only emitted when the selected text changes (position ignored).
         // Listened to by searchbar and highlight word selection plugin
         public signal void selection_changed (Gtk.TextIter start_iter, Gtk.TextIter end_iter);
 
@@ -679,8 +679,7 @@ namespace Scratch.Widgets {
                 selection_changed_timer = 0;
             }
 
-            // Fire deselected immediately
-                selection_changed_timer = Timeout.add (THROTTLE_MS, selection_changed_event);
+            selection_changed_timer = Timeout.add (THROTTLE_MS, selection_changed_event);
         }
 
         private void on_mark_deleted (Gtk.TextMark mark) {


### PR DESCRIPTION
Fixes #1443 

The cause seems to be a clash between the handlers for the "selection-changed" and "deselected" signals in the plugin.  One is throttled and the other not.

For simplicity the "deselected" signal is lost (only used by the plugin) and a deselection now triggers a throttled "selection-changed" signal.  
