### PR TITLE
Use monospace not document font

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -29,7 +29,6 @@ namespace Scratch {
     public class Application : Gtk.Application {
         public string data_home_folder_unsaved { get { return _data_home_folder_unsaved; } }
         public string system_monospace_font { get; set; }
-        public string system_document_font { get; set; }
         public bool is_running_in_flatpak { get; construct; }
 
         private static string _data_home_folder_unsaved;
@@ -72,7 +71,6 @@ namespace Scratch {
             service_settings = new GLib.Settings (Constants.PROJECT_NAME + ".services");
             privacy_settings = new GLib.Settings ("org.gnome.desktop.privacy");
             var desktop_interface_settings = new GLib.Settings ("org.gnome.desktop.interface");
-            desktop_interface_settings.bind ("document-font-name", this, "system-document-font", GET);
             desktop_interface_settings.bind ("monospace-font-name", this, "system-monospace-font", GET);
 
             location_jump_manager = new LocationJumpManager ();

--- a/src/Dialogs/PreferencesDialog.vala
+++ b/src/Dialogs/PreferencesDialog.vala
@@ -125,7 +125,7 @@ public class Scratch.Dialogs.Preferences : Granite.Dialog {
 
         var application = ((Scratch.Application) (GLib.Application.get_default ()));
         var font_switch = new SettingSwitch (
-            _("Use system font (%s)").printf (application.system_document_font),
+            _("Use system font (%s)").printf (application.system_monospace_font),
             "use-system-font"
         );
         // We assume the system font will not change while dialog open

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -932,13 +932,13 @@ namespace Scratch {
         }
 
         public string get_default_font () {
-            string font = app.system_document_font;
+            string font = app.system_monospace_font;
             string font_family = font.substring (0, font.last_index_of (" "));
             return font_family;
         }
 
         public double get_default_font_size () {
-            string font = app.system_document_font;
+            string font = app.system_monospace_font;
             string font_size = font.substring (font.last_index_of (" ") + 1);
             return double.parse (font_size);
         }

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -205,7 +205,7 @@ namespace Scratch.Widgets {
                 }
             });
 
-            application.notify["system-document-font"].connect (() => {
+            application.notify["system-monospace-font"].connect (() => {
                 if (Scratch.settings.get_boolean ("use-system-font")) {
                     update_font ();
                 }
@@ -307,7 +307,7 @@ namespace Scratch.Widgets {
 
         private void update_font () {
             if (Scratch.settings.get_boolean ("use-system-font")) {
-                font = application.system_document_font;
+                font = application.system_monospace_font;
             } else {
                 font = Scratch.settings.get_string ("font");
             }


### PR DESCRIPTION
Fxes #1750 

The system monospace font is used.  It is still possible to pick a non monospace from the font list if the user requires it.