### PR TITLE
SearchBar: set method → properties, rm unused

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -378,7 +378,7 @@ public class Scratch.MainWindow : Hdy.Window {
                     );
                 }
 
-                search_bar.reveal (new_state);
+                search_bar.search_mode_enabled = new_state;
 
                 break;
             case ACTION_TOGGLE_SIDEBAR:
@@ -714,7 +714,7 @@ public class Scratch.MainWindow : Hdy.Window {
     private bool on_key_pressed (uint keyval, uint keycode, Gdk.ModifierType state) {
         switch (Gdk.keyval_name (keyval)) {
             case "Escape":
-                if (search_bar.is_revealed) {
+                if (search_bar.search_mode_enabled) {
                     var action = Utils.action_from_group (ACTION_TOGGLE_SHOW_FIND, actions);
                     action.set_state (false);
                     document_view.current_document.source_view.grab_focus ();
@@ -776,7 +776,7 @@ public class Scratch.MainWindow : Hdy.Window {
         }
 
         if (search_term != "") {
-            search_bar.set_search_entry_text (search_term);
+            search_bar.search_text = search_term;
         }
     }
 
@@ -1271,12 +1271,12 @@ public class Scratch.MainWindow : Hdy.Window {
     private void find (string search_term = "") {
         // Set search term before focusing search bar else maybe ineffective
         if (search_term != "") {
-            search_bar.set_search_entry_text (search_term);
+            search_bar.search_text = search_term;
         } else {
             set_selected_text_for_search ();
         }
 
-        if (!search_bar.is_revealed) {
+        if (!search_bar.search_mode_enabled) {
             var show_find_action = Utils.action_from_group (ACTION_TOGGLE_SHOW_FIND, actions);
             if (show_find_action.enabled) {
                 // This focuses the search bar
@@ -1291,10 +1291,10 @@ public class Scratch.MainWindow : Hdy.Window {
         find ();
         // May have to wait for the search bar to be revealed before we can grab focus
 
-        if (search_bar.is_revealed) {
+        if (search_bar.search_mode_enabled) {
             search_bar.focus_replace_entry ();
         } else {
-            search_bar.reveal (true);
+            search_bar.search_mode_enabled = true;
             Idle.add (() => {
                 search_bar.focus_replace_entry ();
                 return Source.REMOVE;
@@ -1312,7 +1312,7 @@ public class Scratch.MainWindow : Hdy.Window {
 
 
     private void action_find_global (SimpleAction action, Variant? param) {
-        if (!search_bar.is_focused || search_bar.entry_text == "") {
+        if (!search_bar.is_focused || search_bar.search_text == "") {
             set_selected_text_for_search ();
         }
 
@@ -1324,7 +1324,7 @@ public class Scratch.MainWindow : Hdy.Window {
         }
 
         if (search_path != "") {
-            folder_manager_view.search_global (search_path, search_bar.entry_text);
+            folder_manager_view.search_global (search_path, search_bar.search_text);
         } else {
             // Fallback to standard search
             warning ("Unable to perform global search - search document instead");
@@ -1354,10 +1354,10 @@ public class Scratch.MainWindow : Hdy.Window {
         var action = Utils.action_from_group (ACTION_TOGGLE_SHOW_FIND, actions);
         var to_show = !action.get_state ().get_boolean ();
         action.set_state (to_show);
-        search_bar.reveal (to_show);
+        search_bar.search_mode_enabled = to_show;
         if (to_show) {
             search_bar.focus_search_entry ();
-            if (search_bar.entry_text == "") {
+            if (search_bar.search_text == "") {
                 set_selected_text_for_search ();
             }
         }

--- a/src/Widgets/SearchBar.vala
+++ b/src/Widgets/SearchBar.vala
@@ -12,42 +12,33 @@ public enum Scratch.CaseSensitiveMode {
 }
 
 public class Scratch.Widgets.SearchBar : Gtk.Box { //TODO In Gtk4 use a BinLayout Widget
-
     public weak MainWindow window { get; construct; }
 
     public bool is_focused {
         get {
-            return search_is_focused || replace_is_focused;
+            return search_entry.has_focus || replace_entry.has_focus;
         }
     }
 
-    public bool search_is_focused {
-        get {
-            return search_entry.has_focus;
-        }
-    }
-
-    public bool replace_is_focused {
-        get {
-            return replace_entry.has_focus;
-        }
-    }
-
-    public bool is_revealed {
+    public bool search_mode_enabled {
         get {
             return revealer.child_revealed;
         }
-    }
-
-    public string entry_text {
-        get {
-            return search_entry.text;
+        set {
+            revealer.reveal_child = value;
+            // Clear entry when searchbar is hidden
+            if (!value) {
+                search_entry.text = "";
+            }
         }
     }
 
-    public bool has_search_term {
+    public string search_text {
         get {
-            return search_entry.text != "";
+            return search_entry.text;
+        }
+        set {
+            search_entry.text = value;
         }
     }
 
@@ -60,12 +51,6 @@ public class Scratch.Widgets.SearchBar : Gtk.Box { //TODO In Gtk4 use a BinLayou
             } else {
                 return search_context.get_occurrences_count ();
             }
-        }
-    }
-
-    public uint transition_time_msec {
-        get {
-            return revealer.transition_duration + 10;
         }
     }
 
@@ -295,17 +280,17 @@ public class Scratch.Widgets.SearchBar : Gtk.Box { //TODO In Gtk4 use a BinLayou
             search_context = null;
             return;
         } else if (this.text_buffer != null) {
-            this.text_buffer.changed.disconnect (on_text_buffer_changed);
+            this.text_buffer.changed.disconnect (update_search_widgets);
         }
 
         this.text_view = text_view;
         this.text_buffer = text_view.get_buffer ();
-        this.text_buffer.changed.connect (on_text_buffer_changed);
+        this.text_buffer.changed.connect (update_search_widgets);
         this.search_context = new Gtk.SourceSearchContext (text_buffer as Gtk.SourceBuffer, null);
         search_context.settings.wrap_around = cycle_search_button.active;
         search_context.settings.regex_enabled = regex_search_button.active;
         search_context.settings.search_text = search_entry.text;
-        on_text_buffer_changed ();
+        update_search_widgets ();
     }
 
     public bool search () {
@@ -347,12 +332,6 @@ public class Scratch.Widgets.SearchBar : Gtk.Box { //TODO In Gtk4 use a BinLayou
         return true;
     }
 
-    public void highlight_none () {
-        if (search_context != null) {
-            search_context.highlight = false;
-        }
-    }
-
     public void search_previous () {
         /* Get selection range */
         Gtk.TextIter? start_iter, end_iter;
@@ -389,24 +368,12 @@ public class Scratch.Widgets.SearchBar : Gtk.Box { //TODO In Gtk4 use a BinLayou
         replace_entry.grab_focus ();
     }
 
-    public void reveal (bool to_reveal) {
-        revealer.reveal_child = to_reveal;
-        // Clear entry when searchbar is hidden
-        if (is_revealed && !to_reveal) {
-            set_search_entry_text ("");
-        }
-    }
-
-    public void set_search_entry_text (string text) {
-        search_entry.text = text;
-    }
-
     private bool on_key_pressed (uint keyval, uint keycode, Gdk.ModifierType state) {
-        if (!(search_is_focused || replace_is_focused)) {
+        if (!(search_entry.has_focus || replace_entry.has_focus)) {
             return false;
         }
        /* We don't need to perform search if there is nothing to search... */
-        if (!has_search_term) {
+        if (search_entry.text == "") {
             return false;
         }
 
@@ -415,7 +382,7 @@ public class Scratch.Widgets.SearchBar : Gtk.Box { //TODO In Gtk4 use a BinLayou
             key = "<Shift>" + key;
         }
 
-        if (search_is_focused) {
+        if (search_entry.has_focus) {
             switch (key) {
                 case "<Shift>Return":
                 case "Up":
@@ -446,10 +413,6 @@ public class Scratch.Widgets.SearchBar : Gtk.Box { //TODO In Gtk4 use a BinLayou
         }
 
         return false;
-    }
-
-    private void on_text_buffer_changed () {
-        update_search_widgets ();
     }
 
     private void on_replace_entry_activate () {


### PR DESCRIPTION
* `reveal ()` and `is_revealed { get; }` become [`search_mode_enabled { get; set; }`](https://valadoc.org/gtk4/Gtk.SearchBar.search_mode_enabled.html)
* `set_search_entry_text ()` and `entry_text { get; } ` become `search_text { get; set; }`
* Remove one line `search_is_focused { get; }` and `replace_is_focused { get; }` which are only used in one place anyways and `on_text_buffer_changed ()` which just calls `update_search_widgets ()`
* Remove unused `transition_time_msec { get; }` and `highlight_none ()`