### PR TITLE
FuzzySearch: adjust label styles

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -56,18 +56,11 @@ textview.scrubber {
 
 .fuzzy-item.preselect-fuzzy {
     background-color: @selected_bg_color;
+    color: @selected_fg_color;
 }
 
 .fuzzy-item .fuzzy-file-icon {
     margin-right: 0.5rem;
-}
-
-.fuzzy-item label:nth-child(1) {
-    font-weight: 700;
-}
-
-.fuzzy-item.preselect-fuzzy label {
-    opacity: 0.7;
 }
 
 .symbol-outline > box.horizontal {

--- a/plugins/fuzzy-search/file-item.vala
+++ b/plugins/fuzzy-search/file-item.vala
@@ -27,6 +27,8 @@ public class FileItem : Gtk.ListBoxRow {
         var path_label = new Gtk.Label (
             @"$(should_distinguish_project ? result.project + " • " : "")$(result.relative_path)"
         );
+        path_label.get_style_context ().add_class (Gtk.STYLE_CLASS_DIM_LABEL);
+        path_label.get_style_context ().add_class (Granite.STYLE_CLASS_SMALL_LABEL);
 
         path_label.halign = Gtk.Align.START;
 


### PR DESCRIPTION
Use built-in styles. `nth_child` is expensive! 