### PR TITLE
Fix typo in .desktop file

### DIFF
--- a/data/io.elementary.code.desktop.in.in
+++ b/data/io.elementary.code.desktop.in.in
@@ -20,4 +20,4 @@ Icon=document-new
 [Desktop Action NewWindow]
 Name=New Window
 Exec=@EXEC_NAME@ --new-window
-icon=window-new
+Icon=window-new


### PR DESCRIPTION
Without this change, desktop-file-validate considers the .desktop file to be invalid:

```
(...)/usr/share/applications/io.elementary.code.desktop: error: file contains key "icon" in group "Desktop Action NewWindow", but keys extending the format should start with "X-"
```