### PR TITLE
Persist in-use docs per project

### DIFF
--- a/data/io.elementary.code.gschema.xml
+++ b/data/io.elementary.code.gschema.xml
@@ -244,4 +244,14 @@
       <description>Opened folders that should be restored in startup.</description>
     </key>
   </schema>
+
+  <!--Relocatable schema for per project info-->
+  <schema id="io.elementary.code.Projects">
+    <key name="expanded" type="b">
+      <default>false</default>
+      <summary>Project Folder expanded</summary>
+      <description>Whether the project folder in the sidebar should be expanded on loading</description>
+    </key>
+  </schema>
+
 </schemalist>

--- a/data/io.elementary.code.gschema.xml
+++ b/data/io.elementary.code.gschema.xml
@@ -247,11 +247,6 @@
 
   <!--Relocatable schema for per project info-->
   <schema id="io.elementary.code.Projects">
-    <key name="expanded" type="b">
-      <default>false</default>
-      <summary>Project Folder expanded</summary>
-      <description>Whether the project folder in the sidebar should be expanded on loading</description>
-    </key>
     <key name="open-files" type="a(si)">
       <default>[]</default>
       <summary>Open files in project with cursor position</summary>

--- a/data/io.elementary.code.gschema.xml
+++ b/data/io.elementary.code.gschema.xml
@@ -252,6 +252,11 @@
       <summary>Project Folder expanded</summary>
       <description>Whether the project folder in the sidebar should be expanded on loading</description>
     </key>
+    <key name="open-files" type="a(si)">
+      <default>[]</default>
+      <summary>Open files in project with cursor position</summary>
+      <description>Array of paths to files currently being edited in project with the current cursor position (char offset)</description>
+    </key>
   </schema>
 
 </schemalist>

--- a/src/FolderManager/FileView.vala
+++ b/src/FolderManager/FileView.vala
@@ -140,6 +140,8 @@ public class Scratch.FolderManager.FileView : Code.Widgets.SourceList, Code.Pane
         foreach (unowned string path in settings.get_strv ("opened-folders")) {
             yield add_folder (new File (path), false);
         }
+
+        set_project_active (Scratch.Services.GitManager.get_instance ().active_project_path);
     }
 
     public void open_folder (File folder) {
@@ -592,6 +594,11 @@ public class Scratch.FolderManager.FileView : Code.Widgets.SourceList, Code.Pane
                 write_settings ();
             });
 
+            //Make all docs restorable - those of the active project will be loaded later
+            ProjectInfoManager.get_project_info (folder_root).get_open_file_infos ((uri, pos) => {
+                //TODO Make cursor pos restorable
+                Scratch.Services.DocumentManager.get_instance ().make_uri_restorable (folder_root.path, uri);
+            });
             write_settings ();
             add_folder.callback ();
             return Source.REMOVE;

--- a/src/FolderManager/FileView.vala
+++ b/src/FolderManager/FileView.vala
@@ -577,7 +577,10 @@ public class Scratch.FolderManager.FileView : Code.Widgets.SourceList, Code.Pane
 
             folder_root.expanded = expand;
             folder_root.closed.connect (() => {
+                ProjectInfoManager.prepare_close_project (folder_root);
+
                 toplevel_action_group.activate_action (MainWindow.ACTION_CLOSE_PROJECT_DOCS, new Variant.string (folder_root.path));
+
                 root.remove (folder_root);
                 foreach (var child in root.children) {
                     var child_folder = (ProjectFolderItem) child;

--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -56,23 +56,6 @@ namespace Scratch.FolderManager {
             modified_icon = new ThemedIcon ("emblem-git-modified-symbolic");
         }
 
-        private void branch_or_name_changed () {
-            if (monitored_repo != null) {
-                //As SourceList items are not widgets we have to use markup to change appearance of text.
-                if (monitored_repo.head_is_branch) {
-                    markup = "%s\n<span size='small' weight='normal'>%s</span>".printf (
-                        name, monitored_repo.branch_name
-                    );
-                } else { //Distinguish detached heads visually
-                    markup = "%s\n <span size='small' weight='normal' style='italic'>%s</span>".printf (
-                        name, monitored_repo.branch_name
-                    );
-                }
-
-                checkout_local_branch_action.set_state (monitored_repo.branch_name);
-            }
-        }
-
         construct {
             monitored_repo = Scratch.Services.GitManager.get_instance ().add_project (this);
             notify["name"].connect (branch_or_name_changed);
@@ -94,6 +77,23 @@ namespace Scratch.FolderManager {
                 monitored_repo.branch_changed ();
                 checkout_local_branch_action.activate.connect (handle_checkout_local_branch_action);
                 checkout_remote_branch_action.activate.connect (handle_checkout_remote_branch_action);
+            }
+        }
+
+        private void branch_or_name_changed () {
+            if (monitored_repo != null) {
+                //As SourceList items are not widgets we have to use markup to change appearance of text.
+                if (monitored_repo.head_is_branch) {
+                    markup = "%s\n<span size='small' weight='normal'>%s</span>".printf (
+                        name, monitored_repo.branch_name
+                    );
+                } else { //Distinguish detached heads visually
+                    markup = "%s\n <span size='small' weight='normal' style='italic'>%s</span>".printf (
+                        name, monitored_repo.branch_name
+                    );
+                }
+
+                checkout_local_branch_action.set_state (monitored_repo.branch_name);
             }
         }
 

--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -78,6 +78,8 @@ namespace Scratch.FolderManager {
                 checkout_local_branch_action.activate.connect (handle_checkout_local_branch_action);
                 checkout_remote_branch_action.activate.connect (handle_checkout_remote_branch_action);
             }
+
+            ProjectInfoManager.get_project_info (this);
         }
 
         private void branch_or_name_changed () {

--- a/src/FolderManager/ProjectInfoManager.vala
+++ b/src/FolderManager/ProjectInfoManager.vala
@@ -19,7 +19,7 @@ public class Scratch.FolderManager.ProjectInfoManager : Object {
         }
 
         public ProjectFolderItem project { get; construct; }
-        private Settings settings;
+        private Settings project_settings;
 
         public ProjectInfo (ProjectFolderItem project) {
             Object (
@@ -32,7 +32,7 @@ public class Scratch.FolderManager.ProjectInfoManager : Object {
                                 schema_name_from_path (path) +
                                 Path.DIR_SEPARATOR_S;
 
-            settings = new Settings.with_path (
+            project_settings = new Settings.with_path (
                 PROJECT_INFO_SCHEMA_ID,
                 settings_path
             );
@@ -43,31 +43,34 @@ public class Scratch.FolderManager.ProjectInfoManager : Object {
         public void save_doc_info () {
             var doc_manager = Scratch.Services.DocumentManager.get_instance ();
             var vb = new VariantBuilder (new VariantType ("a(si)"));
+            // This will erase any existing open-files setting if history is off
+            if (privacy_settings.get_boolean ("remember-recent-files")) {
+                //NOTE `foreach (var x in y) {}` syntax does not work here!
+                doc_manager.get_open_paths (path).@foreach ((path) => {
+                    //Need to save cursor position in Document Manager
+                    //Default to 0 for now
+                    //Assume path exists for now (do we need check - it might disappear later anyway)
+                    vb.add ("(si)", path, 0);
+                    return true;
+                });
 
-            //NOTE `foreach (var x in y) {}` syntax does not work here!
-            doc_manager.get_open_paths (path).@foreach ((path) => {
-                //Need to save cursor position in Document Manager
-                //Default to 0 for now
-                //Assume path exists for now (do we need check - it might disappear later anyway)
-                vb.add ("(si)", path, 0);
-                return true;
-            });
+                doc_manager.take_restorable_paths (path).@foreach ((path) => {
+                    //Need to save cursor position in Document Manager
+                    //Default to 0 for now
+                    //Assume path exists for now (do we need check - it might disappear later anyway)
+                    vb.add ("(si)", path, 0);
+                    return true;
+                });
+            }
 
-            doc_manager.take_restorable_paths (path).@foreach ((path) => {
-                //Need to save cursor position in Document Manager
-                //Default to 0 for now
-                //Assume path exists for now (do we need check - it might disappear later anyway)
-                vb.add ("(si)", path, 0);
-                return true;
-            });
-
-            this.settings.set_value ("open-files", vb.end ());
+            project_settings.set_value ("open-files", vb.end ());
         }
 
+        //Combine basename and parent folder name and convert to camelcase
         public delegate void OpenFileCallback (string uri, uint pos);
         public void get_open_file_infos (OpenFileCallback cb) {
             if (privacy_settings.get_boolean ("remember-recent-files")) {
-                var doc_infos = this.settings.get_value ("open-files");
+                var doc_infos = project_settings.get_value ("open-files");
                 var doc_info_iter = new VariantIter (doc_infos);
                 //TODO Restore focused doc per project
                 string uri;

--- a/src/FolderManager/ProjectInfoManager.vala
+++ b/src/FolderManager/ProjectInfoManager.vala
@@ -40,6 +40,30 @@ public class Scratch.FolderManager.ProjectInfoManager : Object {
             settings.bind ("expanded", project, "expanded", DEFAULT);
         }
 
+        public void save_doc_info () {
+            var doc_manager = Scratch.Services.DocumentManager.get_instance ();
+            var vb = new VariantBuilder (new VariantType ("a(si)"));
+
+            //NOTE `foreach (var x in y) {}` syntax does not work here!
+            doc_manager.get_open_paths (path).@foreach ((path) => {
+                //Need to save cursor position in Document Manager
+                //Default to 0 for now
+                //Assume path exists for now (do we need check - it might disappear later anyway)
+                vb.add ("(si)", path, 0);
+                return true;
+            });
+
+            doc_manager.take_restorable_paths (path).@foreach ((path) => {
+                //Need to save cursor position in Document Manager
+                //Default to 0 for now
+                //Assume path exists for now (do we need check - it might disappear later anyway)
+                vb.add ("(si)", path, 0);
+                return true;
+            });
+
+            this.settings.set_value ("open-files", vb.end ());
+        }
+
         //Combine basename and parent folder name and convert to camelcase
         private string schema_name_from_path (string path) {
             var dir = Path.get_basename (Path.get_dirname (path)).normalize ();
@@ -66,10 +90,31 @@ public class Scratch.FolderManager.ProjectInfoManager : Object {
 
     //Called when folder created
     public static void get_project_info (ProjectFolderItem project_folder) {
+        //TODO Should we only store info for code (git) projects?
         var info = project_info_map[project_folder.path];
         if (info == null) {
             info = new ProjectInfo (project_folder);
             project_info_map[project_folder.path] = info;
         }
+    }
+
+    //Called when a project closed
+    //We do not bind open doc info so update settings here
+    //TODO closed doc info too?
+    public static void prepare_close_project (ProjectFolderItem project_folder) {
+        var info = project_info_map[project_folder.path];
+        if (info != null) {
+            info.save_doc_info ();
+        }
+
+        //We keep info in case project re-opened
+    }
+
+    public static void prepare_to_quit () {
+        foreach (var info in project_info_map.values) {
+            info.save_doc_info ();
+        }
+
+        //Assume destructor will take care of map when app closes?
     }
 }

--- a/src/FolderManager/ProjectInfoManager.vala
+++ b/src/FolderManager/ProjectInfoManager.vala
@@ -1,0 +1,75 @@
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2026 elementary, Inc. <https://elementary.io>
+ *
+ * Authored by: Jeremy Wootten <jeremywootten@gmail.com>
+ */
+
+// Using static methods unless we find we require singleton
+// We keep a separate list of project infos for future use in e.g. recently closed project list
+// and for re-opening projects without recreating info object
+public class Scratch.FolderManager.ProjectInfoManager : Object {
+    private class ProjectInfo : Object {
+        const string PROJECT_INFO_SCHEMA_ID = "io.elementary.code.Projects";
+        const string PROJECT_INFO_SCHEMA_PATH_PREFIX = "/io/elementary/code/Projects/";
+        public string path {
+            owned get {
+                return project.path;
+            }
+        }
+
+        public ProjectFolderItem project { get; construct; }
+        private Settings settings;
+
+        public ProjectInfo (ProjectFolderItem project) {
+            Object (
+                project: project
+            );
+        }
+
+        construct {
+            var settings_path = PROJECT_INFO_SCHEMA_PATH_PREFIX +
+                                schema_name_from_path (path) +
+                                Path.DIR_SEPARATOR_S;
+
+            settings = new Settings.with_path (
+                PROJECT_INFO_SCHEMA_ID,
+                settings_path
+            );
+
+            settings.bind ("expanded", project, "expanded", DEFAULT);
+        }
+
+        //Combine basename and parent folder name and convert to camelcase
+        private string schema_name_from_path (string path) {
+            var dir = Path.get_basename (Path.get_dirname (path)).normalize ();
+            var basename = Path.get_basename (path).normalize ();
+            var name = dir.substring (0, 1).up () +
+                       dir.substring (1, -1).down () +
+                       basename.substring (0, 1).up () +
+                       basename.substring (1, -1).down ();
+
+            return name;
+        }
+    }
+
+    private static Gee.HashMap<string, ProjectInfo>? map = null;
+    private static Gee.HashMap<string, ProjectInfo> project_info_map {
+        get {
+            if (map == null) {
+                map = new Gee.HashMap<string, ProjectInfo> ();
+            }
+
+            return map;
+        }
+    }
+
+    //Called when folder created
+    public static void get_project_info (ProjectFolderItem project_folder) {
+        var info = project_info_map[project_folder.path];
+        if (info == null) {
+            info = new ProjectInfo (project_folder);
+            project_info_map[project_folder.path] = info;
+        }
+    }
+}

--- a/src/FolderManager/ProjectInfoManager.vala
+++ b/src/FolderManager/ProjectInfoManager.vala
@@ -36,8 +36,6 @@ public class Scratch.FolderManager.ProjectInfoManager : Object {
                 PROJECT_INFO_SCHEMA_ID,
                 settings_path
             );
-
-            settings.bind ("expanded", project, "expanded", DEFAULT);
         }
 
         public void save_doc_info () {

--- a/src/FolderManager/ProjectInfoManager.vala
+++ b/src/FolderManager/ProjectInfoManager.vala
@@ -9,7 +9,7 @@
 // We keep a separate list of project infos for future use in e.g. recently closed project list
 // and for re-opening projects without recreating info object
 public class Scratch.FolderManager.ProjectInfoManager : Object {
-    private class ProjectInfo : Object {
+    public class ProjectInfo : Object {
         const string PROJECT_INFO_SCHEMA_ID = "io.elementary.code.Projects";
         const string PROJECT_INFO_SCHEMA_PATH_PREFIX = "/io/elementary/code/Projects/";
         public string path {
@@ -64,6 +64,20 @@ public class Scratch.FolderManager.ProjectInfoManager : Object {
             this.settings.set_value ("open-files", vb.end ());
         }
 
+        public delegate void OpenFileCallback (string uri, uint pos);
+        public void get_open_file_infos (OpenFileCallback cb) {
+            if (privacy_settings.get_boolean ("remember-recent-files")) {
+                var doc_infos = this.settings.get_value ("open-files");
+                var doc_info_iter = new VariantIter (doc_infos);
+                //TODO Restore focused doc per project
+                string uri;
+                int pos;
+                while (doc_info_iter.next ("(si)", out uri, out pos)) {
+                    cb (uri, pos);
+                }
+            }
+        }
+
         //Combine basename and parent folder name and convert to camelcase
         private string schema_name_from_path (string path) {
             var dir = Path.get_basename (Path.get_dirname (path)).normalize ();
@@ -89,13 +103,15 @@ public class Scratch.FolderManager.ProjectInfoManager : Object {
     }
 
     //Called when folder created
-    public static void get_project_info (ProjectFolderItem project_folder) {
+    public static ProjectInfo get_project_info (ProjectFolderItem project_folder) {
         //TODO Should we only store info for code (git) projects?
         var info = project_info_map[project_folder.path];
         if (info == null) {
             info = new ProjectInfo (project_folder);
             project_info_map[project_folder.path] = info;
         }
+
+        return info;
     }
 
     //Called when a project closed

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -870,6 +870,7 @@ namespace Scratch {
         // For exit cleanup
         private void handle_quit () {
             document_view.save_opened_files ();
+            Scratch.FolderManager.ProjectInfoManager.prepare_to_quit ();
             update_saved_state ();
         }
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -649,54 +649,6 @@ namespace Scratch {
             }
         }
 
-        private async void restore_opened_documents () {
-            File? focused_file = null;
-            if (privacy_settings.get_boolean ("remember-recent-files")) {
-                var doc_infos = settings.get_value ("opened-files");
-                var doc_info_iter = new VariantIter (doc_infos);
-                string focused_uri = settings.get_string ("focused-document");
-                string uri;
-                int pos;
-                bool was_restore_overriden = false;
-                while (doc_info_iter.next ("(si)", out uri, out pos)) {
-                   if (uri != "") {
-                        GLib.File file;
-                        if (Uri.parse_scheme (uri) != null) {
-                            file = File.new_for_uri (uri);
-                        } else {
-                            file = File.new_for_commandline_arg (uri);
-                        }
-                        /* Leave it to doc to handle problematic files properly
-                           But for files that do not exist we need to make sure that doc won't create a new file
-                        */
-                        if (file.query_exists ()) {
-                            var is_focused = uri == focused_uri;
-                            if (is_focused) {
-                                focused_file = file;
-                            }
-                            //TODO Check files valid (settings could have been manually altered)
-                            var doc = new Scratch.Services.Document (actions, file);
-                            if (doc.exists () || !doc.is_file_temporary) {
-                                if (restore_override != null && (file.get_path () == restore_override.file.get_path ())) {
-                                    yield open_document_at_selected_range (doc, true, restore_override.range, true);
-                                    was_restore_overriden = true;
-                                } else {
-                                    yield open_document (doc, was_restore_overriden ? false : is_focused, pos);
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            document_view.request_placeholder_if_empty ();
-            document_view.update_outline_visible ();
-            restore_override = null;
-            if (focused_file != null) {
-                folder_manager_view.expand_to_path (focused_file.get_path ());
-            }
-        }
-
         private bool on_key_pressed (uint keyval, uint keycode, Gdk.ModifierType state) {
             switch (Gdk.keyval_name (keyval)) {
                 case "Escape":
@@ -818,12 +770,10 @@ namespace Scratch {
              // Plugin panes size
              hp1.set_position (Scratch.saved_state.get_int ("hp1-size"));
              vp.set_position (Scratch.saved_state.get_int ("vp-size"));
-            // Ensure foldermanager finishes loading projects before start opening documents
             folder_manager_view.restore_saved_state.begin ((obj, res) => {
                 folder_manager_view.restore_saved_state.end (res);
-                if (restore_docs) {
-                    restore_opened_documents.begin ();
-                }
+                document_view.request_placeholder_if_empty ();
+                document_view.update_outline_visible ();
             });
         }
 
@@ -1457,7 +1407,7 @@ namespace Scratch {
             var project_path = param.get_string ();
             if (folder_manager_view.project_is_open (project_path)) {
                 git_manager.active_project_path = project_path;
-                folder_manager_view.collapse_other_projects ();
+                folder_manager_view.collapse_other_projects (); // triggers restoring project doc action
                 //The opened folders are not changed so no need to update "opened-folders" setting
             } else {
                 warning ("Attempt to set folder path %s which is not opened as active project ignored", project_path);

--- a/src/Services/DocumentManager.vala
+++ b/src/Services/DocumentManager.vala
@@ -37,7 +37,11 @@
     }
 
     public void make_restorable (Document doc) {
-        project_restorable_docs_map.@set (doc.source_view.project.path, doc.file.get_path ());
+        make_uri_restorable (doc.source_view.project.path, doc.file.get_path ());
+    }
+
+    public void make_uri_restorable (string project_path, string uri) {
+        project_restorable_docs_map.@set (project_path, uri);
     }
 
     public void add_open_document (Document doc) {

--- a/src/Services/DocumentManager.vala
+++ b/src/Services/DocumentManager.vala
@@ -66,6 +66,11 @@
         return docs;
     }
 
+    public Gee.Collection<string> get_open_paths (string project_path) {
+        var docs = project_open_docs_map.@get (project_path);
+        return docs;
+    }
+
     public uint restorable_for_project (string project_path) {
         return project_restorable_docs_map.@get (project_path).size;
     }

--- a/src/Services/LocationJumpManager.vala
+++ b/src/Services/LocationJumpManager.vala
@@ -1,6 +1,6 @@
-/*  
- * SPDX-License-Identifier: GPL-3.0-or-later  
- * SPDX-FileCopyrightText: 2023 elementary, Inc. <https://elementary.io>  
+/*
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2023 elementary, Inc. <https://elementary.io>
  *
  * Authored by: Colin Kiama <colinkiama@gmail.com>
  */

--- a/src/Widgets/DocumentView.vala
+++ b/src/Widgets/DocumentView.vala
@@ -329,42 +329,47 @@ public class Scratch.Widgets.DocumentView : Gtk.Box {
             }
 
             if (nth_doc.file != null && nth_doc.file.get_uri () == doc.file.get_uri ()) {
-                if (focus) {
-                    current_document = nth_doc;
-                }
+                after_insert_document (nth_doc, focus, cursor_position, range);
 
-                debug ("This Document was already opened! Not opening a duplicate!");
-                if (range != SelectionRange.EMPTY) {
-                    Idle.add_full (GLib.Priority.LOW, () => { // This helps ensures new tab is drawn before opening document.
-                        current_document.source_view.select_range (range);
-                        save_opened_files ();
-
-                        return false;
-                    });
-                }
 
                 return;
             }
         }
 
         insert_document (doc, (int) docs.length ());
+        yield doc.open (false);
+        after_insert_document (doc, focus, cursor_position, range);
+    }
+
+    private void after_insert_document (Scratch.Services.Document doc, bool focus = true, int cursor_position = 0, SelectionRange range = SelectionRange.EMPTY) {
+        warning ("after insert doc %s", doc.file.get_path ());
         if (focus) {
             current_document = doc;
-        }
-
-        yield doc.open (false);
-
-        if (focus && doc == current_document) {
             doc.focus ();
         }
 
         if (range != SelectionRange.EMPTY) {
             doc.source_view.select_range (range);
+            // It is recommended to run scroll to mark in a low priority idle otherwise may not work
+            Idle.add_full (Priority.LOW, () => {
+                warning ("scroll to insert mark");
+                doc.source_view.scroll_to_mark (doc.source_view.buffer.get_insert (), 0.1, true, 0.5, 0.5);
+                return Source.REMOVE;
+            });
         } else if (cursor_position > 0) {
+            warning ("set cursor at %i", cursor_position);
             doc.source_view.cursor_position = cursor_position;
         }
 
+        if (Scratch.saved_state.get_boolean ("outline-visible")) {
+            debug ("setting outline visible");
+            doc.show_outline (true);
+        }
+
         save_opened_files ();
+
+
+
     }
 
     public void next_document () {
@@ -437,10 +442,7 @@ public class Scratch.Widgets.DocumentView : Gtk.Box {
 
     private void insert_document (Scratch.Services.Document doc, int pos) {
         tab_view.insert (doc, pos);
-        if (Scratch.saved_state.get_boolean ("outline-visible")) {
-            debug ("setting outline visible");
-            doc.show_outline (true);
-        }
+        after_insert_document (doc, true, pos);
     }
 
     private string unsaved_file_path_builder (string extension = "txt") {

--- a/src/meson.build
+++ b/src/meson.build
@@ -31,6 +31,7 @@ code_files = files(
     'FolderManager/FolderItem.vala',
     'FolderManager/Item.vala',
     'FolderManager/ProjectFolderItem.vala',
+    'FolderManager/ProjectInfoManager.vala',
     'Services/CommentToggler.vala',
     'Services/Document.vala',
     'Services/DocumentManager.vala',


### PR DESCRIPTION
Based off #1700 

Fixes #967 

 - Saves and restores list of  in use (open or hidden)  documents for each project open in the sidebar
 - Provision to also store cursor position for each document (to be implemented)
 - Moves the responsibility for restoring project docs out of MainWindow and into FileView.
 - Setting the active project determines which documents are actually opened.