### PR TITLE
Gtk4Prep: Replace expand property with hexpand and vexpand

### DIFF
--- a/plugins/fuzzy-search/fuzzy-search-popover.vala
+++ b/plugins/fuzzy-search/fuzzy-search-popover.vala
@@ -234,7 +234,7 @@ public class Scratch.FuzzySearchPopover : Gtk.Popover {
 
         scrolled = new Gtk.ScrolledWindow (null, null) {
             propagate_natural_height = true,
-            hexpand = true,
+            hexpand = true
         };
 
         scrolled.add (search_result_container);

--- a/plugins/pastebin/pastebin_dialog.vala
+++ b/plugins/pastebin/pastebin_dialog.vala
@@ -376,7 +376,8 @@ namespace Scratch.Dialogs {
             var languages_scrolled = new Gtk.ScrolledWindow (null, null) {
                 hscrollbar_policy = Gtk.PolicyType.NEVER,
                 height_request = 250,
-                expand = true
+                hexpand = true,
+                vexpand = true
             };
             languages_scrolled.add (languages_listbox);
 

--- a/src/FolderManager/FileView.vala
+++ b/src/FolderManager/FileView.vala
@@ -11,7 +11,7 @@
  * but WITHOUT ANY WARRANTY; without even the implied warranties of
  * MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
  * PURPOSE. See the GNU General Public License for more details.
- 
+
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  *

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -532,7 +532,8 @@ namespace Scratch {
             view_grid.add (document_view);
 
             content_stack = new Gtk.Stack () {
-                expand = true,
+                hexpand = true,
+                vexpand = true,
                 width_request = 200
             };
 

--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -220,7 +220,8 @@ namespace Scratch.Services {
             source_view = new Scratch.Widgets.SourceView ();
 
             scroll = new Gtk.ScrolledWindow (null, null) {
-                expand = true
+                hexpand = true,
+                vexpand = true
             };
             scroll.add (source_view);
             source_file = new Gtk.SourceFile ();

--- a/src/Widgets/ChooseProjectButton.vala
+++ b/src/Widgets/ChooseProjectButton.vala
@@ -80,7 +80,8 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
 
         var project_scrolled = new Gtk.ScrolledWindow (null, null) {
             hscrollbar_policy = Gtk.PolicyType.NEVER,
-            expand = true,
+            hexpand = true,
+            vexpand = true,
             margin_top = 3,
             margin_bottom = 3,
             max_content_height = 350,

--- a/src/Widgets/SourceList/SourceList.vala
+++ b/src/Widgets/SourceList/SourceList.vala
@@ -1645,7 +1645,8 @@ public class SourceList : Gtk.ScrolledWindow {
             set_model (data_model);
 
             halign = valign = Gtk.Align.FILL;
-            expand = true;
+            hexpand = true;
+            vexpand = true;
 
             enable_search = false;
             headers_visible = false;

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -89,7 +89,8 @@ namespace Scratch.Widgets {
             application = (Scratch.Application) (GLib.Application.get_default ());
             space_drawer.enable_matrix = true;
 
-            expand = true;
+            hexpand = true;
+            vexpand = true;
             manager = Gtk.SourceLanguageManager.get_default ();
             style_scheme_manager = new Gtk.SourceStyleSchemeManager ();
 


### PR DESCRIPTION
'expand' property no longer exists in Gtk4