### PR TITLE
Cleanup GitManager: Simplify interface

### DIFF
--- a/src/FolderManager/FileView.vala
+++ b/src/FolderManager/FileView.vala
@@ -122,7 +122,7 @@ public class Scratch.FolderManager.FileView : Code.Widgets.SourceList, Code.Pane
                     new Variant.string (project_folder_item.path)
                 );
                 root.remove (project_folder_item);
-                git_manager.remove_project (project_folder_item);
+                git_manager.remove_project (project_folder_item.file.file);
             }
         }
         //Make remaining project the active one
@@ -661,7 +661,7 @@ public class Scratch.FolderManager.FileView : Code.Widgets.SourceList, Code.Pane
                         rename_items_with_same_name (child_folder);
                     }
                 }
-                Scratch.Services.GitManager.get_instance ().remove_project (folder_root);
+                Scratch.Services.GitManager.get_instance ().remove_project (folder_root.file.file);
                 write_settings ();
             });
 

--- a/src/FolderManager/ProjectFolderItem.vala
+++ b/src/FolderManager/ProjectFolderItem.vala
@@ -68,13 +68,11 @@ namespace Scratch.FolderManager {
                         name, monitored_repo.branch_name
                     );
                 }
-
-
             }
         }
 
         construct {
-            monitored_repo = Scratch.Services.GitManager.get_instance ().add_project (this);
+            monitored_repo = Scratch.Services.GitManager.get_instance ().add_project (this.file.file);
             notify["name"].connect (branch_or_name_changed);
             if (monitored_repo != null) {
                 monitored_repo.branch_changed.connect (branch_or_name_changed);

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -776,12 +776,12 @@ namespace Scratch {
             folder_manager_view.open_folder (foldermanager_file);
         }
 
+        // The following two functions are planned to be removed and document_view function
+        // called directly
         public async void open_document (Scratch.Services.Document doc,
                                    bool focus = true,
                                    int cursor_position = 0) {
 
-            FolderManager.ProjectFolderItem? project = folder_manager_view.get_project_for_file (doc.file);
-            doc.source_view.project = project;
             yield document_view.open_document (doc, focus, cursor_position);
         }
 
@@ -793,7 +793,6 @@ namespace Scratch {
                 return;
             }
 
-            doc.source_view.project = folder_manager_view.get_project_for_file (doc.file);
             yield document_view.open_document (doc, focus, 0, range);
         }
 

--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -67,11 +67,8 @@ namespace Scratch.Services {
 
         public string project_path {
             owned get {
-                if (source_view.project != null) {
-                    return source_view.project.path;
-                } else {
-                    return "";
-                }
+                var project_file = GitManager.get_instance ().get_project_file_for_file (file);
+                return project_file != null ? project_file.get_path () : "";
             }
         }
 

--- a/src/Services/DocumentManager.vala
+++ b/src/Services/DocumentManager.vala
@@ -37,23 +37,25 @@
     }
 
     public void make_restorable (Document doc) {
-        project_restorable_docs_map.@set (doc.source_view.project.path, doc.file.get_path ());
+        project_restorable_docs_map.@set (doc.project_path, doc.file.get_path ());
     }
 
     public void add_open_document (Document doc) {
-        if (doc.source_view.project == null) {
+        var project_path = doc.project_path;
+        if (project_path == "") {
             return;
         }
 
-        project_open_docs_map.@set (doc.source_view.project.path, doc.file.get_path ());
+        project_open_docs_map.@set (project_path, doc.file.get_path ());
     }
 
     public void remove_open_document (Document doc) {
-        if (doc.source_view.project == null) {
+        var project_path = doc.project_path;
+        if (project_path == "") {
             return;
         }
 
-        project_open_docs_map.remove (doc.source_view.project.path, doc.file.get_path ());
+        project_open_docs_map.remove (doc.project_path, doc.file.get_path ());
     }
 
     public void remove_project (string project_path) {

--- a/src/Services/GitManager.vala
+++ b/src/Services/GitManager.vala
@@ -46,17 +46,17 @@ namespace Scratch.Services {
 
         construct {
             // Used to populate the ChooseProject popover in sorted order
-            project_liststore = new ListStore (typeof (FolderManager.ProjectFolderItem));
+            project_liststore = new ListStore (typeof (GLib.File));
             settings.bind ("active-project-path", this, "active-project-path", DEFAULT);
         }
 
-        public MonitoredRepository? add_project (FolderManager.ProjectFolderItem root_folder) {
-            var root_path = root_folder.path;
+        public MonitoredRepository? add_project (GLib.File root_folder) {
+            var root_path = root_folder.get_path ();
             MonitoredRepository? monitored_repo = null;
             uint position;
             if (project_liststore.find_with_equal_func (
                     root_folder,
-                    (a, b) => { return ((FolderManager.Item) a).equal ((FolderManager.Item) b); },
+                    (a, b) => { return ((GLib.File) a).equal ((GLib.File) b); },
                     out position
                 )) {
 
@@ -65,7 +65,7 @@ namespace Scratch.Services {
             }
 
             try {
-                var git_repo = Ggit.Repository.open (root_folder.file.file);
+                var git_repo = Ggit.Repository.open (root_folder);
                 if (!project_gitrepo_map.has_key (root_path)) {
                     monitored_repo = new MonitoredRepository (git_repo);
                     project_gitrepo_map.@set (root_path, monitored_repo);
@@ -89,14 +89,14 @@ namespace Scratch.Services {
         }
 
         [CCode (instance_pos = -1)]
-        private int project_sort_func (FolderManager.ProjectFolderItem a, FolderManager.ProjectFolderItem b) {
-            GLib.File file_a = a.file.file;
-            GLib.File file_b = b.file.file;
-            return Path.get_basename (file_a.get_path ()).collate (Path.get_basename (file_b.get_path ()));
+        private int project_sort_func (GLib.File file_a, GLib.File file_b) {
+            var basename_a = Path.get_basename (file_a.get_path ());
+            var basename_b = Path.get_basename (file_b.get_path ());
+            return basename_a.collate (basename_b);
         }
 
-        public void remove_project (FolderManager.ProjectFolderItem root_folder) {
-            var root_path = root_folder.file.file.get_path ();
+        public void remove_project (GLib.File root_folder) {
+            var root_path = root_folder.get_path ();
 
             uint position;
             if (project_liststore.find (root_folder, out position)) {

--- a/src/Services/GitManager.vala
+++ b/src/Services/GitManager.vala
@@ -177,9 +177,7 @@ namespace Scratch.Services {
         public GLib.File? get_project_file_for_file (GLib.File file) {
             for (int n = 0; n < project_liststore.n_items; n++) {
                 var nth_file = (GLib.File) (project_liststore.get_object (n));
-                warning ("relative path for nth file %s is %s", nth_file.get_path (), nth_file.get_relative_path (file));
                 if (nth_file.get_relative_path (file) != null) {
-                    warning ("returning project file %s", nth_file.get_path ());
                     return nth_file;
                 }
             }

--- a/src/Services/GitManager.vala
+++ b/src/Services/GitManager.vala
@@ -172,5 +172,37 @@ namespace Scratch.Services {
 
             return new_repo != null;
         }
+        // Given the path of a file, return the path to the root folder of an open project
+        // that is a parent of that file
+        public GLib.File? get_project_file_for_file (GLib.File file) {
+            for (int n = 0; n < project_liststore.n_items; n++) {
+                var nth_file = (GLib.File) (project_liststore.get_object (n));
+                warning ("relative path for nth file %s is %s", nth_file.get_path (), nth_file.get_relative_path (file));
+                if (nth_file.get_relative_path (file) != null) {
+                    warning ("returning project file %s", nth_file.get_path ());
+                    return nth_file;
+                }
+            }
+
+            return null;
+        }
+
+        public bool is_git_repo (GLib.File project_file) {
+            return get_monitored_repository (project_file.get_path ()) != null;
+        }
+
+        // Returns true if line_status_map was updated otherwise false
+        public bool refresh_diff (GLib.File file, ref Gee.HashMap<int, VCStatus> line_status_map) {
+            var project_file = get_project_file_for_file (file);
+            if (project_file == null) {
+                return false;
+            }
+            var monitored_repo = get_monitored_repository (project_file.get_path ());
+            if (monitored_repo == null) {
+                return false;
+            }
+
+            return monitored_repo.refresh_diff (file.get_path (), ref line_status_map);
+        }
     }
 }

--- a/src/Services/MonitoredRepository.vala
+++ b/src/Services/MonitoredRepository.vala
@@ -463,9 +463,9 @@ namespace Scratch.Services {
 
 
         private bool refreshing = false;
-        public void refresh_diff (string file_path, ref Gee.HashMap<int, VCStatus> line_status_map) {
+        public bool refresh_diff (string file_path, ref Gee.HashMap<int, VCStatus> line_status_map) {
             if (refreshing) {
-                return;
+                return false;
             } else {
                 refreshing = true;
             }
@@ -511,6 +511,7 @@ namespace Scratch.Services {
             }
 
             line_status_map = status_map;
+            return true;
         }
 
         private void process_diff_line (Ggit.DiffLineType line_type, int new_line_no, int old_line_no,

--- a/src/Widgets/ChooseProjectButton.vala
+++ b/src/Widgets/ChooseProjectButton.vala
@@ -102,10 +102,8 @@ public class Code.ChooseProjectButton : Gtk.Bin {
         var src = git_manager.project_liststore;
         for (int index = 0; index < src.n_items; index++) {
             var item = src.get_object (index);
-            if (item is Scratch.FolderManager.ProjectFolderItem) {
-                var row = create_project_row ((Scratch.FolderManager.ProjectFolderItem)item);
-                project_listbox.insert (row, index);
-            }
+            var row = create_project_row ((GLib.File)item);
+            project_listbox.insert (row, index);
         }
 
         git_manager.project_liststore.items_changed.connect ((src, pos, n_removed, n_added) => {
@@ -117,10 +115,8 @@ public class Code.ChooseProjectButton : Gtk.Bin {
 
             for (int index = (int)pos; index < pos + n_added; index++) {
                 var item = src.get_object (index);
-                if (item is Scratch.FolderManager.ProjectFolderItem) {
-                    var row = create_project_row ((Scratch.FolderManager.ProjectFolderItem)item);
-                    project_listbox.insert (row, index);
-                }
+                var row = create_project_row ((GLib.File)item);
+                project_listbox.insert (row, index);
             }
         });
 
@@ -151,11 +147,10 @@ public class Code.ChooseProjectButton : Gtk.Bin {
         }
     }
 
-    private Gtk.Widget create_project_row (Scratch.FolderManager.ProjectFolderItem project_folder) {
-        var project_path = project_folder.file.file.get_path ();
+    private Gtk.Widget create_project_row (GLib.File project_folder) {
+        var project_path = project_folder.get_path ();
         var project_row = new ProjectRow (project_path);
         // Project folder items cannot be renamed in UI, no need to handle
-
         return project_row;
     }
 

--- a/src/Widgets/GitGutterRenderer.vala
+++ b/src/Widgets/GitGutterRenderer.vala
@@ -17,7 +17,6 @@ public class Scratch.Widgets.GitGutterRenderer : Gtk.SourceGutterRenderer {
 
     public Gee.HashMap<int, Services.VCStatus> line_status_map;
     public Gee.HashMap<Services.VCStatus, Gdk.RGBA?> status_color_map;
-    public FolderManager.ProjectFolderItem? project { get; set; default = null; }
 
     static construct {
         fallback_scheme = Gtk.SourceStyleSchemeManager.get_default ().get_scheme ("classic"); // We can assume this always exists

--- a/src/Widgets/SourceView.vala
+++ b/src/Widgets/SourceView.vala
@@ -28,7 +28,6 @@ namespace Scratch.Widgets {
         public Gtk.TextTag error_tag;
 
         public GLib.File location { get; set; }
-        public FolderManager.ProjectFolderItem project { get; set; default = null; }
         public SimpleActionGroup actions { get; construct; }
 
         private string font;
@@ -736,9 +735,12 @@ namespace Scratch.Widgets {
 
             refresh_timeout_id = Timeout.add (250, () => {
                 refresh_timeout_id = 0;
-                if (project != null && project.is_git_repo) {
-                    git_diff_gutter_renderer.line_status_map.clear ();
-                    project.refresh_diff (ref git_diff_gutter_renderer.line_status_map, location.get_path ());
+                var git_manager = Scratch.Services.GitManager.get_instance ();
+                git_diff_gutter_renderer.line_status_map.clear ();
+                if (git_manager.refresh_diff (
+                    location,
+                    ref git_diff_gutter_renderer.line_status_map
+                )) {
                     git_diff_gutter_renderer.queue_draw ();
                 }
 


### PR DESCRIPTION
Towards an easier porting to Gtk4 when the FolderManager will change significantly

 - Use paths and Glib.Files as parameters for functions instead of FolderManager classes
 - Move some git related functions out of SourceView into Git Manager
 - Also avoid referencing ProjectFolderItem in some other places outside the Sidebar