### PR TITLE
FuzzySearch/FileItem: use arrow, account for RTL

### DIFF
--- a/plugins/fuzzy-search/file-item.vala
+++ b/plugins/fuzzy-search/file-item.vala
@@ -24,11 +24,9 @@ public class FileItem : Gtk.ListBoxRow {
         var path_box = new Gtk.Box (Gtk.Orientation.VERTICAL, 1);
         path_box.valign = Gtk.Align.CENTER;
 
-        var path_label = new Gtk.Label (
-            @"$(should_distinguish_project ? result.project + " • " : "")$(result.relative_path)"
-        );
-
-        path_label.halign = Gtk.Align.START;
+        var path_label = new Gtk.Label (get_path_label (should_distinguish_project)) {
+            halign = START
+        };
 
         var filename_label = new Gtk.Label (Path.get_basename (result.relative_path));
         filename_label.halign = Gtk.Align.START;
@@ -55,5 +53,17 @@ public class FileItem : Gtk.ListBoxRow {
         container_box.add (path_box);
 
         this.child = container_box;
+    }
+
+    private string get_path_label (bool show_project) {
+        if (!show_project) {
+            return result.relative_path;
+        }
+
+        if (Gtk.StateFlags.DIR_RTL in get_state_flags ()) {
+            return "%s ← %s".printf (result.relative_path, result.project);
+        }
+
+        return "%s → %s".printf (result.project, result.relative_path);
     }
 }


### PR DESCRIPTION
Use arrow as a delimiter instead of circle and make sure to put things in correct order for RTL