### PR TITLE
SourceList/Item: use GLib.Menu

### DIFF
--- a/src/FolderManager/FileItem.vala
+++ b/src/FolderManager/FileItem.vala
@@ -31,7 +31,7 @@ namespace Scratch.FolderManager {
             view.activate (file.path);
         }
 
-        public override Gtk.Menu? get_context_menu () {
+        public override GLib.Menu? get_context_menu () {
             GLib.FileInfo info = null;
 
             try {
@@ -77,9 +77,7 @@ namespace Scratch.FolderManager {
             menu_model.append_section (null, external_actions_section);
             menu_model.append_section (null, direct_actions_section);
 
-            var menu = new Gtk.Menu.from_model (menu_model);
-            menu.insert_action_group (FileView.ACTION_GROUP, view.actions);
-            return menu;
+            return menu_model;
         }
 
         private GLib.MenuItem create_submenu_for_open_in (string? file_type) {

--- a/src/FolderManager/FolderItem.vala
+++ b/src/FolderManager/FolderItem.vala
@@ -124,7 +124,7 @@ namespace Scratch.FolderManager {
             }
         }
 
-        public override Gtk.Menu? get_context_menu () {
+        public override GLib.Menu? get_context_menu () {
             GLib.FileInfo info = null;
             try {
                 info = file.file.query_info (GLib.FileAttribute.STANDARD_CONTENT_TYPE, GLib.FileQueryInfoFlags.NONE);
@@ -179,9 +179,7 @@ namespace Scratch.FolderManager {
             menu_model.append_section (null, direct_actions_section);
             menu_model.append_section (null, search_section);
 
-            var menu = new Gtk.Menu.from_model (menu_model);
-            menu.insert_action_group (FileView.ACTION_GROUP, view.actions);
-            return menu;
+            return menu_model;
         }
 
         protected GLib.MenuItem create_submenu_for_open_in (string? file_type) {

--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -130,7 +130,7 @@ namespace Scratch.FolderManager {
             }
         }
 
-        public override Gtk.Menu? get_context_menu () {
+        public override GLib.Menu? get_context_menu () {
             string file_type = "";
             try {
                 var info = file.file.query_info (GLib.FileAttribute.STANDARD_CONTENT_TYPE, GLib.FileQueryInfoFlags.NONE);
@@ -303,9 +303,7 @@ namespace Scratch.FolderManager {
             menu_model.append_section (null, direct_actions_section);
             menu_model.append_section (null, search_actions_section);
 
-            var menu = new Gtk.Menu.from_model (menu_model);
-            menu.insert_action_group (FileView.ACTION_GROUP, view.actions);
-            return menu;
+            return menu_model;
         }
 
         protected GLib.MenuItem create_submenu_for_branch () {

--- a/src/Widgets/SourceList/SourceList.vala
+++ b/src/Widgets/SourceList/SourceList.vala
@@ -422,10 +422,10 @@ public class SourceList : Gtk.ScrolledWindow {
          * any context menu items should be actioned on the item instance rather than the selected item
          * in the SourceList
          *
-         * @return A {@link Gtk.Menu} or //null// if nothing should be displayed.
+         * @return A {@link GLib.Menu} or //null// if nothing should be displayed.
          * @since 0.2
          */
-        public virtual Gtk.Menu? get_context_menu () {
+        public virtual GLib.Menu? get_context_menu () {
             return null;
         }
     }
@@ -2407,10 +2407,13 @@ public class SourceList : Gtk.ScrolledWindow {
             if (item != null) {
                 var menu = item.get_context_menu ();
                 if (menu != null) {
-                    menu.attach_widget = this;
-                    menu.popup_at_pointer (event);
+                    var gtk_menu = new Gtk.Menu.from_model (menu) {
+                        attach_widget = this
+                    };
+
+                    gtk_menu.popup_at_pointer (event);
                     if (event == null) {
-                        menu.select_first (false);
+                        gtk_menu.select_first (false);
                     }
 
                     return true;


### PR DESCRIPTION
Make sure `Item` subclasses return a GLib.Menu instead of Gtk.Menu. Then we can use Gtk.Menu only once in SourceList which will be a drop-in for Gtk.PopoverMenu during the GTK4 port

afaict we don't need to insert the action group here because we've set attach widget