### PR TITLE
Gtk4Prep: Do not use Window.get_size ()

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -541,12 +541,8 @@ namespace Scratch {
             content_stack.add (welcome_view);
             content_stack.visible_child = view_grid; // Must be visible while restoring
 
-            // Set a proper position for ThinPaned widgets
-            int width, height;
-            get_size (out width, out height);
-
+            // The pane position is restored from settings
             vp = new Gtk.Paned (Gtk.Orientation.VERTICAL);
-            vp.position = (height - 150);
             vp.pack1 (content_stack, true, false);
             vp.pack2 (terminal, false, false);
 


### PR DESCRIPTION
Window.get_size () does not exist in Gtk4. 

It is not necessary to set the vertical pane position on creation as it is later restored from settings. 