### PR TITLE
SymbolPane: improve tooltips for C tags

### DIFF
--- a/src/SymbolPane/C/CtagsSymbolOutline.vala
+++ b/src/SymbolPane/C/CtagsSymbolOutline.vala
@@ -291,11 +291,18 @@ public class Scratch.Services.CtagsSymbolOutline : Scratch.Services.SymbolOutlin
     private void add_tooltip (Code.Widgets.SourceList.ExpandableItem parent) {
         if (parent is CtagsSymbol) {
             var item = ((CtagsSymbol)parent);
+            var start = item.line;
+            var end = item.line;
+            // The type of a method is often on the previous line
+            if (item.symbol_type == SymbolType.METHOD) {
+                start = start > 0 ? start - 1 : start;
+            }
+
             item.tooltip = Markup.escape_text ("%s".printf (
                 doc.get_slice (
-                    item.line,
+                    start,
                     0,
-                    item.line,
+                    end,
                     0
                 )
             ));

--- a/src/SymbolPane/C/CtagsSymbolOutline.vala
+++ b/src/SymbolPane/C/CtagsSymbolOutline.vala
@@ -275,8 +275,33 @@ public class Scratch.Services.CtagsSymbolOutline : Scratch.Services.SymbolOutlin
             destroy_root (root);
             root = new_root;
 
+            add_tooltips (store.root);
             return false;
         });
+    }
+
+    protected override void add_tooltips (Code.Widgets.SourceList.ExpandableItem root) {
+        foreach (var parent in root.children) {
+            if (parent is Code.Widgets.SourceList.ExpandableItem) {
+                add_tooltip ((Code.Widgets.SourceList.ExpandableItem) parent);
+            }
+        }
+    }
+
+    private void add_tooltip (Code.Widgets.SourceList.ExpandableItem parent) {
+        if (parent is CtagsSymbol) {
+            var item = ((CtagsSymbol)parent);
+            item.tooltip = Markup.escape_text ("%s".printf (
+                doc.get_slice (
+                    item.line,
+                    0,
+                    item.line,
+                    0
+                )
+            ));
+        }
+
+        add_tooltips (parent);
     }
 
     private void destroy_root (Code.Widgets.SourceList.ExpandableItem to_destroy) {


### PR DESCRIPTION
We implemented more informative tooltips for Vala symbols recently.  This does the same for C tags (as far as the parser allows).

The parser does not provide start and end lines for the tags, only the line on which the tag name occurs. As C methods often have the type on the previous line, the start line is decremented for methods.  It is necessary to use Markup.escape_text as some C symbol definitions contain markup characters.