### PR TITLE
Cleanup: FolderManager File object

### DIFF
--- a/src/FolderManager/File.vala
+++ b/src/FolderManager/File.vala
@@ -105,7 +105,7 @@ public class Scratch.FolderManager.File : Object {
     public bool is_executable {
         get {
             // We queried this attribute on construction
-            if (info.has_attribute (FileAttribute.ACCESS_CAN_EXECUTE)) {
+            if (info != null && info.has_attribute (FileAttribute.ACCESS_CAN_EXECUTE)) {
                 return info.get_attribute_boolean (FileAttribute.ACCESS_CAN_EXECUTE);
             }
 

--- a/src/FolderManager/File.vala
+++ b/src/FolderManager/File.vala
@@ -1,216 +1,202 @@
 /*-
- * Copyright (c) 2017-2025 elementary LLC. (https://elementary.io),
- *               2013 Julien Spautz <spautz.julien@gmail.com>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License version 3
- * as published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranties of
- * MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
- * PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Authored by: Julien Spautz <spautz.julien@gmail.com>, Andrei-Costin Zisu <matzipan@gmail.com>
+* Copyright (c) 2017-2025 elementary LLC. (https://elementary.io),
+*               2013 Julien Spautz <spautz.julien@gmail.com>
+*
+* This program is free software: you can redistribute it and/or modify
+* it under the terms of the GNU Lesser General Public License version 3
+* as published by the Free Software Foundation, either version 3 of the
+* License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranties of
+* MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
+* PURPOSE. See the GNU General Public License for more details.
+*
+* You should have received a copy of the GNU General Public License
+* along with this program.  If not, see <http://www.gnu.org/licenses/>.
+*
+* Authored by: Julien Spautz <spautz.julien@gmail.com>, Andrei-Costin Zisu <matzipan@gmail.com>
+*/
+
+/**
+ * Class for easily dealing with files.
  */
-
-namespace Scratch.FolderManager {
-
-    /**
-     * Class for easily dealing with files.
-     */
-    public class File : GLib.Object {
-        public GLib.File file { get; private set; }
-        private GLib.FileInfo? info = null; // Non-null after loading
-
-        public File (string path) {
-            Object (path: path);
+public class Scratch.FolderManager.File : Object {
+    public static int compare (File a, File b) {
+        if (a.is_valid_directory && b.is_valid_textfile) {
+            return -1;
+        }
+        if (a.is_valid_textfile && b.is_valid_directory) {
+            return 1;
         }
 
-        // returns the path the file
-        public string path {
-            owned get {
-                return file.get_path ();
-            }
-            set construct {
-                load_file_for_path (value);
-            }
-        }
+        return strcmp (a.path.collate_key_for_filename (),
+                       b.path.collate_key_for_filename ());
+    }
+    // returns the path the file
+    public string path { get; construct; }
+    public GLib.File file { get; private set; }
 
-        // returns the basename of the file
-        private string _name;
-        public string name {
-            get {
-                if (_name != null) {
-                    return _name;
-                }
-
-                if (info == null) {
-                    _name = file.get_basename ();
-                } else {
-                    _name = info.get_display_name ();
-                }
-
+    // returns the name of the file for display
+    public string name {
+        get {
+            if (_name != null) {
                 return _name;
             }
+
+            if (info == null) {
+                _name = file.get_basename ();
+            } else {
+                _name = info.get_display_name ();
+            }
+
+            return _name;
         }
+    }
 
-        // returns the icon of the file's content type
-        private GLib.Icon? _icon = null;
-        public GLib.Icon icon {
-            get {
-                if (_icon != null) {
-                    return _icon;
-                }
-
-                if (info != null) {
-                    _icon = GLib.ContentType.get_icon (info.get_content_type ());
-                } else {
-                    _icon = new ThemedIcon ("missing-image");
-                }
-
+    // returns the icon of the file's content type
+    public GLib.Icon icon {
+        get {
+            if (_icon != null) {
                 return _icon;
             }
-        }
 
-        // checks if file exists
-        public bool exists {
-            get { return file.query_exists (); }
-        }
-
-        // Checks if we're dealing with a non-backup directory
-        // If parent is hidden then inherit validity from parent
-        private bool? _is_valid_directory = null;
-        public bool is_valid_directory {
-            get {
-                if (_is_valid_directory == null) {
-                    _is_valid_directory = info != null &&
-                                          !info.get_is_backup () &&
-                                          info.get_file_type () == FileType.DIRECTORY;
-                }
-
-                return _is_valid_directory;
+            if (info != null) {
+                _icon = GLib.ContentType.get_icon (info.get_content_type ());
+            } else {
+                _icon = new ThemedIcon ("missing-image");
             }
+
+            return _icon;
         }
+    }
 
-        // checks if we're dealing with a textfile
-        private bool? _is_valid_textfile = null;
-        public bool is_valid_textfile {
-            get {
-                if (_is_valid_textfile == null) {
-                    _is_valid_textfile = !path.has_suffix ("~") && Utils.check_if_valid_text_file (path, info);
-                }
+    // checks if file exists
+    public bool exists {
+        get { return file.query_exists (); }
+    }
 
-                return _is_valid_textfile;
+    // Checks if we're dealing with a non-backup directory
+    // If parent is hidden then inherit validity from parent
+    public bool is_valid_directory {
+        get {
+            if (_is_valid_directory == null) {
+                _is_valid_directory = info != null &&
+                                      !info.get_is_backup () &&
+                                      info.get_file_type () == FileType.DIRECTORY;
             }
-        }
 
-        // Files can be executed and folders can be cd'd into
-        public bool is_executable {
-            get {
-                try {
-                    return get_boolean_file_attribute (GLib.FileAttribute.ACCESS_CAN_EXECUTE);
-                } catch (GLib.Error error) {
-                    return false;
-                }
+            return _is_valid_directory;
+        }
+    }
+
+    // checks if we're dealing with a textfile
+    public bool is_valid_textfile {
+        get {
+            if (_is_valid_textfile == null) {
+                _is_valid_textfile = !path.has_suffix ("~") && Utils.check_if_valid_text_file (path, info);
             }
+
+            return _is_valid_textfile;
         }
+    }
 
-        // returns a list of all children of a directory
-        private bool children_valid = false;
-        private Gee.ArrayList <File> _children = new Gee.ArrayList <File> ();
-        public Gee.Collection <File> children {
-            owned get {
-                if (children_valid) {
-                    return _children;
-                }
+    // Files can be executed and folders can be cd'd into
+    public bool is_executable {
+        get {
+            // We queried this attribute on construction
+            if (info.has_attribute (FileAttribute.ACCESS_CAN_EXECUTE)) {
+                return info.get_attribute_boolean (FileAttribute.ACCESS_CAN_EXECUTE);
+            }
 
-                _children.clear ();
+            return false;
+        }
+    }
 
-                try {
-                    var enumerator = file.enumerate_children (
-                        GLib.FileAttribute.STANDARD_NAME,
-                        FileQueryInfoFlags.NONE
-                    );
-
-                    var file_info = new FileInfo ();
-                    while ((file_info = enumerator.next_file ()) != null) {
-                        var child = file.get_child (file_info.get_name ());
-                        var child_file = new File (child.get_path ());
-                        if (child_file.is_valid_directory || child_file.is_valid_textfile) {
-                            _children.add (child_file);
-                        }
-                    }
-
-                    children_valid = true;
-                } catch (GLib.Error error) {
-                    warning (error.message);
-                }
-
+    // returns a list of all children of a directory
+    public Gee.Collection <File> children {
+        owned get {
+            if (children_valid) {
                 return _children;
             }
-        }
 
-        private bool get_boolean_file_attribute (string attribute) throws GLib.Error {
-            var info = file.query_info (attribute, GLib.FileQueryInfoFlags.NONE);
+            _children.clear ();
 
-            return info.get_attribute_boolean (attribute);
-        }
-
-        private void load_file_for_path (string path) {
-            file = GLib.File.new_for_path (path);
-
-            info = new FileInfo ();
             try {
-                var query_string = GLib.FileAttribute.STANDARD_CONTENT_TYPE + "," +
-                                    GLib.FileAttribute.STANDARD_IS_BACKUP + "," +
-                                    GLib.FileAttribute.STANDARD_IS_HIDDEN + "," +
-                                    GLib.FileAttribute.STANDARD_DISPLAY_NAME + "," +
-                                    GLib.FileAttribute.STANDARD_TYPE;
+                var enumerator = file.enumerate_children (
+                    GLib.FileAttribute.STANDARD_NAME,
+                    FileQueryInfoFlags.NONE
+                );
 
-                info = file.query_info (query_string, FileQueryInfoFlags.NONE);
-            } catch (GLib.Error error) {
-                info = null;
-                warning (error.message);
-            }
-        }
-
-        public void rename (string name) {
-            try {
-                if (exists) {
-                    file.set_display_name (name);
+                var file_info = new FileInfo ();
+                while ((file_info = enumerator.next_file ()) != null) {
+                    var child = file.get_child (file_info.get_name ());
+                    var child_file = new File (child.get_path ());
+                    if (child_file.is_valid_directory || child_file.is_valid_textfile) {
+                        _children.add (child_file);
+                    }
                 }
+
+                children_valid = true;
             } catch (GLib.Error error) {
                 warning (error.message);
             }
-        }
 
-        public void trash () {
-            try {
-                file.trash ();
-            } catch (GLib.Error error) {
-                warning (error.message);
+            return _children;
+        }
+    }
+
+    private GLib.FileInfo? info = null; // Non-null after loading
+    private string _name;
+    private GLib.Icon? _icon = null;
+    private bool? _is_valid_directory = null;
+    private bool? _is_valid_textfile = null;
+    private bool children_valid = false;
+    private Gee.ArrayList <File> _children = new Gee.ArrayList <File> ();
+
+    public File (string path) {
+        Object (path: path);
+    }
+
+    construct {
+        file = GLib.File.new_for_path (path);
+        info = new FileInfo ();
+        try {
+            var query_string = FileAttribute.STANDARD_CONTENT_TYPE + "," +
+                                FileAttribute.STANDARD_IS_BACKUP + "," +
+                                FileAttribute.STANDARD_IS_HIDDEN + "," +
+                                FileAttribute.STANDARD_DISPLAY_NAME + "," +
+                                FileAttribute.STANDARD_TYPE + "," +
+                                FileAttribute.ACCESS_CAN_EXECUTE;
+
+            // We assume the attributes do not change during the lifetime of this object
+            info = file.query_info (query_string, FileQueryInfoFlags.NONE);
+        } catch (GLib.Error error) {
+            info = null;
+            warning (error.message);
+        }
+    }
+
+    public void rename (string name) {
+        try {
+            if (exists) {
+                file.set_display_name (name);
             }
+        } catch (GLib.Error error) {
+            warning (error.message);
         }
+    }
 
-        public static int compare (File a, File b) {
-            if (a.is_valid_directory && b.is_valid_textfile) {
-                return -1;
-            }
-            if (a.is_valid_textfile && b.is_valid_directory) {
-                return 1;
-            }
 
-            return strcmp (a.path.collate_key_for_filename (),
-                           b.path.collate_key_for_filename ());
+    public void trash () {
+        try {
+            file.trash ();
+        } catch (GLib.Error error) {
+            warning (error.message);
         }
+    }
 
-        public void invalidate_cache () {
-            children_valid = false;
-        }
+    public void invalidate_cache () {
+        children_valid = false;
     }
 }

--- a/src/FolderManager/FolderItem.vala
+++ b/src/FolderManager/FolderItem.vala
@@ -1,21 +1,7 @@
-/*-
- * Copyright (c) 2017-2026 elementary LLC. (https://elementary.io),
- *               2013 Julien Spautz <spautz.julien@gmail.com>
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Lesser General Public License version 3
- * as published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranties of
- * MERCHANTABILITY, SATISFACTORY QUALITY, or FITNESS FOR A PARTICULAR
- * PURPOSE. See the GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
- *
- * Authored by: Julien Spautz <spautz.julien@gmail.com>, Andrei-Costin Zisu <matzipan@gmail.com>
+/*
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ * SPDX-FileCopyrightText: 2017–2026 elementary, Inc. <https://elementary.io>
+ *                         2013 Julien Spautz <spautz.julien@gmail.com>
  */
 
 namespace Scratch.FolderManager {

--- a/src/FolderManager/Item.vala
+++ b/src/FolderManager/Item.vala
@@ -23,12 +23,11 @@ namespace Scratch.FolderManager {
      * Common abstract class for file and folder items.
      */
     public abstract class Item: Code.Widgets.SourceList.ExpandableItem, Code.Widgets.SourceListSortable {
-        public File file { get; construct; }
+        public FolderManager.File file { get; construct; }
 
         public FileView view { get; construct; }
         public string path {
             owned get { return file.path; }
-            set { file.path = value; }
         }
 
         construct {

--- a/src/Services/PluginManager.vala
+++ b/src/Services/PluginManager.vala
@@ -30,6 +30,15 @@ public class Scratch.Services.Interface : GLib.Object {
         );
     }
 
+    public Scratch.Services.Document open_file (File file) {
+        var doc = new Scratch.Services.Document (manager.window.actions, file);
+        manager.window.open_document.begin (doc);
+        return doc;
+    }
+
+    public void close_document (Scratch.Services.Document doc) {
+        manager.window.close_document (doc);
+    }
 }
 
 public class Scratch.Services.PluginsManager : GLib.Object {

--- a/src/Services/PluginManager.vala
+++ b/src/Services/PluginManager.vala
@@ -30,15 +30,6 @@ public class Scratch.Services.Interface : GLib.Object {
         );
     }
 
-    public Scratch.Services.Document open_file (File file) {
-        var doc = new Scratch.Services.Document (manager.window.actions, file);
-        manager.window.open_document.begin (doc);
-        return doc;
-    }
-
-    public void close_document (Scratch.Services.Document doc) {
-        manager.window.close_document (doc);
-    }
 }
 
 public class Scratch.Services.PluginsManager : GLib.Object {


### PR DESCRIPTION
 - Inline namespace
 - Inline single use functions
 - Reorder to static, public, private members, create, construct, public methods, private methods
 - Make path construct only
 - Set GLib.File only in construct clause
 - Load info on construct, including executable attribute
 - Start to make naming less ambiguous