### PR TITLE
Use user accent for selection background

### DIFF
--- a/data/styles/elementary-dark.xml
+++ b/data/styles/elementary-dark.xml
@@ -26,7 +26,7 @@
 
   <!-- Global Settings -->
   <style name="text"                        foreground="fg-0" background="bg-2"/>
-  <style name="selection"                   foreground="fg-1" background="bg-4"/>
+  <style name="selection"                   foreground="fg-1"/><!-- The user accent color is used for background -->
   <style name="cursor"                      foreground="fg-0"/>
   <style name="secondary-cursor"            foreground="fg-1"/>
   <style name="current-line"                background="bg-1"/>

--- a/data/styles/elementary-highcontrast-light.xml
+++ b/data/styles/elementary-highcontrast-light.xml
@@ -34,7 +34,7 @@
 
   <!-- Global Settings -->
   <style name="text"                        foreground="fg-0" background="bg-2"/>
-  <style name="selection"                   background="latte"/>
+  <style name="selection"                   foreground="fg-0"/> <!-- The user accent color is used for background -->
   <style name="cursor"                      foreground="fg-0"/>
   <style name="secondary-cursor"            foreground="fg-1"/>
   <style name="current-line"                background="bg-1"/>

--- a/data/styles/elementary-light.xml
+++ b/data/styles/elementary-light.xml
@@ -26,7 +26,7 @@
 
   <!-- Global Settings -->
   <style name="text"                        foreground="fg-0" background="bg-1"/>
-  <style name="selection"                   foreground="fg-1" background="bg-4"/>
+  <style name="selection"                   foreground="fg-1"/> <!-- The user accent color is used for background -->
   <style name="cursor"                      foreground="fg-0"/>
   <style name="secondary-cursor"            foreground="fg-1"/>
   <style name="current-line"                background="bg-2"/>


### PR DESCRIPTION
Fixes #1289

The provided user accent colors contrast better with text and hightlight styles than the present hard-coded colors.  Also the user has control over them and it improves consistency with selections elsewhere in the app and other apps.

Gtk already uses the accent color for selections by default so we just stop overriding it.