### PR TITLE
Control: drop transitional policykit-1

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -20,8 +20,6 @@ Build-Depends: appstream,
                libvte-2.91-dev,
                libxml2-utils,
                meson (>= 0.44.0),
-# Required to generate translation of .policy files in focal+
-               policykit-1,
 # Required to generate translation of .policy files in jammy+
                polkitd,
 # Required to generate translation of .policy files in mantic+


### PR DESCRIPTION
We already pull in polkitd and libpolkit-gobject-1-dev which seems to work in CI?

Fixes build for Resolute where `policykit-1` no longer exists