### PR TITLE
Gtk4Prep: Sidebar stack - do not use deprecated signal

### DIFF
--- a/src/Widgets/Sidebar.vala
+++ b/src/Widgets/Sidebar.vala
@@ -124,19 +124,6 @@ public class Code.Sidebar : Gtk.Grid {
             stack.show_all ();
         });
 
-        stack.remove.connect (() => {
-            switch (stack.get_children ().length ()) {
-                case 0:
-                    stack.no_show_all = true;
-                    stack.hide ();
-                    break;
-                case 1:
-                    stack_switcher.no_show_all = true;
-                    stack_switcher.hide ();
-                    break;
-            }
-        });
-
         Gtk.TargetEntry uris = {"text/uri-list", 0, TargetType.URI_LIST};
         Gtk.drag_dest_set (this, Gtk.DestDefaults.ALL, {uris}, Gdk.DragAction.COPY);
         drag_data_received.connect (drag_received);
@@ -190,6 +177,16 @@ public class Code.Sidebar : Gtk.Grid {
 
     public void remove_tab (Code.PaneSwitcher tab) {
         stack.remove (tab);
+        switch (stack.get_children ().length ()) {
+            case 0:
+                stack.no_show_all = true;
+                stack.hide ();
+                break;
+            case 1:
+                stack_switcher.no_show_all = true;
+                stack_switcher.hide ();
+                break;
+        }
     }
 
     public void notify_cloning_success () {


### PR DESCRIPTION
Stack.remove signal does not exist in Gtk4 and we can execute the handler commands in the `remove_tab` function of Sidebar anyway.

At the moment we only use one sidebar tab and there are no no immediate plans to add anymore (The extra tab used to be used for the symbol pane) so we could remove the stack and switcher altogether.  However, the functionality could be useful in future for some git related or other functions which do not need to be continually shown so leaving in place for now. 
