### PR TITLE
Use GLib.Once to manage GitManager singleton

### DIFF
--- a/plugins/FuzzySearch/FuzzySearchIndexer.vala
+++ b/plugins/FuzzySearch/FuzzySearchIndexer.vala
@@ -252,7 +252,7 @@ public class Scratch.Services.FuzzySearchIndexer : GLib.Object {
 
     private async void add_project_async (ProjectUpdate message) {
         string path = message.source_path;
-        var monitor = Services.GitManager.get_monitored_repository (path);
+        var monitor = Services.GitManager.get_instance ().get_monitored_repository (path);
         var project_search = new Services.SearchProject (path, monitor);
         project_paths[path] = project_search;
 
@@ -290,7 +290,7 @@ public class Scratch.Services.FuzzySearchIndexer : GLib.Object {
         Gee.HashMap<string, Services.SearchProject> project_paths) {
         for (int i = 0; i < request_queue.size; i++) {
             var request = request_queue[i];
-            var monitor = Services.GitManager.get_monitored_repository (request.project_path);
+            var monitor = Services.GitManager.get_instance ().get_monitored_repository (request.project_path);
             var project_search = new Services.SearchProject (request.project_path, monitor);
 
             project_paths[request.project_path] = project_search;

--- a/src/Services/GitManager.vala
+++ b/src/Services/GitManager.vala
@@ -23,31 +23,27 @@ namespace Scratch.Services {
         public ListStore project_liststore { get; private set; }
         public string active_project_path { get; set; default = "";}
 
-        static Gee.HashMap<string, MonitoredRepository> project_gitrepo_map;
-        static GitManager? instance;
+        private static Once<GitManager> instance;
+        private Gee.HashMap<string, MonitoredRepository> project_gitrepo_map;
 
-        static construct {
-            Ggit.init ();
-            instance = null;
-            project_gitrepo_map = new Gee.HashMap<string, MonitoredRepository> ();
-        }
 
-        public static MonitoredRepository? get_monitored_repository (string root_path) {
-            return project_gitrepo_map[root_path];
-        }
 
-        public static GitManager get_instance () {
-            if (instance == null) {
-                instance = new GitManager ();
-            }
 
-            return instance;
-        }
 
         construct {
             // Used to populate the ChooseProject popover in sorted order
+            Ggit.init ();
+            project_gitrepo_map = new Gee.HashMap<string, MonitoredRepository> ();
             project_liststore = new ListStore (typeof (FolderManager.ProjectFolderItem));
             settings.bind ("active-project-path", this, "active-project-path", DEFAULT);
+        }
+
+        public static GitManager get_instance () {
+            return instance.once (() => new GitManager ());
+        }
+
+        public MonitoredRepository? get_monitored_repository (string root_path) {
+            return project_gitrepo_map[root_path];
         }
 
         public MonitoredRepository? add_project (FolderManager.ProjectFolderItem root_folder) {


### PR DESCRIPTION
There is no need to handle ensuring only one instance ourselves.  There is no obvious need to have some static members and methods with a single instance. 

- Use GLib.Once
 - Reduce static members and methods