### PR TITLE
Fix file path in po/plugins/POTFILES

### DIFF
--- a/po/plugins/POTFILES
+++ b/po/plugins/POTFILES
@@ -1,7 +1,7 @@
 plugins/brackets-completion/brackets-completion.plugin
 plugins/detect-indent/detect-indent.plugin
 plugins/editorconfig/editorconfig.plugin
-plugins/fuzzy-search/fuzzy-search.plugin
+plugins/FuzzySearch/fuzzy-search.plugin
 plugins/highlight-word-selection/highlight-word-selection.plugin
 plugins/markdown-actions/markdown-actions.plugin
 plugins/pastebin/pastebin.plugin


### PR DESCRIPTION
Hopefully the last fix of POTFILES 

Seems you have to run separate commands to check the po subdirectories locally (`ninja plugins-update-po` and `ninja extra-update-po` followed by `git reset --hard`) after committing the changes to POTFILES. 