### PR TITLE
Rename RDNN to io.elementary.contractor

### DIFF
--- a/io.elementary.code.yml
+++ b/io.elementary.code.yml
@@ -14,7 +14,7 @@ finish-args:
 
   - '--talk-name=org.gtk.vfs.*'
   - '--talk-name=org.gnome.SettingsDaemon'
-  - '--talk-name=org.elementary.Contractor'
+  - '--talk-name=io.elementary.Contractor'
 
   - '--metadata=X-DConf=migrate-path=/io/elementary/code/'
 cleanup:


### PR DESCRIPTION
In discussions https://github.com/elementary/contractor/pull/31 and https://github.com/elementary/contractor/pull/41, @ryonakano pointed out the need to transition from `org.elementary.Contractor` to `io.elementary.Contractor` as part of the RDNN rename for OS 9

This PR updates the occurrences in `io.elementary.code.yml` and `data/code.metainfo.xml.in` to match the changes in the Contractor daemon

Note: This change is part of a cross-repo transition and should be merged in coordination with the Contractor PR