### PR TITLE
Cleanup: fix some terminal warnings

### DIFF
--- a/data/Application.css
+++ b/data/Application.css
@@ -45,7 +45,7 @@ textview.scrubber {
     background-color: transparent;
 }
 
-.fuzzy-item:focused,
+.fuzzy-item:focus,
 .fuzzy-item:hover {
     border-radius: 0.5rem;
 }
@@ -54,7 +54,7 @@ textview.scrubber {
     background-color: @theme_unfocused_selected_bg_color;
 }
 
-.fuzzy-item:focused {
+.fuzzy-item:focus {
     background-color: @selected_bg_color;
     color: @selected_fg_color;
 }

--- a/src/Services/Document.vala
+++ b/src/Services/Document.vala
@@ -286,7 +286,10 @@ namespace Scratch.Services {
             this.source_view.buffer.create_tag ("highlight_search_all", "background", "yellow", null);
 
             this.source_view.notify["is-focus"].connect (() => {
-                return_if_fail (!locked);
+                if (locked) {
+                    return;
+                }
+
                 if (source_view.is_focus) {
                     if (!is_file_temporary) {
                         check_undoable_actions ();

--- a/src/Widgets/ChooseProjectButton.vala
+++ b/src/Widgets/ChooseProjectButton.vala
@@ -124,7 +124,7 @@ public class Code.ChooseProjectButton : Gtk.Bin {
             }
         });
 
-        menu_button.activate.connect (() => {
+        menu_button.toggled.connect (() => {
             if (menu_button.active) {
                 unowned var active_path = Scratch.Services.GitManager.get_instance ().active_project_path;
                 foreach (var child in project_listbox.get_children ()) {

--- a/src/Widgets/ChooseProjectButton.vala
+++ b/src/Widgets/ChooseProjectButton.vala
@@ -130,7 +130,7 @@ public class Code.ChooseProjectButton : Gtk.Bin {
                 foreach (var child in project_listbox.get_children ()) {
                     var project_row = ((ProjectRow) child);
                     // All paths must not end in directory separator so can be compared directly
-                    project_row.active = active_path == project_row.project_path;
+                    project_row.is_active_project = active_path == project_row.project_path;
                 }
             }
         });
@@ -161,7 +161,7 @@ public class Code.ChooseProjectButton : Gtk.Bin {
 
     public class ProjectRow : Gtk.ListBoxRow {
         private Gtk.CheckButton check_button;
-        public bool active {
+        public bool is_active_project {
             get {
                 return check_button.active;
             }


### PR DESCRIPTION
Fixes terminal warnings originating from

 - startup of ProjectChooserButton
 - Application.css
 - return_if_fail ()

The reason for the ProjectChooserButton warnings was not entirely clear but was caused by the custom "active" property being accessed when the action-name was set before the checkbutton was instantiated. It was fixed by using a different and more explicit property name.

In passing it was noticed that the "activated" signal of the menubutton was used instead of the "toggled" button and the handler was therefore non-functional.

For now the checkbutton state is handled explicitly - there may be a better way but that is outside the scope.

There are still quite a lot of  (apparently upstream) warnings when tabs are closed and when the window is closed but these are not obviously due to Code code.