### PR TITLE
Gtk4Prep: Replace dialog.run () and dialog.present () where simple

### DIFF
--- a/plugins/spell/spell.vala
+++ b/plugins/spell/spell.vala
@@ -72,18 +72,21 @@ public class Scratch.Plugins.Spell: Peas.ExtensionBase, Scratch.Services.Activat
                     }
 
                     if (language_list.length () == 0) {
+                        // This fallback to the LC used but might fail.
+                        spell.set_language (null);
+
                         var dialog = new Granite.MessageDialog (
                             _("No Suitable Dictionaries Were Found"),
                             _("Please install at least one [aspell] dictionary."),
                             new ThemedIcon ("dialog-warning"),
                             Gtk.ButtonsType.CLOSE
                         );
-                        dialog.run ();
-                        dialog.destroy ();
-
-                        // This fallback to the LC used but might fail.
-                        spell.set_language (null);
-
+                        dialog.response.connect (() => {
+                            dialog.destroy ();
+                        });
+                        // The following code does not depend on the dialog response
+                        //so we can just show the dialog
+                        dialog.show ();
                     } else if (!exist_language) {
                         this.lang_dict = language_list.first ().data;
                         spell.set_language (lang_dict);

--- a/src/Dialogs/BranchActions/BranchActionDialog.vala
+++ b/src/Dialogs/BranchActions/BranchActionDialog.vala
@@ -49,7 +49,8 @@ public class Scratch.Dialogs.BranchActionDialog : Granite.MessageDialog {
 
     public BranchActionDialog (FolderManager.ProjectFolderItem project) {
         Object (
-            project: project
+            project: project,
+            modal: true
         );
     }
 

--- a/src/Dialogs/CloneRepositoryDialog.vala
+++ b/src/Dialogs/CloneRepositoryDialog.vala
@@ -41,7 +41,8 @@ public class Scratch.Dialogs.CloneRepositoryDialog : Granite.MessageDialog {
     public CloneRepositoryDialog (string _suggested_local_folder, string _suggested_remote) {
         Object (
             suggested_local_folder: _suggested_local_folder,
-            suggested_remote: _suggested_remote
+            suggested_remote: _suggested_remote,
+            modal: true
         );
     }
 
@@ -49,7 +50,6 @@ public class Scratch.Dialogs.CloneRepositoryDialog : Granite.MessageDialog {
         transient_for = ((Gtk.Application)(GLib.Application.get_default ())).get_active_window ();
         image_icon = new ThemedIcon ("git");
         badge_icon = new ThemedIcon ("emblem-downloads");
-        modal = true;
 
         ///TRANSLATORS "Git" is a proper name and must not be translated
         primary_text = _("Create a local clone of a Git repository");

--- a/src/Dialogs/CloseProjectsConfirmationDialog.vala
+++ b/src/Dialogs/CloseProjectsConfirmationDialog.vala
@@ -26,7 +26,8 @@ public class Scratch.Dialogs.CloseProjectsConfirmationDialog : Granite.MessageDi
             buttons: Gtk.ButtonsType.NONE,
             transient_for: parent,
             n_parents: n_parents,
-            n_children: n_children
+            n_children: n_children,
+            modal: true
         );
     }
 

--- a/src/Dialogs/GlobalSearchDialog.vala
+++ b/src/Dialogs/GlobalSearchDialog.vala
@@ -44,7 +44,8 @@ public class Scratch.Dialogs.GlobalSearchDialog : Granite.MessageDialog {
             is_repo: is_repo,
             case_sensitive: case_sensitive,
             wholeword: wholeword,
-            use_regex: use_regex
+            use_regex: use_regex,
+            modal: true
         );
     }
 

--- a/src/Dialogs/OverwriteUncommittedConfirmationDialog.vala
+++ b/src/Dialogs/OverwriteUncommittedConfirmationDialog.vala
@@ -27,14 +27,14 @@ public class Scratch.Dialogs.OverwriteUncommittedConfirmationDialog : Granite.Me
         Object (
             buttons: Gtk.ButtonsType.NONE,
             transient_for: parent,
-            branch_name: new_branch_name
+            branch_name: new_branch_name,
+            modal: true
         );
 
         show_error_details (details);
     }
 
     construct {
-        modal = true;
         image_icon = new ThemedIcon ("dialog-warning");
 
         primary_text = _("There are uncommitted changes in the current branch");

--- a/src/Dialogs/RestoreConfirmationDialog.vala
+++ b/src/Dialogs/RestoreConfirmationDialog.vala
@@ -21,7 +21,8 @@ public class Scratch.Dialogs.RestoreConfirmationDialog : Granite.MessageDialog {
     public RestoreConfirmationDialog (MainWindow parent) {
         Object (
             buttons: Gtk.ButtonsType.NONE,
-            transient_for: parent
+            transient_for: parent,
+            modal: true
         );
     }
 

--- a/src/FolderManager/FileView.vala
+++ b/src/FolderManager/FileView.vala
@@ -511,14 +511,18 @@ public class Scratch.FolderManager.FileView : Code.Widgets.SourceList, Code.Pane
         var dialog = new Gtk.AppChooserDialog (new Gtk.Window (), Gtk.DialogFlags.MODAL, file);
         dialog.deletable = false;
 
-        if (dialog.run () == Gtk.ResponseType.OK) {
-            var app_info = dialog.get_app_info ();
-            if (app_info != null) {
-                Utils.launch_app_with_file (app_info.get_id (), path);
+        dialog.response.connect ((res) => {
+            if (res == Gtk.ResponseType.OK) {
+                var app_info = dialog.get_app_info ();
+                if (app_info != null) {
+                    Utils.launch_app_with_file (app_info.get_id (), path);
+                }
             }
-        }
 
-        dialog.destroy ();
+            dialog.destroy ();
+        });
+
+        dialog.show ();
     }
 
     private void action_execute_contract_with_file_path (SimpleAction action, Variant? param) {

--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -397,13 +397,14 @@ namespace Scratch.FolderManager {
                     new ThemedIcon ("git"),
                     Gtk.ButtonsType.CLOSE
                 ) {
-                    badge_icon = new ThemedIcon ("dialog-error")
+                    badge_icon = new ThemedIcon ("dialog-error"),
+                    modal = true
                 };
                 dialog.transient_for = (Gtk.Window)(view.get_toplevel ());
                 dialog.response.connect (() => {
                     dialog.destroy ();
                 });
-                dialog.run ();
+                dialog.show ();
             }
         }
 

--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -1095,8 +1095,8 @@ namespace Scratch.Services {
                     new ThemedIcon ("dialog-warning"),
                     Gtk.ButtonsType.NONE
                 ) {
-                transient_for = app_instance.active_window
-
+                transient_for = app_instance.active_window,
+                modal = true
             };
 
             dialog.add_button (_("Continue"), Gtk.ResponseType.REJECT);
@@ -1154,7 +1154,7 @@ namespace Scratch.Services {
                 });
             });
 
-            dialog.present ();
+            dialog.show ();
         }
         // Set Undo/Redo action sensitive property
         public void check_undoable_actions () {

--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -1044,7 +1044,8 @@ namespace Scratch.Services {
                 Gtk.ButtonsType.NONE
             ) {
                 badge_icon = new ThemedIcon ("dialog-question"),
-                transient_for = app_instance.active_window
+                transient_for = app_instance.active_window,
+                modal = true
             };
 
             dialog.add_button (_("Ignore"), Gtk.ResponseType.REJECT);
@@ -1077,7 +1078,7 @@ namespace Scratch.Services {
                 });
             });
 
-            dialog.present ();
+            dialog.show ();
         }
 
         private void ask_external_changes (

--- a/src/Services/MonitoredRepository.vala
+++ b/src/Services/MonitoredRepository.vala
@@ -259,7 +259,7 @@ namespace Scratch.Services {
                 };
 
                 dialog.response.connect (() => {dialog.destroy ();});
-                dialog.present ();
+                dialog.show ();
                 return false;
             }
 
@@ -313,7 +313,9 @@ namespace Scratch.Services {
                     parent,
                     new_branch_name,
                     project_diff
-                );
+                ) {
+                    modal = true
+                };
                 dialog.response.connect ((res) => {
                     dialog.destroy ();
                     if (res == Gtk.ResponseType.ACCEPT) {
@@ -321,8 +323,7 @@ namespace Scratch.Services {
                     }
                 });
 
-                dialog.present ();
-
+                dialog.show ();
                 return false;
             }
 
@@ -342,10 +343,12 @@ namespace Scratch.Services {
                     _("An error occurred while checking out the requested branch"),
                     e.message,
                     "dialog-warning"
-                );
+                ) {
+                    modal = true
+                };
 
                 dialog.response.connect (dialog.destroy);
-                dialog.present ();
+                dialog.show ();
                 return false;
             }
 


### PR DESCRIPTION
In these cases the code following the dialog is either a return or does not depend on the dialog response so we can just use dialog.show ().  The dialogs are made explicitly modal where needed.