### PR TITLE
FuzzySearch: ellipsize middle instead of horizontal scroll

### DIFF
--- a/plugins/fuzzy-search/file-item.vala
+++ b/plugins/fuzzy-search/file-item.vala
@@ -26,7 +26,9 @@ public class FileItem : Gtk.ListBoxRow {
 
         var path_label = new Gtk.Label (
             @"$(should_distinguish_project ? result.project + " • " : "")$(result.relative_path)"
-        );
+        ) {
+            ellipsize = MIDDLE
+        };
 
         path_label.halign = Gtk.Align.START;
 

--- a/plugins/fuzzy-search/fuzzy-search-popover.vala
+++ b/plugins/fuzzy-search/fuzzy-search-popover.vala
@@ -68,7 +68,8 @@ public class Scratch.FuzzySearchPopover : Gtk.Popover {
             propagate_natural_height = true,
             hexpand = true,
             vexpand = true,
-            child = search_result_container
+            child = search_result_container,
+            hscrollbar_policy = NEVER
         };
 
         var box = new Gtk.Box (VERTICAL, 0);


### PR DESCRIPTION
Horizontal scroll pushes the end of the path off screen which is important info. Ellipsize middle instead so that we can always see the most important parts