### PR TITLE
Gtk4Prep: Update Gtk.Popover construction

### DIFF
--- a/src/Widgets/ChooseProjectButton.vala
+++ b/src/Widgets/ChooseProjectButton.vala
@@ -110,11 +110,9 @@ public class Code.ChooseProjectButton : Gtk.MenuButton {
         popover_content.show_all ();
 
         var project_popover = new Gtk.Popover (this) {
-            position = Gtk.PositionType.BOTTOM
+            position = Gtk.PositionType.BOTTOM,
+            child = popover_content
         };
-
-        project_popover.add (popover_content);
-
         popover = project_popover;
 
         // Initialise with any pre-existing projects (needed for second and subsequent window)

--- a/src/Widgets/FormatBar.vala
+++ b/src/Widgets/FormatBar.vala
@@ -119,10 +119,10 @@ public class Code.FormatBar : Gtk.Box {
 
         popover_content.show_all ();
 
-        var lang_popover = new Gtk.Popover (lang_menubutton);
-        lang_popover.position = Gtk.PositionType.BOTTOM;
-        lang_popover.add (popover_content);
-
+        var lang_popover = new Gtk.Popover (lang_menubutton) {
+            position = Gtk.PositionType.BOTTOM,
+            child = popover_content
+        };
         lang_menubutton.popover = lang_popover;
 
         lang_selection_listbox.row_activated.connect ((row) => {
@@ -180,10 +180,9 @@ public class Code.FormatBar : Gtk.Box {
         box.show_all ();
 
         var tab_popover = new Gtk.Popover (tab_menubutton) {
-            position = Gtk.PositionType.BOTTOM
+            position = Gtk.PositionType.BOTTOM,
+            child = box
         };
-        tab_popover.add (box);
-
         tab_menubutton.popover = tab_popover;
 
         Scratch.settings.changed["indent-width"].connect (format_tab_header_from_global_settings);
@@ -251,10 +250,10 @@ public class Code.FormatBar : Gtk.Box {
         line_grid.attach (goto_entry, 1, 0, 1, 1);
         line_grid.show_all ();
 
-        var line_popover = new Gtk.Popover (line_menubutton);
-        line_popover.position = Gtk.PositionType.BOTTOM;
-        line_popover.add (line_grid);
-
+        var line_popover = new Gtk.Popover (line_menubutton) {
+            position = Gtk.PositionType.BOTTOM,
+            child = line_grid
+        };
         line_menubutton.popover = line_popover;
 
         // We need to connect_after because otherwise, the text isn't parsed into the "value" property and we only get the previous value

--- a/src/Widgets/HeaderBar.vala
+++ b/src/Widgets/HeaderBar.vala
@@ -225,8 +225,9 @@ public class Scratch.HeaderBar : Hdy.HeaderBar {
         menu_box.add (preferences_menuitem);
         menu_box.show_all ();
 
-        var menu = new Gtk.Popover (null);
-        menu.add (menu_box);
+        var menu = new Gtk.Popover (null) {
+            child = menu_box
+        };
 
         var app_menu = new Gtk.MenuButton () {
             image = new Gtk.Image.from_icon_name ("open-menu", Gtk.IconSize.LARGE_TOOLBAR),

--- a/src/Widgets/SearchBar.vala
+++ b/src/Widgets/SearchBar.vala
@@ -172,8 +172,9 @@ namespace Scratch.Widgets {
             search_option_box.add (whole_word_search_button);
             search_option_box.add (regex_search_button);
 
-            var search_popover = new Gtk.Popover (null);
-            search_popover.add (search_option_box);
+            var search_popover = new Gtk.Popover (null) {
+                child = search_option_box
+            };
             search_popover.show_all ();
 
             var search_buttonbox = new Gtk.Box (Gtk.Orientation.HORIZONTAL, 6);


### PR DESCRIPTION
Use `child =` instead of deprecated `add ()`