### PR TITLE
Use system font default false

### DIFF
--- a/data/io.elementary.code.gschema.xml
+++ b/data/io.elementary.code.gschema.xml
@@ -143,7 +143,7 @@
       <description>Specifies the number of spaces that should be displayed instead of Tab characters.</description>
     </key>
     <key name="use-system-font" type="b">
-      <default>true</default>
+      <default>false</default>
       <summary>Use system font</summary>
       <description>Whether Code should use the default system font</description>
     </key>


### PR DESCRIPTION
Fixes #1750 (?)

Alternative to #1752  The default app `font` setting is a hardcoded monospace font (but not necessarily the system monospace font)