### PR TITLE
NavMarkGutterRenderer: fix crash when deleting edit marks

### DIFF
--- a/src/Widgets/NavMarkGutterRenderer.vala
+++ b/src/Widgets/NavMarkGutterRenderer.vala
@@ -33,7 +33,6 @@ public class Scratch.Widgets.NavMarkGutterRenderer : Gtk.SourceGutterRendererPix
     }
 
     public void remove_mark (Gtk.TextMark mark) {
-        buffer.delete_mark (mark);
         mark_list.remove (mark);
         purge_and_sort_mark_list ();
     }


### PR DESCRIPTION
Fixes #1681

When `remove_mark()` was called, it explicitly called 
`buffer.delete_mark()` on the mark. However, the `mark-deleted` 
signal is emitted by GTK after the mark is already deleted from 
the buffer — meaning `remove_mark()` was attempting to delete an 
already-invalid mark, causing a segfault.

Removed the redundant `buffer.delete_mark()` call from 
`remove_mark()` in `NavMarkGutterRenderer.vala`.

Tested locally using GDB — reproduced the crash and confirmed 
the fix prevents it. The backtrace shows `gtk_text_buffer_delete_mark` 
appearing twice in the call stack, confirming the double-delete.