### PR TITLE
SymbolPane: Fix filter for C symbols

### DIFF
--- a/src/SymbolPane/C/CtagsSymbol.vala
+++ b/src/SymbolPane/C/CtagsSymbol.vala
@@ -16,7 +16,7 @@
  *
  */
 
-public class Scratch.Services.CtagsSymbol : Code.Widgets.SourceList.ExpandableItem {
+public class Scratch.Services.CtagsSymbol : Code.Widgets.SourceList.ExpandableItem, Scratch.Services.SymbolItem {
     public Scratch.Services.Document doc { get; construct set; }
     public SymbolType symbol_type { get; set; default = SymbolType.OTHER; }
     public int line { get; construct set; }


### PR DESCRIPTION
Fixes #1597

The CtagsSymbol object was not declaring that it implements the SymbolItem interface so was being ignored by the filter function.
