### PR TITLE
Gtk4Prep: Update ScrolledWindow syntax

### DIFF
--- a/plugins/fuzzy-search/fuzzy-search-popover.vala
+++ b/plugins/fuzzy-search/fuzzy-search-popover.vala
@@ -234,10 +234,9 @@ public class Scratch.FuzzySearchPopover : Gtk.Popover {
 
         scrolled = new Gtk.ScrolledWindow (null, null) {
             propagate_natural_height = true,
-            hexpand = true
+            hexpand = true,
+            child = search_result_container
         };
-
-        scrolled.add (search_result_container);
 
         var box = new Gtk.Box (Gtk.Orientation.VERTICAL, 0);
         box.pack_start (entry_layout, false, false);

--- a/plugins/pastebin/pastebin_dialog.vala
+++ b/plugins/pastebin/pastebin_dialog.vala
@@ -379,9 +379,9 @@ namespace Scratch.Dialogs {
                 hscrollbar_policy = Gtk.PolicyType.NEVER,
                 height_request = 250,
                 hexpand = true,
-                vexpand = true
+                vexpand = true,
+                child = languages_listbox
             };
-            languages_scrolled.add (languages_listbox);
 
             var cancel_button = (Gtk.Button)format_dialog.add_button (_("Cancel"), Gtk.ResponseType.CANCEL);
 

--- a/src/Dialogs/BranchActions/BranchListBox.vala
+++ b/src/Dialogs/BranchActions/BranchListBox.vala
@@ -42,9 +42,9 @@ private class Scratch.Dialogs.BranchListBox : Gtk.Box {
             hscrollbar_policy = NEVER,
             vscrollbar_policy = AUTOMATIC,
             min_content_height = 200,
-            vexpand = true
+            vexpand = true,
+            child = list_box
         };
-        scrolled_window.child = list_box;
 
         search_entry = new Gtk.SearchEntry () {
             placeholder_text = _("Enter search term")

--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -226,9 +226,9 @@ namespace Scratch.Services {
 
             scroll = new Gtk.ScrolledWindow (null, null) {
                 hexpand = true,
-                vexpand = true
+                vexpand = true,
+                child = source_view
             };
-            scroll.add (source_view);
 
             scroll_controller = new Gtk.EventControllerScroll (scroll, VERTICAL) {
                 propagation_phase = CAPTURE

--- a/src/Widgets/FormatBar.vala
+++ b/src/Widgets/FormatBar.vala
@@ -93,13 +93,15 @@ public class Code.FormatBar : Gtk.Box {
             lang_selection_listbox.invalidate_filter ();
         });
 
-        var lang_scrolled = new Gtk.ScrolledWindow (null, null);
-        lang_scrolled.hscrollbar_policy = Gtk.PolicyType.NEVER;
-        lang_scrolled.height_request = 350;
-        lang_scrolled.expand = true;
-        lang_scrolled.margin_top = lang_scrolled.margin_bottom = 3;
-
-        lang_scrolled.add (lang_selection_listbox);
+        var lang_scrolled = new Gtk.ScrolledWindow (null, null) {
+            hscrollbar_policy = Gtk.PolicyType.NEVER,
+            height_request = 350,
+            hexpand = true,
+            vexpand = true,
+            margin_top = 3,
+            margin_bottom = 3,
+            child = lang_selection_listbox
+        };
 
         unowned string[]? ids = manager.get_language_ids ();
         unowned SList<Gtk.RadioButton> group = null;

--- a/src/Widgets/Terminal.vala
+++ b/src/Widgets/Terminal.vala
@@ -177,8 +177,9 @@ public class Code.Terminal : Gtk.Box {
 
         spawn_shell (Scratch.saved_state.get_string ("last-opened-path"));
 
-        var scrolled_window = new Gtk.ScrolledWindow (null, terminal.get_vadjustment ());
-        scrolled_window.add (terminal);
+        var scrolled_window = new Gtk.ScrolledWindow (null, terminal.get_vadjustment ()) {
+            child = terminal
+        };
 
         add (scrolled_window);
         show_all ();


### PR DESCRIPTION
Makes the creation of ScrolledWindows nearer to the Gtk4 syntax.
In one case avoid deprecated property `expand`