### PR TITLE
Set  Preferences dialog to be unresizable

### DIFF
--- a/src/Dialogs/PreferencesDialog.vala
+++ b/src/Dialogs/PreferencesDialog.vala
@@ -19,7 +19,7 @@ public class Scratch.Dialogs.Preferences : Granite.Dialog {
     }
 
     construct {
-        set_default_size (100, 200);
+        resizable = false;
         var general_box = new Gtk.Box (VERTICAL, 12);
         general_box.add (new Granite.HeaderLabel (_("General")));
         general_box.add (new SettingSwitch (_("Save files when changed"), "autosave"));


### PR DESCRIPTION
Dialogs are generally not intended to be resizable. The dialog can currently be set to an unreasonable size, which is persisted by the system.

This PR sets the Preferences dialog to be unresizable and then it determines its own size.
