### PR TITLE
Disable-able Syntax Highlighting Preference

### DIFF
--- a/data/io.elementary.code.gschema.xml
+++ b/data/io.elementary.code.gschema.xml
@@ -106,6 +106,11 @@
       <summary>Highlight Matching Brackets</summary>
       <description>Whether Code should highlight matching brackets.</description>
     </key>
+    <key name="syntax-highlighting" type="b">
+      <default>true</default>
+      <summary>Highlight source code syntax</summary>
+      <description>Whether Code should apply syntax highlighting to documents.</description>
+    </key>
     <key name="draw-spaces" enum="io.elementary.code.draw-spaces-states">
       <default>"For Selection"</default>
       <summary>Draw spaces and tabs with symbols</summary>

--- a/src/Dialogs/PreferencesDialog.vala
+++ b/src/Dialogs/PreferencesDialog.vala
@@ -110,6 +110,7 @@ public class Scratch.Dialogs.Preferences : Granite.Dialog {
         var editor_box = new Gtk.Box (VERTICAL, 12);
         editor_box.add (new Granite.HeaderLabel (_("Editor")));
         editor_box.add (new SettingSwitch (_("Highlight matching brackets"), "highlight-matching-brackets"));
+        editor_box.add (new SettingSwitch (_("Syntax highlighting"), "syntax-highlighting"));
         editor_box.add (draw_spaces_box);
         editor_box.add (new SettingSwitch (_("Mini Map"), "show-mini-map"));
         editor_box.add (new SettingSwitch (_("Wrap lines"), "line-wrap"));

--- a/src/Widgets/FormatBar.vala
+++ b/src/Widgets/FormatBar.vala
@@ -47,7 +47,7 @@ public class Code.FormatBar : Gtk.Box {
 
         lang_menubutton = new FormatButton () {
             icon = new ThemedIcon ("application-x-class-file-symbolic"),
-            tooltip_text = _("Syntax Highlighting")
+            tooltip_text = _("Document language")
         };
 
         line_menubutton = new FormatButton () {

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -95,7 +95,7 @@ namespace Scratch.Widgets {
 
             var source_buffer = new Gtk.SourceBuffer (null);
             set_buffer (source_buffer);
-            source_buffer.highlight_syntax = true;
+            source_buffer.highlight_syntax = Scratch.settings.get_boolean ("syntax-highlighting");
             source_buffer.mark_set.connect (on_mark_set);
             source_buffer.mark_deleted.connect (on_mark_deleted);
             highlight_current_line = true;
@@ -239,6 +239,7 @@ namespace Scratch.Widgets {
             insert_spaces_instead_of_tabs = Scratch.settings.get_boolean ("spaces-instead-of-tabs");
             var source_buffer = (Gtk.SourceBuffer) buffer;
             source_buffer.highlight_matching_brackets = Scratch.settings.get_boolean ("highlight-matching-brackets");
+            source_buffer.highlight_syntax = Scratch.settings.get_boolean ("syntax-highlighting");
             space_drawer.enable_matrix = false;
             switch ((ScratchDrawSpacesState) Scratch.settings.get_enum ("draw-spaces")) {
                 case ScratchDrawSpacesState.ALWAYS:


### PR DESCRIPTION
Hey,

I have tried to answer my self-created issue:

https://github.com/elementary/code/issues/1659

As a sum-up, I have added a new syntax-highlighting GSettings key plus a toggle under `Preferences -> Interface` so users who prefer monochrome editing can disable highlighting globally while leaving the existing language picker active for commenting, Markdown shortcuts, etc.

The SourceView simply toggles `Gtk.SourceBuffer.highlight_syntax`, so search hits and other non-language effects keep working, and the language dropdown now says "Document language" to better reflect its broader role.

Happy to adjust any of this if you think there is a better way to expose the preference, or if there is anything with the implementation.