### PR TITLE
Cleanup: Lose unused methods in PluginManager

### DIFF
--- a/plugins/pastebin/pastebin.vala
+++ b/plugins/pastebin/pastebin.vala
@@ -86,6 +86,8 @@ public class Scratch.Plugins.Pastebin : Peas.ExtensionBase, Scratch.Services.Act
     Scratch.Services.Document? doc = null;
     Scratch.Services.Interface plugins;
 
+    private MainWindow? window = null;
+
     const string ACTION_GROUP = "pastebin";
     const string ACTION_PREFIX = ACTION_GROUP + ".";
     const string ACTION_SHOW = "action-show";
@@ -100,6 +102,13 @@ public class Scratch.Plugins.Pastebin : Peas.ExtensionBase, Scratch.Services.Act
 
     public void activate () {
         plugins = (Scratch.Services.Interface) object;
+
+        plugins.hook_window.connect ((w) => {
+            // For simplicity, only the first window has share menu button
+            if (window == null) {
+                window = w;
+            }
+        });
 
         plugins.hook_document.connect ((doc) => {
             this.doc = doc;
@@ -120,9 +129,12 @@ public class Scratch.Plugins.Pastebin : Peas.ExtensionBase, Scratch.Services.Act
         if (actions == null) {
             actions = new SimpleActionGroup ();
             actions.add_action_entries (ACTION_ENTRIES, this);
+        } else {
+            // Only insert action group once
+            return;
         }
 
-        plugins.manager.window.insert_action_group (ACTION_GROUP, actions);
+        window.insert_action_group (ACTION_GROUP, actions);
         share_menu = (GLib.Menu) menu;
         menuitem = new GLib.MenuItem (_("Upload to Pastebin"), ACTION_PREFIX + ACTION_SHOW);
         share_menu.append_item (menuitem);
@@ -141,14 +153,13 @@ public class Scratch.Plugins.Pastebin : Peas.ExtensionBase, Scratch.Services.Act
             }
         }
 
-        plugins.manager.window.insert_action_group (ACTION_GROUP, null);
+        window.insert_action_group (ACTION_GROUP, null);
     }
 
     void show_paste_bin_upload_dialog () {
         if (pastebin_dialog != null) {
             pastebin_dialog.present ();
         } else {
-            MainWindow window = plugins.manager.window;
             pastebin_dialog = new Dialogs.PasteBinDialog (window, doc);
             pastebin_dialog.destroy.connect (() => {
                 pastebin_dialog = null;

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -298,7 +298,7 @@ namespace Scratch {
 
             clipboard = Gtk.Clipboard.get_for_display (get_display (), Gdk.SELECTION_CLIPBOARD);
 
-            plugins = new Scratch.Services.PluginsManager (this);
+            plugins = new Scratch.Services.PluginsManager ();
 
             key_controller = new Gtk.EventControllerKey (this) {
                 propagation_phase = TARGET
@@ -556,6 +556,12 @@ namespace Scratch {
                     plugins.hook_window (this);
                     plugins.hook_toolbar (toolbar);
                     plugins.hook_share_menu (toolbar.share_menu);
+                    // Ensure new plugin active on any existing current doc
+                    var doc = get_current_document ();
+                    if (doc != null) {
+                        plugins.hook_document (doc);
+                    }
+
                 };
 
                 plugins.extension_added.connect (() => {

--- a/src/Services/PluginManager.vala
+++ b/src/Services/PluginManager.vala
@@ -30,6 +30,15 @@ public class Scratch.Services.Interface : GLib.Object {
         );
     }
 
+    public Scratch.Services.Document open_file (File file) {
+        var doc = new Scratch.Services.Document (manager.window.actions, file);
+        manager.window.open_document.begin (doc);
+        return doc;
+    }
+
+    public void close_document (Scratch.Services.Document doc) {
+        manager.window.close_document (doc);
+    }
 }
 
 public class Scratch.Services.PluginsManager : GLib.Object {

--- a/src/Services/PluginManager.vala
+++ b/src/Services/PluginManager.vala
@@ -29,16 +29,6 @@ public class Scratch.Services.Interface : GLib.Object {
             manager: _manager
         );
     }
-
-    public Scratch.Services.Document open_file (File file) {
-        var doc = new Scratch.Services.Document (manager.window.actions, file);
-        manager.window.open_document.begin (doc);
-        return doc;
-    }
-
-    public void close_document (Scratch.Services.Document doc) {
-        manager.window.close_document (doc);
-    }
 }
 
 public class Scratch.Services.PluginsManager : GLib.Object {

--- a/src/Services/PluginManager.vala
+++ b/src/Services/PluginManager.vala
@@ -30,15 +30,6 @@ public class Scratch.Services.Interface : GLib.Object {
         );
     }
 
-    public Scratch.Services.Document open_file (File file) {
-        var doc = new Scratch.Services.Document (manager.window.actions, file);
-        manager.window.open_document.begin (doc);
-        return doc;
-    }
-
-    public void close_document (Scratch.Services.Document doc) {
-        manager.window.close_document (doc);
-    }
 }
 
 public class Scratch.Services.PluginsManager : GLib.Object {

--- a/src/Services/PluginManager.vala
+++ b/src/Services/PluginManager.vala
@@ -46,11 +46,7 @@ public class Scratch.Services.PluginsManager : GLib.Object {
     private Peas.ExtensionSet extension_set;
 
     public Scratch.Services.Interface plugin_iface { get; private set; }
-    public weak Scratch.MainWindow window { get; construct; }
 
-    public PluginsManager (Scratch.MainWindow _window) {
-        Object (window: _window);
-    }
 
     construct {
         plugin_iface = new Scratch.Services.Interface (this);


### PR DESCRIPTION
Two methods are currently unused and seem out of place in the PluginManager as plugins themselves have access to the current window and document.

Also it is not necessary for PluginManager to hold a reference to "window" for the same reason.  For simplicity the pastebin plugin only adds a button to the primary window.

A small bug is fixed in passing whereby when a plugin is activated when there is already an active document that document does not immediately get registered with the plugin (only after focusing another document and returning)

These changes are aimed at making PluginManager a singleton accessible with a `get_default ()` function rather than being a member of window (with a reverse reference)