### PR TITLE
Gtk4 prep: Avoid using focus event

### DIFF
--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -256,24 +256,17 @@ namespace Scratch.Services {
 
             this.source_view.buffer.create_tag ("highlight_search_all", "background", "yellow", null);
 
-            // Focus in event for SourceView
-            // Check if file changed externally or permissions changed
-            this.source_view.focus_in_event.connect (() => {
-                if (!locked && !is_file_temporary) {
-                    check_undoable_actions ();
-                    check_file_status.begin ();
+            this.source_view.notify["is-focus"].connect (() => {
+                if (source_view.is_focus) {
+                    if (!locked && !is_file_temporary) {
+                        check_undoable_actions ();
+                        check_file_status.begin ();
+                    }
+                } else {
+                    if (!locked && Scratch.settings.get_boolean ("autosave")) {
+                        save_with_hold.begin ();
+                    }
                 }
-
-                return false;
-            });
-
-            // Focus out event for SourceView
-            this.source_view.focus_out_event.connect (() => {
-                if (!locked && Scratch.settings.get_boolean ("autosave")) {
-                    save_with_hold.begin ();
-                }
-
-                return false;
             });
 
             source_view.buffer.changed.connect (() => {

--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -257,15 +257,14 @@ namespace Scratch.Services {
             this.source_view.buffer.create_tag ("highlight_search_all", "background", "yellow", null);
 
             this.source_view.notify["is-focus"].connect (() => {
+                return_if_fail (!locked);
                 if (source_view.is_focus) {
-                    if (!locked && !is_file_temporary) {
+                    if (!is_file_temporary) {
                         check_undoable_actions ();
                         check_file_status.begin ();
                     }
-                } else {
-                    if (!locked && Scratch.settings.get_boolean ("autosave")) {
+                } else if (Scratch.settings.get_boolean ("autosave")) {
                         save_with_hold.begin ();
-                    }
                 }
             });
 

--- a/src/Widgets/SearchBar.vala
+++ b/src/Widgets/SearchBar.vala
@@ -227,7 +227,11 @@ namespace Scratch.Widgets {
             // Connecting to some signals
             search_entry.changed.connect (on_search_parameters_changed);
             search_entry.key_press_event.connect (on_search_entry_key_press);
-            search_entry.focus_in_event.connect (on_search_entry_focused_in);
+            search_entry.notify["is-focus"].connect (() => {
+                if (search_entry.is_focus) {
+                    on_search_entry_focused_in ();
+                }
+            });
             search_entry.icon_release.connect ((p0, p1) => {
                 if (p0 == Gtk.EntryIconPosition.PRIMARY) {
                     search_next ();
@@ -359,18 +363,12 @@ namespace Scratch.Widgets {
             update_search_widgets ();
         }
 
-        private bool on_search_entry_focused_in (Gdk.EventFocus event) {
-            if (text_buffer == null) {
-                return false;
-            }
-
+        private void on_search_entry_focused_in () requires (text_buffer != null) {
             Idle.add (() => {
                 update_search_widgets ();
                 search_entry.select_region (0, -1);
                 return Source.REMOVE;
             });
-
-            return Gdk.EVENT_PROPAGATE;
         }
 
         public bool search () {

--- a/src/Widgets/SearchBar.vala
+++ b/src/Widgets/SearchBar.vala
@@ -228,8 +228,12 @@ namespace Scratch.Widgets {
             search_entry.changed.connect (on_search_parameters_changed);
             search_entry.key_press_event.connect (on_search_entry_key_press);
             search_entry.notify["is-focus"].connect (() => {
-                if (search_entry.is_focus) {
-                    on_search_entry_focused_in ();
+                if (search_entry.is_focus && text_buffer != null) {
+                    Idle.add (() => {
+                        update_search_widgets ();
+                        search_entry.select_region (0, -1);
+                        return Source.REMOVE;
+                    });
                 }
             });
             search_entry.icon_release.connect ((p0, p1) => {
@@ -361,14 +365,6 @@ namespace Scratch.Widgets {
             }
 
             update_search_widgets ();
-        }
-
-        private void on_search_entry_focused_in () requires (text_buffer != null) {
-            Idle.add (() => {
-                update_search_widgets ();
-                search_entry.select_region (0, -1);
-                return Source.REMOVE;
-            });
         }
 
         public bool search () {


### PR DESCRIPTION
In these cases, it is sufficient to listen to changes to the "in-focus" property of the widget (there are no focusable child widgets). This code should compile in Gtk4 without change.
